### PR TITLE
add ctrl+(p/n)=up/down for dmenu

### DIFF
--- a/src/editor/minibuffer.rs
+++ b/src/editor/minibuffer.rs
@@ -200,14 +200,14 @@ where
 
             Input::Arrow(Arrow::Right) => self.x = min(self.x + 1, self.input.len()),
             Input::Arrow(Arrow::Left) => self.x = self.x.saturating_sub(1),
-            Input::Alt('k') | Input::Arrow(Arrow::Up) => {
+            Input::Alt('k') | Input::Arrow(Arrow::Up) | Input::Ctrl('p') => {
                 if self.selected_line_idx == 0 {
                     self.b.set_dot(TextObject::BufferEnd, 1);
                 } else {
                     self.b.set_dot(TextObject::Arr(Arrow::Up), 1);
                 }
             }
-            Input::Alt('j') | Input::Arrow(Arrow::Down) => {
+            Input::Alt('j') | Input::Arrow(Arrow::Down) | Input::Ctrl('n') => {
                 if self.selected_line_idx == self.n_visible_lines - 1 {
                     self.b.set_dot(TextObject::BufferStart, 1);
                 } else {


### PR DESCRIPTION
hi @sminez,

I don't know if you are accepting contributions, I like the idea of this editor, I'm trying to use it

what I noticed immediately was lack of some standard vim keys that I'm used to

let me know if you're interested, I will add more e.g. $, ^, 0, ctrl+(left/right) - bprevious/bnext and so on