### PR TITLE
Set editor mode on tui init to NORMAL

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -241,6 +241,7 @@ where
         // SAFETY: we only register our signal handler once
         unsafe { register_signal_handler() };
         self.update_window_size();
+        self.set_mode("NORMAL");
         StdinInput::new(tx).run_threaded();
     }
 


### PR DESCRIPTION
When you start `ad`, the initial mode is NORMAL, but the cursor looks as if it is in INSERT mode. 

Here's a gif where I start `ad`, observe that the editor is in NORMAL mode but the cursor is a bar, then enter INSERT mode and observe the cursor is still a bar, and then switch back to NORMAL mode and observe the cursor finally being a block: 

![Screenshot 2024-10-14 at 00 03 29](https://github.com/user-attachments/assets/540402d8-d431-4277-871a-c16d8fefdb4b)

This PR is my attempt to fix this by calling `set_mode` within `tui_init`. This helps because `set_mode` is where the cursor's shape is actually changed. So, I guess that by default the editor's mode is NORMAL (perhaps due to normal mode being the first mode listed in [the list of modes](https://github.com/sminez/ad/blob/c2d01cf67dfb0fb28aa9787ac34b75d0a8c1493a/src/mode/mod.rs#L17)), but the default cursor shape is a bar (where is this defined?). So, we need to call `set_mode` to set the cursor shape to what it should be, even though the mode is already NORMAL. 

There's quite possibly a better way to do this, so please feel free to edit this PR, or close it and open a new one with a better fix. 😄 I just wanted to use this as an opportunity to dig into the code a little bit and offer a potential fix.