### PR TITLE
to add a data/contrib directory Closes #47

### DIFF
--- a/data/contrib/sh/comment
+++ b/data/contrib/sh/comment
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+source "$HOME/.ad/lib/ad.sh"
+
+requireAd
+id="$(currentBufferId)"
+addr="$(bufRead "$id" addr | sed -E 's/(.+):.+,(.+):.+/\1,\2/')"
+adEdit '. x/.+/ s/^/#/'
+echo "$addr" | bufWrite "$id" addr

--- a/data/contrib/sh/uncomment
+++ b/data/contrib/sh/uncomment
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+source "$HOME/.ad/lib/ad.sh"
+
+requireAd
+id="$(currentBufferId)"
+addr="$(bufRead "$id" addr | sed -E 's/(.+):.+,(.+):.+/\1,\2/')"
+adEdit '. x/.+/ s/^#//'
+echo "$addr" | bufWrite "$id" addr


### PR DESCRIPTION
This adds a directory data/contrib for user scripts to reside.

As a first example two scripts have been added to directory sh

comment/uncomment which adds/removes a '#' at the beginning of dot lines 
