### PR TITLE
feat: match p9p namespace calculation by respecting NAMESPACE and DISPLAY

### DIFF
--- a/crates/ninep/README.md
+++ b/crates/ninep/README.md
@@ -19,10 +19,12 @@ test it out.
 See [the 9p man page](https://9fans.github.io/plan9port/man/man1/9p.html) for
 more information on how the tool works
 
-```bash
-# Let 9p know where to find the socket we have opened
-$ export NAMESPACE="/tmp/ns.$USER.$DISPLAY"
+If you want to use a non standard location for the unix socket, set
+the `NAMESPACE` environment variable in the environment of both the
+server and the `9p` utility. See [intro(4)](https://9fans.github.io/plan9port/man/man4/intro.html)
+for details.
 
+```bash
 # List the contents of the filesystem and read the contents of a file
 $ 9p ls ninep-server
 $ 9p read ninep-server/foo

--- a/crates/ninep/examples/server.rs
+++ b/crates/ninep/examples/server.rs
@@ -5,10 +5,10 @@
 //!
 //!   https://9fans.github.io/plan9port/man/man1/9p.html
 //!
-//! ```sh
-//! # Let 9p know where to find the socket we have opened
-//! $ export NAMESPACE="/tmp/ns.$USER.$DISPLAY"
+//! The location of the unix type socket can be customized, see `unix::namespace()`
+//! for details.
 //!
+//! ```sh
 //! # List the contents of the filesystem and read the contents of a file
 //! $ 9p ls ninep-server
 //! $ 9p read ninep-server/foo

--- a/crates/ninep/src/client.rs
+++ b/crates/ninep/src/client.rs
@@ -161,7 +161,7 @@ impl Client<UnixStream> {
     /// `server_name` under the default namespace. The client will attach
     /// to the filetree given by `aname`.
     ///
-    /// The default namespace is located in /tmp/ns.$USER.:0/
+    /// See `unix::namespace()` on how the namespace is determined.
     pub fn new_unix(server_name: impl AsRef<Path>, aname: impl Into<String>) -> io::Result<Self> {
         let mut path = unix::namespace().map_err(io::Error::other)?;
         path.push(server_name);

--- a/crates/ninep/src/client.rs
+++ b/crates/ninep/src/client.rs
@@ -157,17 +157,18 @@ impl Client<UnixStream> {
         Ok(client)
     }
 
-    /// Create a new [Client] connected to a unix socket at the given aname under the default
-    /// namespace.
+    /// Create a new [Client] connected to a unix socket at the given
+    /// `server_name` under the default namespace. The client will attach
+    /// to the filetree given by `aname`.
     ///
     /// The default namespace is located in /tmp/ns.$USER.:0/
-    pub fn new_unix(ns: impl Into<String>, aname: impl Into<String>) -> io::Result<Self> {
-        let ns = ns.into();
+    pub fn new_unix(server_name: impl Into<String>, aname: impl Into<String>) -> io::Result<Self> {
+        let server_name = server_name.into();
         let uname = match env::var("USER") {
             Ok(s) => s,
             Err(_) => return err("USER env var not set"),
         };
-        let path = format!("/tmp/ns.{uname}.:0/{ns}");
+        let path = format!("/tmp/ns.{uname}.:0/{server_name}");
 
         Self::new_unix_with_explicit_path(uname, path, aname)
     }

--- a/crates/ninep/src/client.rs
+++ b/crates/ninep/src/client.rs
@@ -11,6 +11,7 @@ use std::{
     mem,
     net::{TcpStream, ToSocketAddrs},
     os::unix::net::UnixStream,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex, MutexGuard},
 };
 
@@ -134,7 +135,7 @@ impl Client<UnixStream> {
     /// Create a new [Client] connected to a unix socket at the specified path.
     pub fn new_unix_with_explicit_path(
         uname: String,
-        path: String,
+        path: PathBuf,
         aname: impl Into<String>,
     ) -> io::Result<Self> {
         let stream = UnixStream::connect(path)?;
@@ -161,10 +162,9 @@ impl Client<UnixStream> {
     /// to the filetree given by `aname`.
     ///
     /// The default namespace is located in /tmp/ns.$USER.:0/
-    pub fn new_unix(server_name: impl Into<String>, aname: impl Into<String>) -> io::Result<Self> {
-        let server_name = server_name.into();
-        let namespace = unix::namespace().map_err(io::Error::other)?;
-        let path = format!("{namespace}/{server_name}");
+    pub fn new_unix(server_name: impl AsRef<Path>, aname: impl Into<String>) -> io::Result<Self> {
+        let mut path = unix::namespace().map_err(io::Error::other)?;
+        path.push(server_name);
 
         let uname = unix::get_user_name().map_err(io::Error::other)?;
 

--- a/crates/ninep/src/lib.rs
+++ b/crates/ninep/src/lib.rs
@@ -21,6 +21,7 @@ pub mod client;
 pub mod fs;
 pub mod protocol;
 pub mod server;
+pub mod unix;
 
 use protocol::{Format9p, Rdata, Rmessage};
 

--- a/crates/ninep/src/server.rs
+++ b/crates/ninep/src/server.rs
@@ -2,12 +2,12 @@
 use crate::{
     fs::{FileMeta, FileType, IoUnit, Mode, Perm, Stat, QID_ROOT},
     protocol::{Data, Format9p, Qid, RawStat, Rdata, Tdata, Tmessage, MAX_DATA_LEN},
-    Result, Stream,
+    unix, Result, Stream,
 };
 use std::{
     cmp::min,
     collections::btree_map::{BTreeMap, Entry},
-    env, fs,
+    fs,
     mem::size_of,
     net::TcpListener,
     os::unix::net::UnixListener,
@@ -32,14 +32,12 @@ impl Drop for Socket {
 
 /// The unix socket path that will be used for a given server name.
 pub fn socket_path(name: &str) -> String {
-    let uname = env::var("USER").unwrap();
-    let socket_dir = format!("/tmp/ns.{uname}.:0");
+    let socket_dir = unix::namespace().unwrap();
     format!("{socket_dir}/{name}")
 }
 
 fn unix_socket(name: &str) -> Socket {
-    let uname = env::var("USER").unwrap();
-    let socket_dir = format!("/tmp/ns.{uname}.:0");
+    let socket_dir = unix::namespace().unwrap();
     let _ = fs::create_dir_all(&socket_dir);
     let path = format!("{socket_dir}/{name}");
 

--- a/crates/ninep/src/unix.rs
+++ b/crates/ninep/src/unix.rs
@@ -1,0 +1,25 @@
+//! Unix specific handling of 9p connections.
+//! See [intro(3)](https://9fans.github.io/plan9port/man/man3/intro.html)
+//! and [intro(4)](https://9fans.github.io/plan9port/man/man4/intro.html)
+//! of  Plan 9 from User Space (`plan9port`).
+
+use crate::Result;
+
+use std::env;
+
+pub fn namespace() -> Result<String> {
+    let uname = get_user_name()?;
+    Ok(format!("/tmp/ns.{uname}.:0"))
+}
+
+// FIXME: use something more robust like getuid()
+/// Determine the (unix) name of the executing user.
+pub fn get_user_name() -> Result<String> {
+    match env::var("USER") {
+        Ok(s) => Ok(s),
+        Err(env::VarError::NotPresent) => Err("USER environment variable is not set".to_string()),
+        Err(env::VarError::NotUnicode(_)) => {
+            Err("USER environment variable is not valid UTF-8".to_string())
+        }
+    }
+}

--- a/crates/ninep/src/unix.rs
+++ b/crates/ninep/src/unix.rs
@@ -21,8 +21,8 @@ pub fn namespace() -> Result<PathBuf> {
         Ok(ns.into())
     } else {
         let uname = get_user_name()?;
-        // FIXME: we should fail if DISPLAY is unset, like getns.c in p9p
-        let display = env::var_os("DISPLAY").unwrap_or(OsString::from(":0"));
+        let display = env::var_os("DISPLAY")
+            .ok_or("Need NAMESPACE or DISPLAY environment variable to determine namespace")?;
         // plan9port hardcodes /tmp, believe it or not
         let mut ns = OsString::from("/tmp/ns.");
         ns.push(uname);

--- a/crates/ninep/src/unix.rs
+++ b/crates/ninep/src/unix.rs
@@ -7,12 +7,29 @@ use crate::Result;
 
 use std::{env, ffi::OsString, path::PathBuf};
 
+/// Determine the current namespace (set by the user via the `NAMESPACE`
+/// environment variable) or fallback to the default location
+/// (based on user name and `DISPLAY`).
+/// On unix, the namespace is a directory which 9p unix type sockets are
+/// placed by different 9p servers.
+///
+/// The implementation follows `getns.c` from `plan9port`.
+/// See also [intro(4)](https://9fans.github.io/plan9port/man/man4/intro.html)
+/// and [namespace(1)](https://9fans.github.io/plan9port/man/man1/namespace.html).
 pub fn namespace() -> Result<PathBuf> {
-    let uname = get_user_name()?;
-    let mut ns = OsString::from("/tmp/ns.");
-    ns.push(uname);
-    ns.push(".:0");
-    Ok(ns.into())
+    if let Some(ns) = env::var_os("NAMESPACE") {
+        Ok(ns.into())
+    } else {
+        let uname = get_user_name()?;
+        // FIXME: we should fail if DISPLAY is unset, like getns.c in p9p
+        let display = env::var_os("DISPLAY").unwrap_or(OsString::from(":0"));
+        // plan9port hardcodes /tmp, believe it or not
+        let mut ns = OsString::from("/tmp/ns.");
+        ns.push(uname);
+        ns.push(".");
+        ns.push(display);
+        Ok(ns.into())
+    }
 }
 
 // FIXME: use something more robust like getuid()

--- a/crates/ninep/src/unix.rs
+++ b/crates/ninep/src/unix.rs
@@ -5,11 +5,14 @@
 
 use crate::Result;
 
-use std::env;
+use std::{env, ffi::OsString, path::PathBuf};
 
-pub fn namespace() -> Result<String> {
+pub fn namespace() -> Result<PathBuf> {
     let uname = get_user_name()?;
-    Ok(format!("/tmp/ns.{uname}.:0"))
+    let mut ns = OsString::from("/tmp/ns.");
+    ns.push(uname);
+    ns.push(".:0");
+    Ok(ns.into())
 }
 
 // FIXME: use something more robust like getuid()

--- a/data/bin/mount-ad
+++ b/data/bin/mount-ad
@@ -2,5 +2,6 @@
 # mount the ad virtual filesystem using 9pfuse
 source "$HOME/.ad/lib/ad.sh"
 
-9pfuse "/tmp/ns.$USER.:0/ad" "$HOME/.ad/mnt"
+ns="$(namespace)"
+9pfuse "$ns/ad" "$HOME/.ad/mnt"
 adCtl "echo mounted ad filesystem to $HOME/.ad/mnt"

--- a/src/fsys/mod.rs
+++ b/src/fsys/mod.rs
@@ -216,7 +216,8 @@ impl AdFs {
 
         if auto_mount {
             let res = Command::new("9pfuse")
-                .args([socket_path, mount_path])
+                .arg(socket_path)
+                .arg(mount_path)
                 .spawn();
 
             if let Ok(mut child) = res {


### PR DESCRIPTION
With this PR, the ninep crate should default to the same namespace as plan9port utilities in all cases, i.e. match `getns.c`.

This entails the following, technically breaking, changes

1. `ad` will now crash on startup if `DISPLAY` (and also `NAMESPACE`) is not set. This could be made a bit nicer by threading the error through which I haven't done yet.
2. ninep uses `PathBuf` in some places now. This is an API breaking change, so probably needs a semver bump. I don't know how this is managed at the moment, so I haven't done anything on this front.
3. `mount-ad` needs the `namespace(1)` utility from plan9port additionally now.