### PR TITLE
fix(config): update init.conf file references to config.toml, fixes: #67

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ensure-mountpoint:
 
 .PHONY: backup-current-config
 backup-current-config: ensure-mountpoint
-	[ -f $$HOME/.ad/init.conf ] && mv $$HOME/.ad/init.conf $$HOME/.ad/init.conf.bck || true
+	[ -f $$HOME/.ad/config.toml ] && mv $$HOME/.ad/config.toml $$HOME/.ad/config.toml.bck || true
 
 .PHONY: backup-current-plumbing
 backup-current-plumbing: ensure-mountpoint
@@ -57,7 +57,7 @@ backup-current-plumbing: ensure-mountpoint
 
 .PHONY: copy-default-config
 copy-default-config: ensure-mountpoint backup-current-config
-	cp data/init.conf $$HOME/.ad
+	cp data/config.toml $$HOME/.ad
 
 .PHONY: copy-default-plumbing
 copy-default-plumbing: ensure-mountpoint backup-current-plumbing
@@ -65,7 +65,7 @@ copy-default-plumbing: ensure-mountpoint backup-current-plumbing
 
 .PHONY: copy-rust-config
 copy-rust-config: ensure-mountpoint backup-current-config
-	cp data/init-rust.conf $$HOME/.ad/init.conf
+	cp data/init-rust.conf $$HOME/.ad/config.toml
 
 .PHONY: copy-bin
 copy-bin: ensure-mountpoint

--- a/data/help-template.txt
+++ b/data/help-template.txt
@@ -269,8 +269,8 @@ If you have the 9p(1) command line utility installed you can use it to explore t
   9p ls ad/buffers/1
   9p read ad/buffers/1/dot
 
-If you have the fusermount(1) and 9pfuse(4) programs installed then you can set the "auto-mount"
-property in ~/.ad/init.conf to true and mount the filesystem directly at ~/.ad/mnt when ad starts.
+If you have the fusermount(1) and 9pfuse(4) programs installed then you can set the "auto_mount"
+property in ~/.ad/config.toml to true and mount the filesystem directly at ~/.ad/mnt when ad starts.
 The default scripts provided in the ad GitHub repo serve as a useful reference for the sorts of
 interactions that are possible through this interface:
 

--- a/data/regression/edit-landing-on-gap-end.txt
+++ b/data/regression/edit-landing-on-gap-end.txt
@@ -19,7 +19,7 @@ pwd                   -- print the current editor working directory
 q | quit              -- quit ad as long as there are no buffers with pending changes
 q! | quit!            -- quit ad discarding all pending changes for open buffers
 reload-buffer | Get   -- refresh the current buffer's content from the state of the file on disk
-reload-config         -- reload the editor config file located at ~/.ad/init.conf
+reload-config         -- reload the editor config file located at ~/.ad/config.toml
 set                   -- set a config property ('set bg-color=#ebdbb2')
 view-logs             -- open ad's internal logs in a new buffer
 viewport-bottom       -- place the current line at the bottom of the window

--- a/docs/tour/fsys
+++ b/docs/tour/fsys
@@ -11,4 +11,4 @@ interacting with ad from other programs:
         9p read ad/buffers/1/dot
 
     - if you have the fusermount(1) and 9pfuse(4) programs installed then you can set the
-      "auto-mount" property in ../../data/init.conf to true and mount the filesystem directly
+      "auto-mount" property in ../../data/config.toml to true and mount the filesystem directly

--- a/examples/demos/structural-regex-reformatting.txt
+++ b/examples/demos/structural-regex-reformatting.txt
@@ -25,7 +25,7 @@ pwd                   -- print the current editor working directory
 q | quit              -- quit ad as long as there are no buffers with pending changes
 q! | quit!            -- quit ad discarding all pending changes for open buffers
 reload-buffer | Get   -- refresh the current buffer's content from the state of the file on disk
-reload-config         -- reload the editor config file located at ~/.ad/init.conf
+reload-config         -- reload the editor config file located at ~/.ad/config.toml
 set                   -- set a config property ('set bg-color=#ebdbb2')
 view-logs             -- open ad's internal logs in a new buffer
 viewport-bottom       -- place the current line at the bottom of the window

--- a/src/editor/built_in_commands.rs
+++ b/src/editor/built_in_commands.rs
@@ -94,7 +94,7 @@ pub fn built_in_commands() -> Vec<(Vec<&'static str>, &'static str)> {
         ),
         (
             vec!["reload-config"],
-            "reload the editor config file located at ~/.ad/init.conf",
+            "reload the editor config file located at ~/.ad/config.toml",
         ),
         (
             vec!["set"],


### PR DESCRIPTION
Updated all references from init.conf to config.toml in various files including Makefile, help-template.txt, edit-landing-on-gap-end.txt, fsys, structural-regex-reformatting.txt, and built_in_commands.rs.

Fixes: #67