### PR TITLE
fix: set correct bg colour for trailing line whitespaces

### DIFF
--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -726,6 +726,7 @@ fn render_line(
     }
 
     if cols < max_cols {
+        buf.push_str(&Style::Bg(cs.bg).to_string());
         buf.extend(std::iter::repeat_n(' ', max_cols - cols));
     }
 


### PR DESCRIPTION
Fixes issue: https://github.com/sminez/ad/issues/72

Trailing whitespaces aren't coloured correctly when inserted inside of  `render_line`:
- `render_line` inserts empty whitespace characters after rendering the last token that is available.
- `render_slice` that is used for rendering individual tokens finishes by inserting "[m" ASCII escape sequence which resets all previously set style options including background colour.
- Trailing whitespace characters are inserted without any background colour specified.

So in order to properly insert trailing whitespace we must specify a background colour ASCII escape sequence before that.