### PR TITLE
Implement fsys SetBufferName operation

### DIFF
--- a/data/bin/Slide
+++ b/data/bin/Slide
@@ -16,7 +16,7 @@
 # > Example index content:
 #   intro
 #   body
-#   conclusion 
+#   conclusion
 
 . "$HOME/.ad/lib/ad.sh"
 
@@ -46,11 +46,9 @@ case "$1" in
     ;;
 esac
 
-# TODO: being able to replace the current buffer with a new one
-#       rather than opening new buffers each time would be nice
-adCtl "open $d/$toLoad"
+id="$(currentBufferId)"
+echo "$d/$toLoad" | bufWrite "$id" filename
 adCtl "Get"
 adEdit "0 i/[PrevSlide] [NextSlide]\n\n/"
-id="$(currentBufferId)"
 curToBof "$id"
 markClean "$id"

--- a/src/fsys/buffer.rs
+++ b/src/fsys/buffer.rs
@@ -246,7 +246,7 @@ impl BufferNodes {
             XADDR => Req::SetBufferXAddr { id, s },
             OUTPUT => Req::AppendOutput { id, s },
             EVENT => return send_event_to_editor(id, &s, &self.tx),
-            FILENAME => return Err(E_UNKNOWN_FILE.to_string()),
+            FILENAME => Req::SetBufferName { id, s },
             _ => return Err(E_UNKNOWN_FILE.to_string()),
         };
 

--- a/src/fsys/message.rs
+++ b/src/fsys/message.rs
@@ -44,6 +44,10 @@ pub enum Req {
     ReadBufferName {
         id: usize,
     },
+    SetBufferName {
+        id: usize,
+        s: String,
+    },
     ReadBufferDot {
         id: usize,
     },


### PR DESCRIPTION
_This is based on the discussion in https://github.com/sminez/ad/issues/77#issuecomment-2599695604._

Currently, it's not possible to do something like this:

```
$> echo "/Users/izuzak/Developer/ad/docs/tour/intro" | 9p write ad/buffers/1/filename
9p: write error: unknown file
```

As @sminez wrote in that issue:

> All of the filesystem logic lives in the fsys module. The handler for writing to a buffer's filename file is here: https://github.com/sminez/ad/blob/develop/src%2Ffsys%2Fbuffer.rs#L249 (currently hard coded to return an error). To achieve what you're after you would need to alter that handler to send a message to the main event loop similar to how things are handled for writing to the body.

> The behaviour around this in acme would be something like writing to the filename to update it to the file you wanted to swap to and then sending a command to reload that buffer from disk (to load the file content)

We'll use this PR to iterate towards a solution. List of things that need to be done:

- [ ] Support file renaming. _"It wouldn't be possible to rename a file (as the file not being found results in an error) and I think at least from how I've seen this used in acme this is an expected use case (update the filename of the "window" in acme terminology and then run Get to load that file into the window)."_
- [ ] Support changing buffer type. _"The current buffer type is being retained rather than being set based on the new path, which would mean you would be unable to move from a file, to a directory or scratch buffer etc"_
