### PR TITLE
tree-sitter and lsp for python and R

### DIFF
--- a/data/config.toml
+++ b/data/config.toml
@@ -149,3 +149,17 @@ extensions = ["sql"]
 [[languages]]
 name = "toml"
 extensions = ["toml"]
+
+[[languages]]
+name = "r"
+extensions = ["R"]
+lsp.command = "R"
+lsp.args = ["--slave", "-e", "languageserver::run()"]
+lsp.roots = ["dummy.R"]
+
+[[languages]]
+name = "python"
+extensions = ["py"]
+lsp.command = "pylsp"
+lsp.roots = ["dummy.py"]
+

--- a/data/tree-sitter/queries/python/highlights.scm
+++ b/data/tree-sitter/queries/python/highlights.scm
@@ -6,21 +6,13 @@
 ; Reset highlighting in f-string interpolations
 (interpolation) @none
 
-; Identifier naming conventions
-((identifier) @type
-  (#lua-match? @type "^[A-Z].*[a-z]"))
-
-((identifier) @constant
-  (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
-
 ((identifier) @constant.builtin
-  (#lua-match? @constant.builtin "^__[a-zA-Z0-9_]*__$"))
+  (#any-of? @constant.builtin
+    ; https://docs.python.org/3/library/constants.html
+    "NotImplemented" "Ellipsis" "quit" "exit" "copyright" "credits" "license"))
 
 "_" @character.special ; match wildcard
 
-((attribute
-  attribute: (identifier) @variable.member)
-  (#lua-match? @variable.member "^[%l_].*$"))
 
 ((assignment
   left: (identifier) @type.definition
@@ -41,15 +33,6 @@
 (call
   function: (attribute
     attribute: (identifier) @function.method.call))
-
-((call
-  function: (identifier) @constructor)
-  (#lua-match? @constructor "^%u"))
-
-((call
-  function: (attribute
-    attribute: (identifier) @constructor))
-  (#lua-match? @constructor "^%u"))
 
 ; Decorators
 ((decorator
@@ -75,6 +58,18 @@
 ((decorator
   (identifier) @attribute.builtin)
   (#any-of? @attribute.builtin "classmethod" "property" "staticmethod"))
+
+; Builtin functions
+((call
+  function: (identifier) @function.builtin)
+  (#any-of? @function.builtin
+    "abs" "all" "any" "ascii" "bin" "bool" "breakpoint" "bytearray" "bytes" "callable" "chr"
+    "classmethod" "compile" "complex" "delattr" "dict" "dir" "divmod" "enumerate" "eval" "exec"
+    "filter" "float" "format" "frozenset" "getattr" "globals" "hasattr" "hash" "help" "hex" "id"
+    "input" "int" "isinstance" "issubclass" "iter" "len" "list" "locals" "map" "max" "memoryview"
+    "min" "next" "object" "oct" "open" "ord" "pow" "print" "property" "range" "repr" "reversed"
+    "round" "set" "setattr" "slice" "sorted" "staticmethod" "str" "sum" "super" "tuple" "type"
+    "vars" "zip" "__import__"))
 
 ; Function definitions
 (function_definition
@@ -157,16 +152,17 @@
   (false)
 ] @boolean
 
+((identifier) @variable.builtin
+  (#eq? @variable.builtin "self"))
+
+((identifier) @variable.builtin
+  (#eq? @variable.builtin "cls"))
+
 (integer) @number
 
 (float) @number.float
 
 (comment) @comment @spell
-
-((module
-  .
-  (comment) @keyword.directive @nospell)
-  (#lua-match? @keyword.directive "^#!/"))
 
 (string) @string
 
@@ -386,25 +382,30 @@
     (identifier) @type))
 
 ((class_definition
-  body: (block
-    (expression_statement
-      (assignment
-        left: (identifier) @variable.member))))
-  (#lua-match? @variable.member "^[%l_].*$"))
-
-((class_definition
-  body: (block
-    (expression_statement
-      (assignment
-        left: (_
-          (identifier) @variable.member)))))
-  (#lua-match? @variable.member "^[%l_].*$"))
-
-((class_definition
   (block
     (function_definition
       name: (identifier) @constructor)))
   (#any-of? @constructor "__new__" "__init__"))
+
+((identifier) @type.builtin
+  (#any-of? @type.builtin
+    ; https://docs.python.org/3/library/exceptions.html
+    "BaseException" "Exception" "ArithmeticError" "BufferError" "LookupError" "AssertionError"
+    "AttributeError" "EOFError" "FloatingPointError" "GeneratorExit" "ImportError"
+    "ModuleNotFoundError" "IndexError" "KeyError" "KeyboardInterrupt" "MemoryError" "NameError"
+    "NotImplementedError" "OSError" "OverflowError" "RecursionError" "ReferenceError" "RuntimeError"
+    "StopIteration" "StopAsyncIteration" "SyntaxError" "IndentationError" "TabError" "SystemError"
+    "SystemExit" "TypeError" "UnboundLocalError" "UnicodeError" "UnicodeEncodeError"
+    "UnicodeDecodeError" "UnicodeTranslateError" "ValueError" "ZeroDivisionError" "EnvironmentError"
+    "IOError" "WindowsError" "BlockingIOError" "ChildProcessError" "ConnectionError"
+    "BrokenPipeError" "ConnectionAbortedError" "ConnectionRefusedError" "ConnectionResetError"
+    "FileExistsError" "FileNotFoundError" "InterruptedError" "IsADirectoryError"
+    "NotADirectoryError" "PermissionError" "ProcessLookupError" "TimeoutError" "Warning"
+    "UserWarning" "DeprecationWarning" "PendingDeprecationWarning" "SyntaxWarning" "RuntimeWarning"
+    "FutureWarning" "ImportWarning" "UnicodeWarning" "BytesWarning" "ResourceWarning"
+    ; https://docs.python.org/3/library/stdtypes.html
+    "bool" "int" "float" "complex" "list" "tuple" "range" "str" "bytes" "bytearray" "memoryview"
+    "set" "frozenset" "dict" "type" "object"))
 
 ; Regex from the `re` module
 (call
@@ -415,5 +416,3 @@
     (string
       (string_content) @string.regexp))
   (#eq? @_re "re"))
-
-

--- a/data/tree-sitter/queries/python/highlights.scm
+++ b/data/tree-sitter/queries/python/highlights.scm
@@ -1,0 +1,419 @@
+; From tree-sitter-python licensed under MIT License
+; Copyright (c) 2016 Max Brunsfeld
+; Variables
+(identifier) @variable
+
+; Reset highlighting in f-string interpolations
+(interpolation) @none
+
+; Identifier naming conventions
+((identifier) @type
+  (#lua-match? @type "^[A-Z].*[a-z]"))
+
+((identifier) @constant
+  (#lua-match? @constant "^[A-Z][A-Z_0-9]*$"))
+
+((identifier) @constant.builtin
+  (#lua-match? @constant.builtin "^__[a-zA-Z0-9_]*__$"))
+
+"_" @character.special ; match wildcard
+
+((attribute
+  attribute: (identifier) @variable.member)
+  (#lua-match? @variable.member "^[%l_].*$"))
+
+((assignment
+  left: (identifier) @type.definition
+  (type
+    (identifier) @_annotation))
+  (#eq? @_annotation "TypeAlias"))
+
+((assignment
+  left: (identifier) @type.definition
+  right: (call
+    function: (identifier) @_func))
+  (#any-of? @_func "TypeVar" "NewType"))
+
+; Function calls
+(call
+  function: (identifier) @function.call)
+
+(call
+  function: (attribute
+    attribute: (identifier) @function.method.call))
+
+((call
+  function: (identifier) @constructor)
+  (#lua-match? @constructor "^%u"))
+
+((call
+  function: (attribute
+    attribute: (identifier) @constructor))
+  (#lua-match? @constructor "^%u"))
+
+; Decorators
+((decorator
+  "@" @attribute)
+  (#set! priority 101))
+
+(decorator
+  (identifier) @attribute)
+
+(decorator
+  (attribute
+    attribute: (identifier) @attribute))
+
+(decorator
+  (call
+    (identifier) @attribute))
+
+(decorator
+  (call
+    (attribute
+      attribute: (identifier) @attribute)))
+
+((decorator
+  (identifier) @attribute.builtin)
+  (#any-of? @attribute.builtin "classmethod" "property" "staticmethod"))
+
+; Function definitions
+(function_definition
+  name: (identifier) @function)
+
+(type
+  (identifier) @type)
+
+(type
+  (subscript
+    (identifier) @type)) ; type subscript: Tuple[int]
+
+((call
+  function: (identifier) @_isinstance
+  arguments: (argument_list
+    (_)
+    (identifier) @type))
+  (#eq? @_isinstance "isinstance"))
+
+; Normal parameters
+(parameters
+  (identifier) @variable.parameter)
+
+; Lambda parameters
+(lambda_parameters
+  (identifier) @variable.parameter)
+
+(lambda_parameters
+  (tuple_pattern
+    (identifier) @variable.parameter))
+
+; Default parameters
+(keyword_argument
+  name: (identifier) @variable.parameter)
+
+; Naming parameters on call-site
+(default_parameter
+  name: (identifier) @variable.parameter)
+
+(typed_parameter
+  (identifier) @variable.parameter)
+
+(typed_default_parameter
+  name: (identifier) @variable.parameter)
+
+; Variadic parameters *args, **kwargs
+(parameters
+  (list_splat_pattern ; *args
+    (identifier) @variable.parameter))
+
+(parameters
+  (dictionary_splat_pattern ; **kwargs
+    (identifier) @variable.parameter))
+
+; Typed variadic parameters
+(parameters
+  (typed_parameter
+    (list_splat_pattern ; *args: type
+      (identifier) @variable.parameter)))
+
+(parameters
+  (typed_parameter
+    (dictionary_splat_pattern ; *kwargs: type
+      (identifier) @variable.parameter)))
+
+; Lambda parameters
+(lambda_parameters
+  (list_splat_pattern
+    (identifier) @variable.parameter))
+
+(lambda_parameters
+  (dictionary_splat_pattern
+    (identifier) @variable.parameter))
+
+; Literals
+(none) @constant.builtin
+
+[
+  (true)
+  (false)
+] @boolean
+
+(integer) @number
+
+(float) @number.float
+
+(comment) @comment @spell
+
+((module
+  .
+  (comment) @keyword.directive @nospell)
+  (#lua-match? @keyword.directive "^#!/"))
+
+(string) @string
+
+[
+  (escape_sequence)
+  (escape_interpolation)
+] @string.escape
+
+; doc-strings
+(module
+  .
+  (comment)*
+  .
+  (expression_statement
+    (string
+      (string_content) @spell) @string.documentation))
+
+(class_definition
+  body: (block
+    .
+    (expression_statement
+      (string
+        (string_content) @spell) @string.documentation)))
+
+(function_definition
+  body: (block
+    .
+    (expression_statement
+      (string
+        (string_content) @spell) @string.documentation)))
+
+; Tokens
+[
+  "-"
+  "-="
+  ":="
+  "!="
+  "*"
+  "**"
+  "**="
+  "*="
+  "/"
+  "//"
+  "//="
+  "/="
+  "&"
+  "&="
+  "%"
+  "%="
+  "^"
+  "^="
+  "+"
+  "+="
+  "<"
+  "<<"
+  "<<="
+  "<="
+  "<>"
+  "="
+  "=="
+  ">"
+  ">="
+  ">>"
+  ">>="
+  "@"
+  "@="
+  "|"
+  "|="
+  "~"
+  "->"
+] @operator
+
+; Keywords
+[
+  "and"
+  "in"
+  "is"
+  "not"
+  "or"
+  "is not"
+  "not in"
+  "del"
+] @keyword.operator
+
+[
+  "def"
+  "lambda"
+] @keyword.function
+
+[
+  "assert"
+  "exec"
+  "global"
+  "nonlocal"
+  "pass"
+  "print"
+  "with"
+  "as"
+] @keyword
+
+[
+  "type"
+  "class"
+] @keyword.type
+
+[
+  "async"
+  "await"
+] @keyword.coroutine
+
+[
+  "return"
+  "yield"
+] @keyword.return
+
+(yield
+  "from" @keyword.return)
+
+(future_import_statement
+  "from" @keyword.import
+  "__future__" @module.builtin)
+
+(import_from_statement
+  "from" @keyword.import)
+
+"import" @keyword.import
+
+(aliased_import
+  "as" @keyword.import)
+
+(wildcard_import
+  "*" @character.special)
+
+(import_statement
+  name: (dotted_name
+    (identifier) @module))
+
+(import_statement
+  name: (aliased_import
+    name: (dotted_name
+      (identifier) @module)
+    alias: (identifier) @module))
+
+(import_from_statement
+  module_name: (dotted_name
+    (identifier) @module))
+
+(import_from_statement
+  module_name: (relative_import
+    (dotted_name
+      (identifier) @module)))
+
+[
+  "if"
+  "elif"
+  "else"
+  "match"
+  "case"
+] @keyword.conditional
+
+[
+  "for"
+  "while"
+  "break"
+  "continue"
+] @keyword.repeat
+
+[
+  "try"
+  "except"
+  "except*"
+  "raise"
+  "finally"
+] @keyword.exception
+
+(raise_statement
+  "from" @keyword.exception)
+
+(try_statement
+  (else_clause
+    "else" @keyword.exception))
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+(interpolation
+  "{" @punctuation.special
+  "}" @punctuation.special)
+
+(type_conversion) @function.macro
+
+[
+  ","
+  "."
+  ":"
+  ";"
+  (ellipsis)
+] @punctuation.delimiter
+
+; Class definitions
+(class_definition
+  name: (identifier) @type)
+
+(class_definition
+  body: (block
+    (function_definition
+      name: (identifier) @function.method)))
+
+(class_definition
+  superclasses: (argument_list
+    (identifier) @type))
+
+((class_definition
+  body: (block
+    (expression_statement
+      (assignment
+        left: (identifier) @variable.member))))
+  (#lua-match? @variable.member "^[%l_].*$"))
+
+((class_definition
+  body: (block
+    (expression_statement
+      (assignment
+        left: (_
+          (identifier) @variable.member)))))
+  (#lua-match? @variable.member "^[%l_].*$"))
+
+((class_definition
+  (block
+    (function_definition
+      name: (identifier) @constructor)))
+  (#any-of? @constructor "__new__" "__init__"))
+
+; Regex from the `re` module
+(call
+  function: (attribute
+    object: (identifier) @_re)
+  arguments: (argument_list
+    .
+    (string
+      (string_content) @string.regexp))
+  (#eq? @_re "re"))
+
+

--- a/data/tree-sitter/queries/r/highlights.scm
+++ b/data/tree-sitter/queries/r/highlights.scm
@@ -1,0 +1,148 @@
+; Literals
+(integer) @number
+
+(float) @number.float
+
+(complex) @number
+
+(string) @string
+
+(string
+  (string_content
+    (escape_sequence) @string.escape))
+
+; Comments
+(comment) @comment @spell
+
+((program
+  .
+  (comment) @keyword.directive @nospell)
+  (#lua-match? @keyword.directive "^#!/"))
+
+; Operators
+[
+  "?"
+  ":="
+  "="
+  "<-"
+  "<<-"
+  "->"
+  "->>"
+  "~"
+  "|>"
+  "||"
+  "|"
+  "&&"
+  "&"
+  "<"
+  "<="
+  ">"
+  ">="
+  "=="
+  "!="
+  "+"
+  "-"
+  "*"
+  "/"
+  "::"
+  ":::"
+  "**"
+  "^"
+  "$"
+  "@"
+  ":"
+  "!"
+  "special"
+] @operator
+
+; Punctuation
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+  "[["
+  "]]"
+] @punctuation.bracket
+
+(comma) @punctuation.delimiter
+
+; Variables
+(identifier) @variable
+
+; Functions
+(binary_operator
+  lhs: (identifier) @function
+  operator: "<-"
+  rhs: (function_definition))
+
+(binary_operator
+  lhs: (identifier) @function
+  operator: "="
+  rhs: (function_definition))
+
+; Calls
+(call
+  function: (identifier) @function.call)
+
+(extract_operator
+  rhs: (identifier) @variable.member)
+
+function: (extract_operator
+  rhs: (identifier) @function.method.call)
+
+; Parameters
+(parameters
+  (parameter
+    name: (identifier) @variable.parameter))
+
+(arguments
+  (argument
+    name: (identifier) @variable.parameter))
+
+; Namespace
+(namespace_operator
+  lhs: (identifier) @module)
+
+(call
+  function: (namespace_operator
+    rhs: (identifier) @function))
+
+; Keywords
+(function_definition
+  name: "function" @keyword.function)
+
+(function_definition
+  name: "\\" @operator)
+
+(return) @keyword.return
+
+[
+  "if"
+  "else"
+] @keyword.conditional
+
+[
+  "while"
+  "repeat"
+  "for"
+  "in"
+  (break)
+  (next)
+] @keyword.repeat
+
+[
+  (true)
+  (false)
+] @boolean
+
+[
+  (null)
+  (inf)
+  (nan)
+  (na)
+  (dots)
+  (dot_dot_i)
+] @constant.builtin

--- a/data/tree-sitter/queries/r/highlights.scm
+++ b/data/tree-sitter/queries/r/highlights.scm
@@ -14,11 +14,6 @@
 ; Comments
 (comment) @comment @spell
 
-((program
-  .
-  (comment) @keyword.directive @nospell)
-  (#lua-match? @keyword.directive "^#!/"))
-
 ; Operators
 [
   "?"


### PR DESCRIPTION
This is to add some configuration to get tree-sitter and LSP working in a minimal way for python and R. #87

Python in ad 
![ad-python](https://github.com/user-attachments/assets/68980813-b6ce-4bff-998b-2bb788ddde9f)

R in ad 
![ad-R](https://github.com/user-attachments/assets/5d036074-da75-499c-b761-ed1d0a997aae)
