### PR TITLE
contrib: add a simple markdown preview script

### DIFF
--- a/data/contrib/sh/markdown-preview
+++ b/data/contrib/sh/markdown-preview
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# A simple ad helper script to preview markdown in ad using pandoc and w3m
+
+. "$HOME/.ad/lib/ad.sh"
+
+requireAd
+
+processMarkdown() {
+  clearBuffer "$1"
+  bufRead "$2" body | pandoc | w3m -T text/html 2>&1 | bufWrite "$1" body
+  curToBof "$1"
+  markClean "$1"  
+}
+
+currentId="$(currentBufferId)"
+adCtl "open-in-new-window ./+markdown-preview"
+id="$(adIndex | grep "+markdown-preview" | cut -f1)"
+focusBuffer "$currentId"
+processMarkdown "$id" "$currentId"


### PR DESCRIPTION
The idea if this simple bash script "markdown-preview" is to create a preview window in ad of the markdown code in a buffer processed to html using pandoc. 

pandoc (https://pandoc.org/) is needed for the conversion to html and w3m (https://w3m.sourceforge.net/) is needed for viewing the html in an ad buffer.  

This PR is linked with #99 

![markdown-preview](https://github.com/user-attachments/assets/a065883f-212d-448a-8f9a-bc221731099d)


 