### PR TITLE
A bunch of improvements to the ninep crate

### DIFF
--- a/crates/ninep/src/sansio/client.rs
+++ b/crates/ninep/src/sansio/client.rs
@@ -43,7 +43,6 @@ where
 /// to implement a concrete Client.
 #[derive(Debug)]
 pub(crate) struct State {
-    pub(crate) uname: String,
     pub(crate) msize: u32,
     pub(crate) fids: HashMap<String, u32>,
     pub(crate) next_fid: u32,
@@ -60,6 +59,7 @@ impl State {
     /// Establish our connection to the target 9p server and begin the session.
     pub(crate) fn handle_connect(
         &mut self,
+        uname: String,
         aname: String,
     ) -> Coro9p<(), impl Future<Output = io::Result<()>> + use<'_>> {
         Coro::from(move |handle: Handle<Tmessage, Rmessage>| async move {
@@ -84,7 +84,7 @@ impl State {
                     Tdata::Attach {
                         fid: 0,
                         afid: u32::MAX, // no auth
-                        uname: self.uname.clone(),
+                        uname,
                         aname,
                     },
                 ))

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -1,8 +1,7 @@
 //! Traits and structs for implementing a 9p fileserver
 use crate::{
     fs::{FileMeta, FileType, Stat, QID_ROOT},
-    sansio::protocol::{Data, Qid, RawStat, Rdata, Tdata, Tmessage, MAX_DATA_LEN},
-    sync::SyncNineP,
+    sansio::protocol::{Data, NineP, Qid, RawStat, Rdata, Tdata, Tmessage, MAX_DATA_LEN},
     Result,
 };
 use simple_coro::{Coro, Handle, ReadyCoro};
@@ -263,8 +262,7 @@ impl SessionState<Attached> {
                 for stat in stats.into_iter() {
                     self.qids.entry(stat.fm.qid).or_insert(stat.fm.clone());
                     let rstat: RawStat = stat.into();
-                    let mut tmp = Vec::new();
-                    rstat.write_to(&mut tmp).unwrap();
+                    let tmp = rstat.write_9p_bytes().unwrap();
 
                     if to_skip != 0 {
                         if tmp.len() > to_skip {

--- a/crates/ninep/src/sync/client.rs
+++ b/crates/ninep/src/sync/client.rs
@@ -37,10 +37,9 @@ impl<S> Clone for Client<S> {
 }
 
 impl<S> Client<S> {
-    fn new(uname: impl Into<String>, stream: S) -> Self {
+    fn new(stream: S) -> Self {
         Self {
             state: Arc::new(Mutex::new(State {
-                uname: uname.into(),
                 msize: MSIZE,
                 fids: HashMap::from([(String::new(), 0)]),
                 next_fid: 1,
@@ -81,8 +80,8 @@ impl Client<UnixStream> {
     ) -> io::Result<Self> {
         let stream = UnixStream::connect(path.as_ref())?;
 
-        let mut client = Self::new(uname, stream);
-        client.connect(aname)?;
+        let mut client = Self::new(stream);
+        client.connect(uname, aname)?;
 
         Ok(client)
     }
@@ -113,8 +112,8 @@ impl Client<TcpStream> {
     ) -> io::Result<Self> {
         let stream = TcpStream::connect(addr)?;
 
-        let mut client = Self::new(uname, stream);
-        client.connect(aname)?;
+        let mut client = Self::new(stream);
+        client.connect(uname, aname)?;
 
         Ok(client)
     }
@@ -162,8 +161,8 @@ where
     }
 
     /// Establish our connection to the target 9p server and begin the session.
-    fn connect(&mut self, aname: impl Into<String>) -> io::Result<()> {
-        run_9p_coro!(self, handle_connect, aname.into())
+    fn connect(&mut self, uname: impl Into<String>, aname: impl Into<String>) -> io::Result<()> {
+        run_9p_coro!(self, handle_connect, uname.into(), aname.into())
     }
 
     /// Associate the given path with a new fid.

--- a/crates/ninep/src/sync/client.rs
+++ b/crates/ninep/src/sync/client.rs
@@ -37,12 +37,12 @@ impl<S> Clone for Client<S> {
 }
 
 impl<S> Client<S> {
-    fn new(uname: impl Into<String>, fids: HashMap<String, u32>, stream: S) -> Self {
+    fn new(uname: impl Into<String>, stream: S) -> Self {
         Self {
             state: Arc::new(Mutex::new(State {
                 uname: uname.into(),
                 msize: MSIZE,
-                fids,
+                fids: HashMap::from([(String::new(), 0)]),
                 next_fid: 1,
             })),
             stream: Arc::new(Mutex::new(stream)),
@@ -80,10 +80,8 @@ impl Client<UnixStream> {
         aname: impl Into<String>,
     ) -> io::Result<Self> {
         let stream = UnixStream::connect(path.as_ref())?;
-        let mut fids = HashMap::new();
-        fids.insert(String::new(), 0);
 
-        let mut client = Self::new(uname, fids, stream);
+        let mut client = Self::new(uname, stream);
         client.connect(aname)?;
 
         Ok(client)
@@ -114,10 +112,8 @@ impl Client<TcpStream> {
         aname: impl Into<String>,
     ) -> io::Result<Self> {
         let stream = TcpStream::connect(addr)?;
-        let mut fids = HashMap::new();
-        fids.insert(String::new(), 0);
 
-        let mut client = Self::new(uname, fids, stream);
+        let mut client = Self::new(uname, stream);
         client.connect(aname)?;
 
         Ok(client)

--- a/crates/ninep/src/sync/mod.rs
+++ b/crates/ninep/src/sync/mod.rs
@@ -41,18 +41,25 @@ pub trait SyncNineP: NineP {
 impl<T> SyncNineP for T where T: NineP {}
 
 /// A [Stream] that makes use of the standard library [Read] and [Write] traits to perform IO
-pub trait SyncStream: Read + Write + Send + Sized + 'static {
+pub trait SyncStream: Read + Write + Send + Sized + 'static {}
+
+impl SyncStream for UnixStream {}
+impl SyncStream for TcpStream {}
+
+/// A [Stream] that makes use of the standard library [Read] and [Write] traits to perform IO
+/// and additionally supports cloning the stream.
+pub trait SyncServerStream: SyncStream {
     /// Clone this stream, accounting for operating system errors
     fn try_clone(&self) -> Result<Self>;
 }
 
-impl SyncStream for UnixStream {
+impl SyncServerStream for UnixStream {
     fn try_clone(&self) -> Result<Self> {
         self.try_clone().map_err(|e| e.to_string())
     }
 }
 
-impl SyncStream for TcpStream {
+impl SyncServerStream for TcpStream {
     fn try_clone(&self) -> Result<Self> {
         self.try_clone().map_err(|e| e.to_string())
     }

--- a/crates/ninep/src/sync/mod.rs
+++ b/crates/ninep/src/sync/mod.rs
@@ -1,8 +1,5 @@
 //! A synchronous implementation of 9p Servers and Clients
-use crate::{
-    sansio::protocol::{NineP, Rdata, Rmessage},
-    Result,
-};
+use crate::{sansio::protocol::NineP, Result};
 use simple_coro::{Coro, CoroState};
 use std::{
     io::{self, Read, Write},
@@ -47,13 +44,6 @@ impl<T> SyncNineP for T where T: NineP {}
 pub trait SyncStream: Read + Write + Send + Sized + 'static {
     /// Clone this stream, accounting for operating system errors
     fn try_clone(&self) -> Result<Self>;
-
-    /// Reply to the specified tag with a given Result. Err's will be converted to 9p error
-    /// messages automatically.
-    fn reply(&mut self, tag: u16, resp: Result<Rdata>) {
-        let r: Rmessage = (tag, resp).into();
-        let _ = r.write_to(self);
-    }
 }
 
 impl SyncStream for UnixStream {

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -11,7 +11,7 @@ use crate::{
             E_CREATE_NON_DIR, E_UNKNOWN_FID,
         },
     },
-    sync::{SyncNineP, SyncStream},
+    sync::{SyncNineP, SyncServerStream, SyncStream},
     Result,
 };
 use simple_coro::CoroState;
@@ -206,7 +206,7 @@ where
 impl<S, U> Session<Unattached, S, U>
 where
     S: Serve9p,
-    U: SyncStream,
+    U: SyncServerStream,
 {
     fn handle_connection(mut self) {
         loop {
@@ -229,7 +229,7 @@ where
 impl<S, U> Session<Attached, S, U>
 where
     S: Serve9p,
-    U: SyncStream,
+    U: SyncServerStream,
 {
     /// Explicitly clunk all
     fn clunk_and_clear(&mut self) {

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -5,7 +5,7 @@
 use crate::{
     fs::{FileMeta, FileType, IoUnit, Mode, Perm, Stat},
     sansio::{
-        protocol::{Data, RawStat, Rdata, Tdata, Tmessage},
+        protocol::{Data, RawStat, Rdata, Rmessage, Tdata, Tmessage},
         server::{
             Attached, Either, Session, SessionType, Unattached, E_ALREADY_ATTACHED,
             E_CREATE_NON_DIR, E_UNKNOWN_FID,
@@ -198,7 +198,8 @@ where
     U: SyncStream,
 {
     fn reply(&mut self, tag: u16, resp: Result<Rdata>) {
-        self.stream.reply(tag, resp);
+        let r: Rmessage = (tag, resp).into();
+        let _ = r.write_to(&mut self.stream);
     }
 }
 
@@ -444,7 +445,9 @@ where
                         let mut stream = self.stream.try_clone()?;
                         spawn(move || {
                             let data = chan.recv().unwrap_or_default();
-                            stream.reply(tag, Ok(Rdata::Read { data: Data(data) }));
+                            let resp = Ok(Rdata::Read { data: Data(data) });
+                            let r: Rmessage = (tag, resp).into();
+                            let _ = r.write_to(&mut stream);
                         });
 
                         Ok(None)

--- a/crates/ninep/src/tokio/client.rs
+++ b/crates/ninep/src/tokio/client.rs
@@ -34,10 +34,9 @@ impl<S> Clone for Client<S> {
 }
 
 impl<S> Client<S> {
-    fn new(uname: impl Into<String>, fids: HashMap<String, u32>, stream: S) -> Self {
+    fn new(fids: HashMap<String, u32>, stream: S) -> Self {
         Self {
             state: Arc::new(Mutex::new(State {
-                uname: uname.into(),
                 msize: MSIZE,
                 fids,
                 next_fid: 1,
@@ -64,8 +63,8 @@ impl Client<UnixStream> {
         let mut fids = HashMap::new();
         fids.insert(String::new(), 0);
 
-        let mut client = Self::new(uname, fids, stream);
-        client.connect(aname).await?;
+        let mut client = Self::new(fids, stream);
+        client.connect(uname, aname).await?;
 
         Ok(client)
     }
@@ -98,8 +97,8 @@ impl Client<TcpStream> {
         let mut fids = HashMap::new();
         fids.insert(String::new(), 0);
 
-        let mut client = Self::new(uname, fids, stream);
-        client.connect(aname).await?;
+        let mut client = Self::new(fids, stream);
+        client.connect(uname, aname).await?;
 
         Ok(client)
     }
@@ -149,8 +148,12 @@ where
     }
 
     /// Establish our connection to the target 9p server and begin the session.
-    async fn connect(&mut self, aname: impl Into<String>) -> io::Result<()> {
-        run_9p_coro!(self, handle_connect, aname.into())
+    async fn connect(
+        &mut self,
+        uname: impl Into<String>,
+        aname: impl Into<String>,
+    ) -> io::Result<()> {
+        run_9p_coro!(self, handle_connect, uname.into(), aname.into())
     }
 
     /// Associate the given path with a new fid.


### PR DESCRIPTION
I've been investigating if it would be possible to use this crate for a virtio-9p client. There are bunch more changes necessary to actually be able to wire it up to virtio as transport layer (among other things each request needs to be written as a unit and the maximum size of the response needs to be known in advance to allocate a large enough response buffer), but I figured I would already post this set of improvements.