### PR TITLE
feat: reducing allocations in the 9p protocol layer

### DIFF
--- a/crates/ninep/src/fs.rs
+++ b/crates/ninep/src/fs.rs
@@ -1,5 +1,5 @@
 //! Types for describing files in a 9p virtual filesystem
-use super::sansio::protocol::{NineP, Qid, RawStat};
+use crate::sansio::protocol::{NineP, Qid, RawStat};
 use std::{
     mem::size_of,
     time::{Duration, SystemTime, UNIX_EPOCH},

--- a/crates/ninep/src/sansio/client.rs
+++ b/crates/ninep/src/sansio/client.rs
@@ -211,7 +211,7 @@ impl State {
             let bytes = handle.yield_from(self._read_all(path, Mode::DIR)).await?;
             let mut buf = io::Cursor::new(bytes);
             let mut stats: Vec<Stat> = Vec::new();
-            let sb = SharedBuf::new();
+            let sb = SharedBuf::default();
 
             loop {
                 match RawStat::read_from(&sb, &mut buf) {

--- a/crates/ninep/src/sansio/client.rs
+++ b/crates/ninep/src/sansio/client.rs
@@ -1,7 +1,7 @@
 //! Traits and structs for implementing a 9p client
 use crate::{
     fs::{Mode, Perm, Stat},
-    sansio::protocol::{Data, RawStat, Rdata, Rmessage, Tdata, Tmessage},
+    sansio::protocol::{Data, RawStat, Rdata, Rmessage, SharedBuf, Tdata, Tmessage},
     sync::SyncNineP,
 };
 use simple_coro::{Coro, Handle, ReadyCoro};
@@ -211,9 +211,10 @@ impl State {
             let bytes = handle.yield_from(self._read_all(path, Mode::DIR)).await?;
             let mut buf = io::Cursor::new(bytes);
             let mut stats: Vec<Stat> = Vec::new();
+            let sb = SharedBuf::new();
 
             loop {
-                match RawStat::read_from(&mut buf) {
+                match RawStat::read_from(&sb, &mut buf) {
                     Ok(rs) => match rs.try_into() {
                         Ok(s) => stats.push(s),
                         Err(e) => return err(e),

--- a/crates/ninep/src/sansio/protocol.rs
+++ b/crates/ninep/src/sansio/protocol.rs
@@ -2,13 +2,59 @@
 //!
 //!   http://man.cat-v.org/plan_9/5/
 use crate::sync::SyncNineP;
-use simple_coro::Handle;
+use simple_coro::{Coro, CoroState, Handle, ReadyCoro};
 use std::{
+    cell::UnsafeCell,
     fmt,
     future::Future,
-    io::{self, Cursor, ErrorKind},
+    io::{self, ErrorKind},
     mem::size_of,
 };
+
+/// A shared byte buffer that can be accessed inside of 9p parsing functions.
+///
+/// This is wildly unsafe as a general purpose API and only makes any sort of sense as a
+/// communication mechanism between a running `Coro` and the code that is driving it as we can
+/// guarantee that both are never executing at the same time.
+#[derive(Debug)]
+pub struct SharedBuf(UnsafeCell<Vec<u8>>);
+
+/// SAFETY: requres that the safety guarantees for as_inner_mut are upheld
+unsafe impl Send for SharedBuf {}
+/// SAFETY: requres that the safety guarantees for as_inner_mut are upheld
+unsafe impl Sync for SharedBuf {}
+
+impl Default for SharedBuf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SharedBuf {
+    /// Construct a new SharedBuf
+    pub fn new() -> Self {
+        Self(UnsafeCell::new(Vec::new()))
+    }
+
+    /// Get an exclusive reference to the inner buffer from a shared reference to the outer
+    /// [SharedBuf].
+    ///
+    /// # Safety
+    /// The caller must guarantee that no concurrent access to the inner buffer takes place while
+    /// this exclusive reference is held. In practice this is only safe to do as part of the IO
+    /// loop that is parsing a 9p message using a `Coro` that this [SharedBuf] is shared with.
+    #[allow(clippy::mut_from_ref)]
+    pub(crate) unsafe fn as_inner_mut(&self) -> &mut Vec<u8> {
+        // SAFETY: the caller must guarantee that no concurrent access takes place
+        unsafe { &mut *self.0.get() }
+    }
+
+    /// Get a shared reference to the inner buffer.
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        // SAFETY: the caller must guarantee that no concurrent access takes place
+        unsafe { &*self.0.get() }
+    }
+}
 
 /// The size of variable length data is denoted using a u16 so anything longer
 /// than u16::MAX is not something we can handle.
@@ -65,11 +111,18 @@ pub trait NineP: Sized {
 
     /// This is not a normal async function. It is used to set up a sans-io state machine that
     /// can be driven by a concrete implementation.
-    ///
-    /// # Safety
-    /// Implementations of `read` need to ensure that the only await points they contain are
-    /// from calls to the [request_bytes] macro.
-    fn read_9p(handle: Handle<usize, Vec<u8>>) -> impl Future<Output = io::Result<Self>> + Send;
+    fn read_9p(
+        buf: &SharedBuf,
+        handle: Handle<usize>,
+    ) -> impl Future<Output = io::Result<Self>> + Send;
+
+    /// Create a new [Coro] that reads from a [SharedBuf] to parse 9p protocol messages with
+    /// minimal allocation.
+    fn read_9p_coro(
+        buf: &SharedBuf,
+    ) -> ReadyCoro<usize, (), io::Result<Self>, impl Future<Output = io::Result<Self>> + Send> {
+        Coro::from(async move |handle: Handle<usize>| Self::read_9p(buf, handle).await)
+    }
 }
 
 /// wrapper around uX::from_le_bytes that accepts a slice rather than a fixed size array
@@ -95,9 +148,9 @@ macro_rules! impl_u {
                     Ok(())
                 }
 
-                async fn read_9p(handle: Handle<usize, Vec<u8>>) -> io::Result<$ty> {
-                    let buf = handle.yield_value(size_of::<$ty>()).await;
-                    Ok(from_le_bytes!($ty, buf))
+                async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<$ty> {
+                    handle.yield_value(size_of::<$ty>()).await;
+                    Ok(from_le_bytes!($ty, buf.as_slice()))
                 }
             }
         )+
@@ -133,11 +186,12 @@ impl NineP for String {
         Ok(())
     }
 
-    async fn read_9p(handle: Handle<usize, Vec<u8>>) -> io::Result<Self> {
-        let len = u16::read_9p(handle).await? as usize;
-        let buf = handle.yield_value(len).await;
+    async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+        let len = u16::read_9p(buf, handle).await? as usize;
+        handle.yield_value(len).await;
 
-        String::from_utf8(buf).map_err(|e| io::Error::new(ErrorKind::InvalidData, e.to_string()))
+        String::from_utf8(buf.as_slice()[..len].to_vec())
+            .map_err(|e| io::Error::new(ErrorKind::InvalidData, e.to_string()))
     }
 }
 
@@ -168,14 +222,14 @@ impl<T: NineP + fmt::Debug + Send> NineP for Vec<T> {
         Ok(())
     }
 
-    async fn read_9p(handle: Handle<usize, Vec<u8>>) -> io::Result<Self> {
-        let len = u16::read_9p(handle).await? as usize;
-        let mut buf = Vec::with_capacity(len);
+    async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+        let len = u16::read_9p(buf, handle).await? as usize;
+        let mut elems = Vec::with_capacity(len);
         for _ in 0..len {
-            buf.push(T::read_9p(handle).await?);
+            elems.push(T::read_9p(buf, handle).await?);
         }
 
-        Ok(buf)
+        Ok(elems)
     }
 }
 
@@ -214,9 +268,10 @@ impl TryFrom<Data> for Vec<RawStat> {
         let mut buf = Vec::new();
         let mut bytes = bytes.as_slice();
         let n = size_of::<RawStat>();
+        let sb = SharedBuf::new();
 
         loop {
-            match RawStat::read_from(&mut bytes) {
+            match RawStat::read_from(&sb, &mut bytes) {
                 Ok(rs) => {
                     buf.push(rs);
                     bytes = &bytes[n..];
@@ -247,16 +302,17 @@ impl NineP for Data {
         Ok(())
     }
 
-    async fn read_9p(handle: Handle<usize, Vec<u8>>) -> io::Result<Self> {
-        let len = u32::read_9p(handle).await? as usize;
+    async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+        let len = u32::read_9p(buf, handle).await? as usize;
         if len > MAX_DATA_LEN {
             return Err(io::Error::new(
                 ErrorKind::InvalidData,
                 format!("data field too long: max={MAX_DATA_LEN} len={len}"),
             ));
         }
+        handle.yield_value(len).await;
 
-        Ok(Data(handle.yield_value(len).await))
+        Ok(Data(buf.as_slice()[..len].to_vec()))
     }
 }
 
@@ -317,23 +373,23 @@ impl NineP for RawStat {
         )
     }
 
-    async fn read_9p(handle: Handle<usize, Vec<u8>>) -> io::Result<Self> {
+    async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
         // Request the fixed sized data before the strings in one block up front
-        let buf = handle.yield_value(41).await;
+        handle.yield_value(41).await;
         let bytes = buf.as_slice();
 
         let size = from_le_bytes!(u16, bytes);
         let ty = from_le_bytes!(u16, &bytes[2..]);
         let dev = from_le_bytes!(u32, &bytes[4..]);
-        let qid = Qid::read_from(&mut &bytes[8..])?;
+        let qid = Qid::read_from(buf, &mut &bytes[8..])?;
         let mode = from_le_bytes!(u32, &bytes[21..]);
         let atime = from_le_bytes!(u32, &bytes[25..]);
         let mtime = from_le_bytes!(u32, &bytes[29..]);
         let length = from_le_bytes!(u64, &bytes[33..]);
-        let name = String::read_9p(handle).await?;
-        let uid = String::read_9p(handle).await?;
-        let gid = String::read_9p(handle).await?;
-        let muid = String::read_9p(handle).await?;
+        let name = String::read_9p(buf, handle).await?;
+        let uid = String::read_9p(buf, handle).await?;
+        let gid = String::read_9p(buf, handle).await?;
+        let muid = String::read_9p(buf, handle).await?;
 
         Ok(RawStat {
             size,
@@ -386,8 +442,8 @@ macro_rules! impl_message_datatype {
                 write_fields!(buf, self, $($field),*)
             }
 
-            async fn read_9p(handle: Handle<usize, Vec<u8>>) -> io::Result<Self> {
-                $(let $field = <$ty>::read_9p(handle).await?;)*
+            async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+                $(let $field = <$ty>::read_9p(buf, handle).await?;)*
                 Ok($struct { $($field),* })
             }
         }
@@ -519,18 +575,25 @@ macro_rules! impl_message_format {
             }
 
             #[allow(unused_assignments)]
-            async fn read_9p(handle: Handle<usize, Vec<u8>>) -> io::Result<Self> {
-                let len = u32::read_9p(handle).await? as usize;
-                let bytes = handle.yield_value(len-4).await;
-                let ty = from_le_bytes!(u8, &bytes);
-                let tag = from_le_bytes!(u16, &bytes[1..]);
-                let mut cur = Cursor::new(bytes);
-                cur.set_position(3);
+            async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+                let len = u32::read_9p(buf, handle).await? as usize;
+                handle.yield_value(len-4).await;
+
+                let (ty, tag) = {
+                    // SAFETY: this is inside a running coro so the outer code is unable to take a
+                    //         reference to buf
+                    let bytes = unsafe { buf.as_inner_mut() };
+                    let ty = from_le_bytes!(u8, &bytes);
+                    let tag = from_le_bytes!(u16, &bytes[1..]);
+                    bytes.rotate_left(3);
+
+                    (ty, tag)
+                };
 
                 let content = match MessageType(ty) {
                     $(
                         MessageType::$message_variant => $enum_ty::$enum_variant {
-                            $($field: <$ty>::read_from(&mut cur)?),*
+                            $($field: read_from_exact_sized_buffer::<$ty>(buf)?),*
                         },
                     )+
 
@@ -544,6 +607,30 @@ macro_rules! impl_message_format {
             }
         }
     };
+}
+
+/// Helper for reading a single [NineP] value from a [SharedBuf] that has already been filled with
+/// the correct number of bytes for parsing the entire message without any further IO.
+fn read_from_exact_sized_buffer<T: NineP>(buf: &SharedBuf) -> io::Result<T> {
+    let mut coro = T::read_9p_coro(buf);
+    let mut prev_n = 0;
+
+    loop {
+        coro = {
+            let state = coro.resume();
+            // SAFETY: coro is currently suspended and unable to take a reference to buf
+            let mut_buf = unsafe { buf.as_inner_mut() };
+            mut_buf.rotate_left(prev_n);
+
+            match state {
+                CoroState::Complete(res) => return res,
+                CoroState::Pending(c, n) => {
+                    prev_n = n;
+                    c.send(())
+                }
+            }
+        };
+    }
 }
 
 /// The Plan 9 File Protocol, 9P, is used for messages between clients and servers. A client
@@ -890,13 +977,17 @@ mod tests {
     #[test]
     fn uint_decode() {
         let buf: Vec<u8> = vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
+        let sb = SharedBuf::new();
 
-        assert_eq!(0x01, u8::read_from(&mut buf.as_slice()).unwrap());
-        assert_eq!(0x2301, u16::read_from(&mut buf.as_slice()).unwrap());
-        assert_eq!(0x67452301, u32::read_from(&mut buf.as_slice()).unwrap());
+        assert_eq!(0x01, u8::read_from(&sb, &mut buf.as_slice()).unwrap());
+        assert_eq!(0x2301, u16::read_from(&sb, &mut buf.as_slice()).unwrap());
+        assert_eq!(
+            0x67452301,
+            u32::read_from(&sb, &mut buf.as_slice()).unwrap()
+        );
         assert_eq!(
             0xefcdab8967452301,
-            u64::read_from(&mut buf.as_slice()).unwrap()
+            u64::read_from(&sb, &mut buf.as_slice()).unwrap()
         );
     }
 
@@ -925,6 +1016,7 @@ mod tests {
         RawStat,
         Clunk,
         Walk,
+        Rwalk,
     }
 
     // simple_test_case doesn't handle generic args for parameterised
@@ -935,7 +1027,8 @@ mod tests {
         T: NineP + PartialEq + fmt::Debug,
     {
         let buf = t1.write_9p_bytes().unwrap();
-        let t2 = T::read_from(&mut buf.as_slice()).unwrap();
+        let sb = SharedBuf::new();
+        let t2 = T::read_from(&sb, &mut buf.as_slice()).unwrap();
 
         assert_eq!(t1, t2);
     }
@@ -951,6 +1044,7 @@ mod tests {
     #[test_case(F9::RawStat; "raw stat")]
     #[test_case(F9::Clunk; "clunk")]
     #[test_case(F9::Walk; "walk")]
+    #[test_case(F9::Rwalk; "rwalk")]
     #[test]
     fn round_trip_is_fine(data: F9) {
         match data {
@@ -989,6 +1083,23 @@ mod tests {
                     fid: 0,
                     new_fid: 2,
                     wnames: vec!["bar".to_string()],
+                },
+            }),
+            F9::Rwalk => round_trip_inner(Rmessage {
+                tag: 0,
+                content: Rdata::Walk {
+                    wqids: vec![
+                        Qid {
+                            ty: 0,
+                            version: 1,
+                            path: 2,
+                        },
+                        Qid {
+                            ty: 3,
+                            version: 4,
+                            path: 5,
+                        },
+                    ],
                 },
             }),
         }

--- a/crates/ninep/src/sansio/protocol.rs
+++ b/crates/ninep/src/sansio/protocol.rs
@@ -11,51 +11,6 @@ use std::{
     mem::size_of,
 };
 
-/// A shared byte buffer that can be accessed inside of 9p parsing functions.
-///
-/// This is wildly unsafe as a general purpose API and only makes any sort of sense as a
-/// communication mechanism between a running `Coro` and the code that is driving it as we can
-/// guarantee that both are never executing at the same time.
-#[derive(Debug)]
-pub struct SharedBuf(UnsafeCell<Vec<u8>>);
-
-/// SAFETY: requres that the safety guarantees for as_inner_mut are upheld
-unsafe impl Send for SharedBuf {}
-/// SAFETY: requres that the safety guarantees for as_inner_mut are upheld
-unsafe impl Sync for SharedBuf {}
-
-impl Default for SharedBuf {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SharedBuf {
-    /// Construct a new SharedBuf
-    pub fn new() -> Self {
-        Self(UnsafeCell::new(Vec::new()))
-    }
-
-    /// Get an exclusive reference to the inner buffer from a shared reference to the outer
-    /// [SharedBuf].
-    ///
-    /// # Safety
-    /// The caller must guarantee that no concurrent access to the inner buffer takes place while
-    /// this exclusive reference is held. In practice this is only safe to do as part of the IO
-    /// loop that is parsing a 9p message using a `Coro` that this [SharedBuf] is shared with.
-    #[allow(clippy::mut_from_ref)]
-    pub(crate) unsafe fn as_inner_mut(&self) -> &mut Vec<u8> {
-        // SAFETY: the caller must guarantee that no concurrent access takes place
-        unsafe { &mut *self.0.get() }
-    }
-
-    /// Get a shared reference to the inner buffer.
-    pub(crate) fn as_slice(&self) -> &[u8] {
-        // SAFETY: the caller must guarantee that no concurrent access takes place
-        unsafe { &*self.0.get() }
-    }
-}
-
 /// The size of variable length data is denoted using a u16 so anything longer
 /// than u16::MAX is not something we can handle.
 pub const MAX_SIZE_FIELD: usize = u16::MAX as usize;
@@ -84,6 +39,88 @@ impl fmt::Display for WriteError {
                 "data field too long: max={MAX_DATA_SIZE_FIELD} len={n_bytes}"
             ),
             Self::FieldLength(len) => write!(f, "string too long: max={MAX_SIZE_FIELD} len={len}"),
+        }
+    }
+}
+
+/// A shared byte buffer that can be accessed inside of 9p parsing functions.
+///
+/// The internals of this API can only be accessed from within this crate as in practice this is
+/// only safe to do as part of the IO loop that is parsing a 9p message using a [Coro] that this
+/// [SharedBuf] is shared with.
+#[derive(Debug)]
+pub struct SharedBuf(UnsafeCell<SharedBufInner>);
+struct SharedBufInner {
+    pos: usize,
+    buf: Vec<u8>,
+}
+
+/// SAFETY: requres that the safety guarantees for as_inner_mut and as_slice_to are upheld
+unsafe impl Send for SharedBuf {}
+/// SAFETY: requres that the safety guarantees for as_inner_mut and as_slice_to are upheld
+unsafe impl Sync for SharedBuf {}
+
+impl Default for SharedBuf {
+    fn default() -> Self {
+        Self(UnsafeCell::new(SharedBufInner {
+            pos: 0,
+            buf: Vec::new(),
+        }))
+    }
+}
+
+impl SharedBuf {
+    /// Get an exclusive reference to the inner buffer from a shared reference to the outer
+    /// [SharedBuf], resetting `pos` to the start of the buffer.
+    ///
+    /// # Safety
+    /// The caller must guarantee that no concurrent access to the inner buffer takes place while
+    /// this exclusive reference is held.
+    #[allow(clippy::mut_from_ref)]
+    pub(crate) unsafe fn as_inner_mut(&self) -> &mut Vec<u8> {
+        // SAFETY: the caller must guarantee that no concurrent access takes place
+        unsafe {
+            let inner = &mut *self.0.get();
+            inner.pos = 0;
+
+            &mut inner.buf
+        }
+    }
+
+    /// Get a shared reference to the inner buffer, updating `pos` to account for the bytes read
+    /// out of the buffer.
+    ///
+    /// # Panics
+    /// This method will panic if `end` is out of bounds for the remaining data in the buffer.
+    ///
+    /// # Safety
+    /// The caller must guarantee that no concurrent access to the inner buffer takes place while
+    /// this reference is held.
+    pub(crate) unsafe fn as_slice_to(&self, end: usize) -> &[u8] {
+        // SAFETY: the caller must guarantee that no concurrent access takes place
+        unsafe {
+            let inner = &mut *self.0.get();
+            let prev = inner.pos;
+            inner.pos += end;
+
+            &inner.buf[prev..inner.pos]
+        }
+    }
+
+    /// Helper for reading a single [NineP] value from a [SharedBuf] that has already been filled with
+    /// the correct number of bytes for parsing the entire message without any further IO.
+    ///
+    /// # Safety
+    /// The caller must guarantee that no concurrent access to the inner buffer takes place while
+    /// this reference is held.
+    unsafe fn parse_from_buffer<T: NineP>(&self) -> io::Result<T> {
+        let mut coro = T::read_9p_coro(self);
+
+        loop {
+            coro = match coro.resume() {
+                CoroState::Pending(c, _) => c.send(()),
+                CoroState::Complete(res) => return res,
+            };
         }
     }
 }
@@ -149,8 +186,10 @@ macro_rules! impl_u {
                 }
 
                 async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<$ty> {
-                    handle.yield_value(size_of::<$ty>()).await;
-                    Ok(from_le_bytes!($ty, buf.as_slice()))
+                    let n = size_of::<$ty>();
+                    handle.yield_value(n).await;
+
+                    Ok(from_le_bytes!($ty, buf.as_slice_to(n)))
                 }
             }
         )+
@@ -190,8 +229,10 @@ impl NineP for String {
         let len = u16::read_9p(buf, handle).await? as usize;
         handle.yield_value(len).await;
 
-        String::from_utf8(buf.as_slice()[..len].to_vec())
-            .map_err(|e| io::Error::new(ErrorKind::InvalidData, e.to_string()))
+        // SAFETY: this is the only read we are doing and it matches the data we requested
+        let data = unsafe { buf.as_slice_to(len).to_vec() };
+
+        String::from_utf8(data).map_err(|e| io::Error::new(ErrorKind::InvalidData, e.to_string()))
     }
 }
 
@@ -268,7 +309,7 @@ impl TryFrom<Data> for Vec<RawStat> {
         let mut buf = Vec::new();
         let mut bytes = bytes.as_slice();
         let n = size_of::<RawStat>();
-        let sb = SharedBuf::new();
+        let sb = SharedBuf::default();
 
         loop {
             match RawStat::read_from(&sb, &mut bytes) {
@@ -312,7 +353,10 @@ impl NineP for Data {
         }
         handle.yield_value(len).await;
 
-        Ok(Data(buf.as_slice()[..len].to_vec()))
+        // SAFETY: this is the only read we are doing and it matches the data we requested
+        let data = unsafe { buf.as_slice_to(len).to_vec() };
+
+        Ok(Data(data))
     }
 }
 
@@ -376,12 +420,14 @@ impl NineP for RawStat {
     async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
         // Request the fixed sized data before the strings in one block up front
         handle.yield_value(41).await;
-        let bytes = buf.as_slice();
+
+        // SAFETY: this is the only read we are doing and it matches the data we requested
+        let bytes = unsafe { buf.as_slice_to(41) };
 
         let size = from_le_bytes!(u16, bytes);
         let ty = from_le_bytes!(u16, &bytes[2..]);
         let dev = from_le_bytes!(u32, &bytes[4..]);
-        let qid = Qid::read_from(buf, &mut &bytes[8..])?;
+        let qid = Qid::from_bytes(&bytes[8..]);
         let mode = from_le_bytes!(u32, &bytes[21..]);
         let atime = from_le_bytes!(u32, &bytes[25..]);
         let mtime = from_le_bytes!(u32, &bytes[29..]);
@@ -408,65 +454,47 @@ impl NineP for RawStat {
     }
 }
 
-/// Helper for defining a struct that implements Format9p by just serialising their
-/// fields directly without a size field.
-macro_rules! impl_message_datatype {
-    (
-        $reader:ident;
-        $(#[$docs:meta])+
-        struct $struct:ident {
-            $(
-                $(#[$field_docs:meta])*
-                $field:ident: $ty:ty,
-            )*
-        }
-    ) => {
-        $(#[$docs])+
-        #[derive(Debug, Clone, PartialEq, Eq)]
-        pub struct $struct {
-            $(
-                $(#[$field_docs])*
-                pub $field: $ty,
-            )*
-        }
-
-        impl NineP for $struct {
-            fn n_bytes(&self) -> usize {
-                #[allow(unused_mut)]
-                let mut n = 0;
-                $(n += self.$field.n_bytes();)*
-                n
-            }
-
-            fn write_bytes(&self, mut buf: &mut [u8]) -> Result<(), WriteError> {
-                write_fields!(buf, self, $($field),*)
-            }
-
-            async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
-                $(let $field = <$ty>::read_9p(buf, handle).await?;)*
-                Ok($struct { $($field),* })
-            }
-        }
-    };
+/// A qid represents the server's unique identification for the file being accessed: two files
+/// on the same server hierarchy are the same if and only if their qids are the same.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Qid {
+    /// qid.type[1] the type of the file (directory, etc.), represented as a bit vector
+    /// corresponding to the high 8 bits of the file's mode word.
+    pub ty: u8,
+    /// qid.vers[4]  version number for given path
+    pub version: u32,
+    /// qid.path[8]  the file server's unique identification for the file
+    pub path: u64,
 }
 
-impl_message_datatype!(
-    QidReader;
+impl Qid {
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Self {
+        let ty = from_le_bytes!(u8, &bytes);
+        let version = from_le_bytes!(u32, &bytes[1..]);
+        let path = from_le_bytes!(u64, &bytes[5..]);
 
-    /// A qid represents the server's unique identification for the file being accessed: two files
-    /// on the same server hierarchy are the same if and only if their qids are the same.
-    #[derive(Copy)]
-    struct Qid {
-        /// qid.type[1]
-        /// the type of the file (directory, etc.), repre- sented as a bit vector corresponding to the
-        /// high 8 bits of the file's mode word.
-        ty: u8,
-        /// qid.vers[4]  version number for given path
-        version: u32,
-        /// qid.path[8]  the file server's unique identification for the file
-        path: u64,
+        Self { ty, version, path }
     }
-);
+}
+
+impl NineP for Qid {
+    fn n_bytes(&self) -> usize {
+        1 + 4 + 8
+    }
+
+    fn write_bytes(&self, mut buf: &mut [u8]) -> Result<(), WriteError> {
+        write_fields!(buf, self, ty, version, path)
+    }
+
+    async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+        let ty = u8::read_9p(buf, handle).await?;
+        let version = u32::read_9p(buf, handle).await?;
+        let path = u64::read_9p(buf, handle).await?;
+
+        Ok(Qid { ty, version, path })
+    }
+}
 
 /// Taken from the enum in fcall.h in the plan9 source.
 ///   https://github.com/9fans/plan9port/blob/master/include/fcall.h#L80
@@ -574,63 +602,36 @@ macro_rules! impl_message_format {
                 Ok(())
             }
 
-            #[allow(unused_assignments)]
+            #[allow(unused_assignments, unused_unsafe)]
             async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
                 let len = u32::read_9p(buf, handle).await? as usize;
                 handle.yield_value(len-4).await;
 
-                let (ty, tag) = {
-                    // SAFETY: this is inside a running coro so the outer code is unable to take a
-                    //         reference to buf
-                    let bytes = unsafe { buf.as_inner_mut() };
+                // SAFETY: this is inside a running coro so the outer code is unable to take a
+                //         reference to buf while we update `pos` and read from the inner buffer
+                unsafe {
+                    let bytes = buf.as_slice_to(3);
                     let ty = from_le_bytes!(u8, &bytes);
                     let tag = from_le_bytes!(u16, &bytes[1..]);
-                    bytes.rotate_left(3);
 
-                    (ty, tag)
-                };
+                    let content = match MessageType(ty) {
+                        $(
+                            MessageType::$message_variant => $enum_ty::$enum_variant {
+                                $($field: buf.parse_from_buffer::<$ty>()?),*
+                            },
+                        )+
 
-                let content = match MessageType(ty) {
-                    $(
-                        MessageType::$message_variant => $enum_ty::$enum_variant {
-                            $($field: read_from_exact_sized_buffer::<$ty>(buf)?),*
-                        },
-                    )+
+                        MessageType(ty) => return Err(io::Error::new(
+                            ErrorKind::InvalidData,
+                            format!($err, ty),
+                        )),
+                    };
 
-                    MessageType(ty) => return Err(io::Error::new(
-                        ErrorKind::InvalidData,
-                        format!($err, ty),
-                    )),
-                };
-
-                Ok($message_ty { tag, content })
+                    Ok($message_ty { tag, content })
+                }
             }
         }
     };
-}
-
-/// Helper for reading a single [NineP] value from a [SharedBuf] that has already been filled with
-/// the correct number of bytes for parsing the entire message without any further IO.
-fn read_from_exact_sized_buffer<T: NineP>(buf: &SharedBuf) -> io::Result<T> {
-    let mut coro = T::read_9p_coro(buf);
-    let mut prev_n = 0;
-
-    loop {
-        coro = {
-            let state = coro.resume();
-            // SAFETY: coro is currently suspended and unable to take a reference to buf
-            let mut_buf = unsafe { buf.as_inner_mut() };
-            mut_buf.rotate_left(prev_n);
-
-            match state {
-                CoroState::Complete(res) => return res,
-                CoroState::Pending(c, n) => {
-                    prev_n = n;
-                    c.send(())
-                }
-            }
-        };
-    }
 }
 
 /// The Plan 9 File Protocol, 9P, is used for messages between clients and servers. A client
@@ -977,7 +978,7 @@ mod tests {
     #[test]
     fn uint_decode() {
         let buf: Vec<u8> = vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
-        let sb = SharedBuf::new();
+        let sb = SharedBuf::default();
 
         assert_eq!(0x01, u8::read_from(&sb, &mut buf.as_slice()).unwrap());
         assert_eq!(0x2301, u16::read_from(&sb, &mut buf.as_slice()).unwrap());
@@ -1027,7 +1028,7 @@ mod tests {
         T: NineP + PartialEq + fmt::Debug,
     {
         let buf = t1.write_9p_bytes().unwrap();
-        let sb = SharedBuf::new();
+        let sb = SharedBuf::default();
         let t2 = T::read_from(&sb, &mut buf.as_slice()).unwrap();
 
         assert_eq!(t1, t2);

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -109,7 +109,7 @@ where
             self.s.clone(),
             self.qids.clone(),
             stream,
-            SharedBuf::new(),
+            SharedBuf::default(),
         );
         self.next_client_id += 1;
 
@@ -461,22 +461,19 @@ where
         Either::L((tag, resp))
     }
 
-    pub(crate) fn into_attached(self, ty: Attached) -> Session<Attached, S, U> {
-        let Self {
-            s,
-            stream,
-            session_state:
-                SessionState {
-                    client_id,
-                    msize,
-                    roots,
-                    qids,
-                    ..
-                },
-            buf,
-        } = self;
-
-        Session::new_attached(client_id, ty, msize, roots, s, qids, stream, buf)
+    pub(crate) fn into_attached(self, state: Attached) -> Session<Attached, S, U> {
+        Session {
+            s: self.s,
+            stream: self.stream,
+            session_state: SessionState {
+                client_id: self.session_state.client_id,
+                state,
+                msize: self.session_state.msize,
+                roots: self.session_state.roots,
+                qids: self.session_state.qids,
+            },
+            buf: self.buf,
+        }
     }
 
     /// The attach message serves as a fresh introduction from a user on the client machine to the
@@ -508,35 +505,5 @@ where
         let aqid = self.qid(root_qid).expect("to have root qid");
 
         Ok((st, aqid))
-    }
-}
-
-impl<S, U> Session<Attached, S, U>
-where
-    S: Send,
-{
-    #[allow(clippy::too_many_arguments)]
-    fn new_attached(
-        client_id: ClientId,
-        state: Attached,
-        msize: u32,
-        roots: BTreeMap<String, u64>,
-        s: Arc<S>,
-        qids: BTreeMap<u64, FileMeta>,
-        stream: U,
-        buf: SharedBuf,
-    ) -> Self {
-        Self {
-            s,
-            stream,
-            session_state: SessionState {
-                client_id,
-                state,
-                msize,
-                roots,
-                qids,
-            },
-            buf,
-        }
     }
 }

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -1,7 +1,9 @@
 //! Traits and structs for implementing a 9p fileserver
 use crate::{
     fs::{FileMeta, FileType, Stat, QID_ROOT},
-    sansio::protocol::{Data, NineP, Qid, RawStat, Rdata, Tdata, Tmessage, MAX_DATA_LEN},
+    sansio::protocol::{
+        Data, NineP, Qid, RawStat, Rdata, SharedBuf, Tdata, Tmessage, MAX_DATA_LEN,
+    },
     Result,
 };
 use simple_coro::{Coro, Handle, ReadyCoro};
@@ -107,6 +109,7 @@ where
             self.s.clone(),
             self.qids.clone(),
             stream,
+            SharedBuf::new(),
         );
         self.next_client_id += 1;
 
@@ -295,6 +298,7 @@ where
     pub(crate) s: Arc<S>,
     pub(crate) stream: U,
     pub(crate) session_state: SessionState<T>,
+    pub(crate) buf: SharedBuf,
 }
 
 impl<T, S, U> Deref for Session<T, S, U>
@@ -397,6 +401,7 @@ where
         s: Arc<S>,
         qids: BTreeMap<u64, FileMeta>,
         stream: U,
+        buf: SharedBuf,
     ) -> Self {
         Self {
             s,
@@ -408,6 +413,7 @@ where
                 roots,
                 qids,
             },
+            buf,
         }
     }
 
@@ -467,9 +473,10 @@ where
                     qids,
                     ..
                 },
+            buf,
         } = self;
 
-        Session::new_attached(client_id, ty, msize, roots, s, qids, stream)
+        Session::new_attached(client_id, ty, msize, roots, s, qids, stream, buf)
     }
 
     /// The attach message serves as a fresh introduction from a user on the client machine to the
@@ -508,6 +515,7 @@ impl<S, U> Session<Attached, S, U>
 where
     S: Send,
 {
+    #[allow(clippy::too_many_arguments)]
     fn new_attached(
         client_id: ClientId,
         state: Attached,
@@ -516,6 +524,7 @@ where
         s: Arc<S>,
         qids: BTreeMap<u64, FileMeta>,
         stream: U,
+        buf: SharedBuf,
     ) -> Self {
         Self {
             s,
@@ -527,6 +536,7 @@ where
                 roots,
                 qids,
             },
+            buf,
         }
     }
 }

--- a/crates/ninep/src/sync/client.rs
+++ b/crates/ninep/src/sync/client.rs
@@ -3,7 +3,7 @@ use crate::{
     fs::{Mode, Perm, Stat},
     sansio::{
         client::{err, State, MSIZE},
-        protocol::{Rdata, Rmessage, Tdata, Tmessage},
+        protocol::{Rdata, Rmessage, SharedBuf, Tdata, Tmessage},
     },
     sync::{SyncNineP, SyncStream},
 };
@@ -25,6 +25,7 @@ use std::{
 pub struct Client<S> {
     state: Arc<Mutex<State>>,
     stream: Arc<Mutex<S>>,
+    buf: SharedBuf,
 }
 
 impl<S> Clone for Client<S> {
@@ -32,6 +33,7 @@ impl<S> Clone for Client<S> {
         Self {
             state: Arc::clone(&self.state),
             stream: Arc::clone(&self.stream),
+            buf: SharedBuf::new(),
         }
     }
 }
@@ -45,6 +47,7 @@ impl<S> Client<S> {
                 next_fid: 1,
             })),
             stream: Arc::new(Mutex::new(stream)),
+            buf: SharedBuf::new(),
         }
     }
 
@@ -130,7 +133,7 @@ macro_rules! run_9p_coro {
                     let mut stream = $self.stream();
                     t.write_to(&mut *stream)?;
 
-                    match Rmessage::read_from(&mut *stream)? {
+                    match Rmessage::read_from(&$self.buf, &mut *stream)? {
                         Rmessage {
                             content: Rdata::Error { ename },
                             ..
@@ -151,7 +154,7 @@ where
         let mut stream = self.stream();
         Tmessage { tag, content }.write_to(&mut *stream)?;
 
-        match Rmessage::read_from(&mut *stream)? {
+        match Rmessage::read_from(&self.buf, &mut *stream)? {
             Rmessage {
                 content: Rdata::Error { ename },
                 ..

--- a/crates/ninep/src/sync/client.rs
+++ b/crates/ninep/src/sync/client.rs
@@ -33,7 +33,7 @@ impl<S> Clone for Client<S> {
         Self {
             state: Arc::clone(&self.state),
             stream: Arc::clone(&self.stream),
-            buf: SharedBuf::new(),
+            buf: SharedBuf::default(),
         }
     }
 }
@@ -47,7 +47,7 @@ impl<S> Client<S> {
                 next_fid: 1,
             })),
             stream: Arc::new(Mutex::new(stream)),
-            buf: SharedBuf::new(),
+            buf: SharedBuf::default(),
         }
     }
 

--- a/crates/ninep/src/sync/mod.rs
+++ b/crates/ninep/src/sync/mod.rs
@@ -1,6 +1,9 @@
 //! A synchronous implementation of 9p Servers and Clients
-use crate::{sansio::protocol::NineP, Result};
-use simple_coro::{Coro, CoroState};
+use crate::{
+    sansio::protocol::{NineP, SharedBuf},
+    Result,
+};
+use simple_coro::CoroState;
 use std::{
     io::{self, Read, Write},
     net::TcpStream,
@@ -22,14 +25,16 @@ pub trait SyncNineP: NineP {
     }
 
     /// Decode self from 9p protocol bytes coming from the given [SyncStream].
-    fn read_from<R: Read>(r: &mut R) -> io::Result<Self> {
-        let mut coro = Coro::from(Self::read_9p);
+    fn read_from<R: Read>(buf: &SharedBuf, r: &mut R) -> io::Result<Self> {
+        let mut coro = Self::read_9p_coro(buf);
         loop {
             coro = match coro.resume() {
                 CoroState::Pending(c, n) => {
-                    let mut buf = vec![0; n];
-                    r.read_exact(&mut buf)?;
-                    c.send(buf)
+                    // SAFETY: coro is currently suspended and unable to take a reference to buf
+                    let mut_buf = unsafe { buf.as_inner_mut() };
+                    mut_buf.resize(n, 0);
+                    r.read_exact(mut_buf)?;
+                    c.send(())
                 }
 
                 CoroState::Complete(res) => return res,

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -210,7 +210,7 @@ where
 {
     fn handle_connection(mut self) {
         loop {
-            let t = match Tmessage::read_from(&mut self.stream) {
+            let t = match Tmessage::read_from(&self.buf, &mut self.stream) {
                 Ok(t) => t,
                 Err(_) => return,
             };
@@ -243,7 +243,7 @@ where
         use Tdata::*;
 
         loop {
-            let t = match Tmessage::read_from(&mut self.stream) {
+            let t = match Tmessage::read_from(&self.buf, &mut self.stream) {
                 Ok(t) => t,
                 Err(_) => return self.clunk_and_clear(),
             };

--- a/crates/ninep/src/tokio/client.rs
+++ b/crates/ninep/src/tokio/client.rs
@@ -30,7 +30,7 @@ impl<S> Clone for Client<S> {
         Self {
             state: Arc::clone(&self.state),
             stream: Arc::clone(&self.stream),
-            buf: SharedBuf::new(),
+            buf: SharedBuf::default(),
         }
     }
 }
@@ -44,7 +44,7 @@ impl<S> Client<S> {
                 next_fid: 1,
             })),
             stream: Arc::new(Mutex::new(stream)),
-            buf: SharedBuf::new(),
+            buf: SharedBuf::default(),
         }
     }
 }

--- a/crates/ninep/src/tokio/client.rs
+++ b/crates/ninep/src/tokio/client.rs
@@ -3,7 +3,7 @@ use crate::{
     fs::{Mode, Perm, Stat},
     sansio::{
         client::{err, State, MSIZE},
-        protocol::{Rdata, Rmessage, Tdata, Tmessage},
+        protocol::{Rdata, Rmessage, SharedBuf, Tdata, Tmessage},
     },
     tokio::{AsyncNineP, AsyncStream},
 };
@@ -22,6 +22,7 @@ use tokio::{
 pub struct Client<S> {
     state: Arc<Mutex<State>>,
     stream: Arc<Mutex<S>>,
+    buf: SharedBuf,
 }
 
 impl<S> Clone for Client<S> {
@@ -29,6 +30,7 @@ impl<S> Clone for Client<S> {
         Self {
             state: Arc::clone(&self.state),
             stream: Arc::clone(&self.stream),
+            buf: SharedBuf::new(),
         }
     }
 }
@@ -42,6 +44,7 @@ impl<S> Client<S> {
                 next_fid: 1,
             })),
             stream: Arc::new(Mutex::new(stream)),
+            buf: SharedBuf::new(),
         }
     }
 }
@@ -116,7 +119,7 @@ macro_rules! run_9p_coro {
                         let mut stream = $self.stream.lock().await;
                         t.write_to(&mut *stream).await?;
 
-                        match Rmessage::read_from(&mut *stream).await? {
+                        match Rmessage::read_from(&$self.buf, &mut *stream).await? {
                             Rmessage {
                                 content: Rdata::Error { ename },
                                 ..
@@ -138,7 +141,7 @@ where
         let mut stream = self.stream.lock().await;
         Tmessage { tag, content }.write_to(&mut *stream).await?;
 
-        match Rmessage::read_from(&mut *stream).await? {
+        match Rmessage::read_from(&self.buf, &mut *stream).await? {
             Rmessage {
                 content: Rdata::Error { ename },
                 ..

--- a/crates/ninep/src/tokio/mod.rs
+++ b/crates/ninep/src/tokio/mod.rs
@@ -1,9 +1,9 @@
 //! Tokio based asynchronous implementation of 9p Servers and Clients
 use crate::{
-    sansio::protocol::{NineP, Rdata, Rmessage},
+    sansio::protocol::{NineP, Rdata, Rmessage, SharedBuf},
     Result,
 };
-use simple_coro::{Coro, CoroState};
+use simple_coro::CoroState;
 use std::{future::Future, io, marker::Unpin};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
@@ -24,11 +24,11 @@ pub trait AsyncNineP: NineP + Send + Sync {
     }
 
     /// Decode self from 9p protocol bytes coming from the given [SyncStream].
-    fn read_from<R>(r: &mut R) -> impl Future<Output = io::Result<Self>> + Send
+    fn read_from<R>(buf: &SharedBuf, r: &mut R) -> impl Future<Output = io::Result<Self>> + Send
     where
         R: AsyncRead + Unpin + Send,
     {
-        read_from(r)
+        read_from(buf, r)
     }
 }
 
@@ -51,18 +51,20 @@ where
 }
 
 #[inline(always)]
-async fn read_from<T, R>(r: &mut R) -> io::Result<T>
+async fn read_from<T, R>(buf: &SharedBuf, r: &mut R) -> io::Result<T>
 where
     T: NineP + Send,
     R: AsyncRead + Unpin + Send,
 {
-    let mut coro = Coro::from(T::read_9p);
+    let mut coro = T::read_9p_coro(buf);
     loop {
         coro = match coro.resume() {
             CoroState::Pending(c, n) => {
-                let mut buf = vec![0; n];
-                r.read_exact(&mut buf).await?;
-                c.send(buf)
+                // SAFETY: coro is currently suspended and unable to take a reference to buf
+                let mut_buf = unsafe { buf.as_inner_mut() };
+                mut_buf.resize(n, 0);
+                r.read_exact(mut_buf).await?;
+                c.send(())
             }
 
             CoroState::Complete(res) => return res,

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -240,7 +240,7 @@ where
 {
     async fn handle_connection_async(mut self) {
         loop {
-            let t = match Tmessage::read_from(&mut self.stream).await {
+            let t = match Tmessage::read_from(&self.buf, &mut self.stream).await {
                 Ok(t) => t,
                 Err(_) => return,
             };
@@ -282,7 +282,7 @@ where
                         .await;
                     continue;
                 },
-                res = Tmessage::read_from(&mut self.stream) => match res {
+                res = Tmessage::read_from(&self.buf, &mut self.stream) => match res {
                     Ok(t) => t,
                     Err(_) => return self.clunk_and_clear_async().await,
                 },


### PR DESCRIPTION
Making use of a shared mutable buffer between 9p parsing Coros and the logic running them in the sans-io layer so that we only need to allocate and re-use a single buffer for parsing messages rather than allocating a new Vec for each read.

The resulting public API is a little odd as it means that consumers of the crate will not be able to implement their own IO wrappers unless the methods on `SharedBuf` are made public. Until there is a use case for that however, I am planning on leaving things this way so that consumers of `ninep` aren't able to footgun with the unsafe API that `SharedBuf` exposes.