### PR TITLE
feat: #77 supporting renaming of open buffers

### DIFF
--- a/data/bin/Slide
+++ b/data/bin/Slide
@@ -16,7 +16,7 @@
 # > Example index content:
 #   intro
 #   body
-#   conclusion 
+#   conclusion
 
 . "$HOME/.ad/lib/ad.sh"
 
@@ -27,8 +27,7 @@ f="$(basename "$fname")"
 d="$(dirname "$fname")"
 
 [ ! -f "$d/index" ] && adError "not in a slideshow directory"
-index="$(cat "$d/index")"
-toLoad="$(cat "$d/index" | head -n1)"
+toLoad="$(head -n1 "$d/index")"
 
 case "$1" in
   next)
@@ -46,11 +45,8 @@ case "$1" in
     ;;
 esac
 
-# TODO: being able to replace the current buffer with a new one
-#       rather than opening new buffers each time would be nice
-adCtl "open $d/$toLoad"
+echo "$d/$toLoad" | bufWrite "$bufid" filename
 adCtl "Get"
 adEdit "0 i/[PrevSlide] [NextSlide]\n\n/"
-id="$(currentBufferId)"
-curToBof "$id"
-markClean "$id"
+curToBof "$bufid"
+markClean "$bufid"

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -186,7 +186,7 @@ impl Buffer {
         Ok(b)
     }
 
-    /// Clear any existing tree-sitter state and then attempt to detect and set the state 
+    /// Clear any existing tree-sitter state and then attempt to detect and set the state
     /// based on this buffer's BufferKind
     fn try_set_ts_state(&mut self) {
         self.ts_state = None;

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -181,20 +181,27 @@ impl Buffer {
             ts_state: None,
         };
 
+        b.try_set_ts_state();
+
+        Ok(b)
+    }
+
+    /// Clear any existing tree-sitter state and then attempt to detect and set the state 
+    /// based on this buffer's BufferKind
+    fn try_set_ts_state(&mut self) {
+        self.ts_state = None;
         let cfg = config_handle!();
-        if let Some(lang) = cfg.ts_lang_for_buffer(&b) {
+        if let Some(lang) = cfg.ts_lang_for_buffer(self) {
             match TsState::try_new(
                 lang,
                 &cfg.tree_sitter.parser_dir,
                 &cfg.tree_sitter.syntax_query_dir,
-                &b.txt,
+                &self.txt,
             ) {
-                Ok(state) => b.ts_state = Some(state),
+                Ok(state) => self.ts_state = Some(state),
                 Err(msg) => error!("unable to initialise tree-sitter: {msg}"),
             }
         }
-
-        Ok(b)
     }
 
     pub(crate) fn state_changed_on_disk(&self) -> Result<bool, String> {
@@ -213,6 +220,31 @@ impl Buffer {
             Err(e) if e.kind() == ErrorKind::NotFound => Ok(false),
             Err(e) => Err(format!("Error checking file state: {e}")),
         }
+    }
+
+    /// Set this buffer's filename (an therefore kind) to the provided path.
+    /// -> This will also re-set / clear any tree-sitter state that is currently held
+    pub(crate) fn set_filename<P: AsRef<Path>>(&mut self, path: P) -> Option<ActionOutcome> {
+        let path = match path.as_ref().canonicalize() {
+            Ok(p) => p,
+            Err(e) if e.kind() == ErrorKind::NotFound => path.as_ref().to_path_buf(),
+            Err(e) => {
+                return Some(ActionOutcome::SetStatusMessage(format!(
+                    "invalid file path: {e}"
+                )))
+            }
+        };
+
+        let kind = if path.is_dir() {
+            BufferKind::Directory(path)
+        } else {
+            BufferKind::File(path)
+        };
+
+        self.kind = kind;
+        self.try_set_ts_state();
+
+        None
     }
 
     pub(crate) fn save_to_disk_at(&mut self, path: PathBuf, force: bool) -> String {
@@ -756,6 +788,7 @@ impl Buffer {
             Action::DotSet(t, count) => self.set_dot(t, count),
             Action::DotSetFromCoords { coords } => self.set_dot_from_coords(coords),
 
+            Action::RenameActiveBuffer { name } => return self.set_filename(name),
             Action::RawInput { i } => return self.handle_raw_input(i),
 
             _ => (),

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -107,6 +107,7 @@ pub enum Action {
     ReloadActiveBuffer,
     ReloadBuffer { id: usize },
     ReloadConfig,
+    RenameActiveBuffer { name: String },
     RunMode,
     SamMode,
     SaveBuffer { force: bool },

--- a/src/editor/built_in_commands.rs
+++ b/src/editor/built_in_commands.rs
@@ -102,6 +102,10 @@ pub fn built_in_commands() -> Vec<(Vec<&'static str>, &'static str)> {
             "reload the editor config file located at ~/.ad/config.toml",
         ),
         (
+            vec!["rename-buffer"],
+            "rename the active buffer so that subsequent file operations will apply to the new path"
+        ),
+        (
             vec!["set"],
             "set a config property ('set bg-color=#ebdbb2')",
         ),

--- a/src/editor/commands.rs
+++ b/src/editor/commands.rs
@@ -139,6 +139,10 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
             }
         }
 
+        "rename-buffer" => Ok(Single(RenameActiveBuffer {
+            name: args.to_string(),
+        })),
+
         "set" => Ok(Single(UpdateConfig {
             input: input.to_string(),
         })),

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -292,6 +292,10 @@ where
             ReadBufferXDot { id } => self.send_buffer_resp(id, tx, |b| b.xdot_contents()),
             ReadBufferBody { id } => self.send_buffer_resp(id, tx, |b| b.str_contents()),
 
+            SetBufferName { id, s } => self.handle_buffer_mutation(id, tx, s, |b, s| {
+                b.set_filename(s.trim());
+            }),
+
             SetBufferAddr { id, s } => self.handle_buffer_mutation(id, tx, s, |b, s| {
                 if let Ok(mut expr) = Addr::parse(&mut s.trim_end().chars().peekable()) {
                     b.dot = b.map_addr(&mut expr);

--- a/src/fsys/buffer.rs
+++ b/src/fsys/buffer.rs
@@ -246,7 +246,7 @@ impl BufferNodes {
             XADDR => Req::SetBufferXAddr { id, s },
             OUTPUT => Req::AppendOutput { id, s },
             EVENT => return send_event_to_editor(id, &s, &self.tx),
-            FILENAME => return Err(E_UNKNOWN_FILE.to_string()),
+            FILENAME => Req::SetBufferName { id, s },
             _ => return Err(E_UNKNOWN_FILE.to_string()),
         };
 

--- a/src/fsys/message.rs
+++ b/src/fsys/message.rs
@@ -59,6 +59,10 @@ pub enum Req {
     ReadBufferBody {
         id: usize,
     },
+    SetBufferName {
+        id: usize,
+        s: String,
+    },
     SetBufferDot {
         id: usize,
         s: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub const LOG_LEVEL_ENV_VAR: &str = "AD_LOG";
 
 pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub(crate) const UNNAMED_BUFFER: &str = "[No Name]";
-pub(crate) const MAX_NAME_LEN: usize = 40;
+pub(crate) const MAX_NAME_LEN: usize = 50;
 
 pub(crate) static ORIGINAL_TERMIOS: OnceLock<Termios> = OnceLock::new();
 


### PR DESCRIPTION
#83 was originally opened for this but it has been in a draft state for months and there were a couple of issues that we wanted to sort out before merging. The core of the change in this PR is the same as found there (thank you @izuzak!) with the following changes/additions:

  - buffer renaming is a method on `Buffer` so it can be reused
  - there is also a command (`rename-buffer`) for renaming a buffer from within ad itself
  - the tree-sitter state is cleared and re-initialised if that is appropriate for the new buffer type