### PR TITLE
Adding acme style tags #26

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,13 @@
 :: TODO
 
+- [ ] TAG SUPPORT
+  - Need to update cur_from_screen_coords to be aware of tags
+  - Need to update window size calculations to be aware of tags taking up screen space
+  - Tags also need to be truncated if there is insufficient screen space
+  - Exposing through fsys will mean having to have window state as well as buffer state
+  - Events need updating to say whether they came from buffers or tags
+
+
 -- Misc / Editor features --
 - [ ] split apart the Regex itself and a Matcher struct which is what needs to be mutable
       - The matcher can be reused if needed or used as a oneshot for the common case of

--- a/TODO
+++ b/TODO
@@ -1,5 +1,10 @@
 :: TODO
 
+
+// FIXME!!! This is where the different range semantics are
+// -> GapBuffer.slice(from, to)            is [from, to)
+//    but Dot::from_char_indices(from, to) is [from, to]
+
 - [ ] TAG SUPPORT
   - Need to update cur_from_screen_coords to be aware of tags
     >> current usage

--- a/TODO
+++ b/TODO
@@ -6,21 +6,9 @@
 //    but Dot::from_char_indices(from, to) is [from, to]
 
 - [ ] TAG SUPPORT
-  - Need to update cur_from_screen_coords to be aware of tags
-    >> current usage
-      * (set_focus=false) update mouse drag position
-      * (set_focus=false) mouse button release
-      * (set_focus=true)  handle_right_or_middle_click
-      * (set_focus=true)  set_dot_from_screen_coords
-        * only used inside of handle_mouse_event when handling a left click
-    >> So,
-      -> set_focus=false is used updating a held mouse drag (release logic is this as well)
-      -> set_focus=true is used when handling an initial click
-
-  - Need to update window size calculations to be aware of tags taking up screen space
-  - Tags also need to be truncated if there is insufficient screen space
-  - Exposing through fsys will mean having to have window state as well as buffer state
-  - Events need updating to say whether they came from buffers or tags
+  - [ ] Exposing through fsys will mean having to have window state as well as buffer state
+  - [ ] Load from tag seems to anchor at the first match in the buffer rather than searching
+        forward from the current buffer dot
 
 
 -- Misc / Editor features --

--- a/TODO
+++ b/TODO
@@ -7,9 +7,6 @@
 
 - [ ] TAG SUPPORT
   - [ ] Exposing through fsys will mean having to have window state as well as buffer state
-  - [ ] Load from tag seems to anchor at the first match in the buffer rather than searching
-        forward from the current buffer dot
-
 
 -- Misc / Editor features --
 - [ ] split apart the Regex itself and a Matcher struct which is what needs to be mutable

--- a/TODO
+++ b/TODO
@@ -2,6 +2,16 @@
 
 - [ ] TAG SUPPORT
   - Need to update cur_from_screen_coords to be aware of tags
+    >> current usage
+      * (set_focus=false) update mouse drag position
+      * (set_focus=false) mouse button release
+      * (set_focus=true)  handle_right_or_middle_click
+      * (set_focus=true)  set_dot_from_screen_coords
+        * only used inside of handle_mouse_event when handling a left click
+    >> So,
+      -> set_focus=false is used updating a held mouse drag (release logic is this as well)
+      -> set_focus=true is used when handling an initial click
+
   - Need to update window size calculations to be aware of tags taking up screen space
   - Tags also need to be truncated if there is insufficient screen space
   - Exposing through fsys will mean having to have window state as well as buffer state

--- a/src/buffer/buffers.rs
+++ b/src/buffer/buffers.rs
@@ -47,7 +47,7 @@ impl Buffers {
     #[cfg(test)]
     pub(crate) fn new_stubbed(ids: &[usize], tx_req: Sender<Req>) -> Self {
         Self {
-            next_id: ids.last().unwrap() + 1,
+            next_id: ids.last().copied().unwrap_or_default() + 1,
             inner: ZipList::try_from_iter(
                 ids.iter()
                     .map(|i| Buffer::new_virtual(*i, "".to_owned(), "".to_owned())),

--- a/src/buffer/buffers.rs
+++ b/src/buffer/buffers.rs
@@ -1,6 +1,7 @@
 use crate::{
-    buffer::{Buffer, BufferKind, Cur, SPLASH},
-    dot::TextObject,
+    buffer::{Buffer, BufferKind, Tag, SPLASH},
+    die,
+    dot::{Cur, TextObject},
     lsp::LspManagerHandle,
     ziplist,
     ziplist::{Position, ZipList},
@@ -159,7 +160,18 @@ impl Buffers {
     }
 
     /// Create a new tag buffer with a unique ID that is not tracked within the main buffer state
-    pub(crate) fn new_tag_buffer(&mut self) -> Buffer {
+    ///
+    /// This will panic if the given parent ID is not a known buffer.
+    pub(crate) fn new_tag_buffer(
+        &mut self,
+        initial_parent_id: BufferId,
+        tabstop: usize,
+        n_cols: usize,
+    ) -> Tag {
+        if !self.contains_bufid(initial_parent_id) {
+            die!("attempt to create tag for unknown buffer");
+        }
+
         // We need the tag IDs to be unique in order to distinguish them from our regular buffer
         // state but we also don't want to make use of the normal next_id counter as that would
         // result in disjoint buffer IDs for the user which is going to be confusing.
@@ -169,7 +181,10 @@ impl Buffers {
         let id = self.next_tag_id;
         self.next_tag_id -= 1;
 
-        Buffer::new_unnamed(id, "")
+        // checked the existence of the parent above
+        let parent = self.with_id(initial_parent_id).unwrap();
+
+        Tag::new(parent, id, tabstop, n_cols)
     }
 
     pub(crate) fn open_virtual(&mut self, name: String, content: String) -> BufferId {

--- a/src/buffer/buffers.rs
+++ b/src/buffer/buffers.rs
@@ -29,6 +29,7 @@ pub type BufferId = usize;
 #[derive(Debug)]
 pub struct Buffers {
     next_id: BufferId,
+    next_tag_id: BufferId,
     inner: ZipList<Buffer>,
     jump_list: JumpList,
     lsp_handle: Arc<LspManagerHandle>,
@@ -38,6 +39,7 @@ impl Buffers {
     pub fn new(lsp_handle: Arc<LspManagerHandle>) -> Self {
         Self {
             next_id: 1,
+            next_tag_id: usize::MAX,
             inner: ziplist![Buffer::new_unnamed(0, "")],
             jump_list: JumpList::default(),
             lsp_handle,
@@ -48,11 +50,9 @@ impl Buffers {
     pub(crate) fn new_stubbed(ids: &[usize], tx_req: Sender<Req>) -> Self {
         Self {
             next_id: ids.last().copied().unwrap_or_default() + 1,
-            inner: ZipList::try_from_iter(
-                ids.iter()
-                    .map(|i| Buffer::new_virtual(*i, "".to_owned(), "".to_owned())),
-            )
-            .unwrap(),
+            next_tag_id: usize::MAX,
+            inner: ZipList::try_from_iter(ids.iter().map(|i| Buffer::new_virtual(*i, "", "")))
+                .unwrap(),
             jump_list: JumpList::default(),
             lsp_handle: Arc::new(LspManagerHandle::new_stubbed(tx_req)),
         }
@@ -156,6 +156,20 @@ impl Buffers {
 
     fn push_buffer(&mut self, buf: Buffer) {
         self.inner.insert(buf);
+    }
+
+    /// Create a new tag buffer with a unique ID that is not tracked within the main buffer state
+    pub(crate) fn new_tag_buffer(&mut self) -> Buffer {
+        // We need the tag IDs to be unique in order to distinguish them from our regular buffer
+        // state but we also don't want to make use of the normal next_id counter as that would
+        // result in disjoint buffer IDs for the user which is going to be confusing.
+        //
+        // If this ever collides with self.next_id (or hits 0) we have a problem but the chances of
+        // actually hitting that are so low we don't bother to check for it.
+        let id = self.next_tag_id;
+        self.next_tag_id -= 1;
+
+        Buffer::new_unnamed(id, "")
     }
 
     pub(crate) fn open_virtual(&mut self, name: String, content: String) -> BufferId {

--- a/src/buffer/internal.rs
+++ b/src/buffer/internal.rs
@@ -427,6 +427,10 @@ impl GapBuffer {
         Slice::from_raw_offsets(from, to, self)
     }
 
+    pub fn as_slice(&self) -> Slice<'_> {
+        self.slice(0, self.len_chars())
+    }
+
     fn chars_in_raw_range(&self, raw_from: usize, raw_to: usize) -> usize {
         if raw_to <= self.gap_start || raw_from >= self.gap_end {
             count_chars(&self.data[raw_from..raw_to])

--- a/src/buffer/internal.rs
+++ b/src/buffer/internal.rs
@@ -229,6 +229,11 @@ impl GapBuffer {
         v
     }
 
+    /// Iterate over the characters of the buffer
+    pub fn chars(&self) -> Chars<'_> {
+        self.slice(0, self.n_chars).chars()
+    }
+
     /// Iterate over the lines of the buffer
     pub fn iter_lines(&self) -> impl Iterator<Item = Slice<'_>> {
         let mut line_idx = 0;

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -25,11 +25,13 @@ use tracing::{debug, error};
 mod buffers;
 mod edit;
 mod internal;
+mod tag;
 
 use edit::{Edit, EditLog, Kind, Txt};
 pub use internal::{Chars, GapBuffer, IdxChars, Slice, SliceIter};
 
 pub(crate) use buffers::{BufferId, Buffers};
+pub(crate) use tag::Tag;
 
 // Welcome splash message for new users to help them get started (rather than just presenting them
 // with a blank buffer.
@@ -205,6 +207,87 @@ impl Buffer {
         Ok(b)
     }
 
+    /// Create a new anonymous minibuffer
+    pub(super) fn new_minibuffer() -> Self {
+        Self {
+            id: usize::MAX,
+            kind: BufferKind::MiniBuffer,
+            dot: Default::default(),
+            xdot: Default::default(),
+            txt: GapBuffer::from(""),
+            cached_rx: 0,
+            last_save: SystemTime::now(),
+            dirty: false,
+            edit_log: Default::default(),
+            input_filter: None,
+            ts_state: None,
+            version: AtomicUsize::new(1),
+        }
+    }
+
+    /// Create a new unnamed buffer with the given content
+    pub fn new_unnamed(id: usize, content: impl Into<String>) -> Self {
+        Self {
+            id,
+            kind: BufferKind::Unnamed,
+            dot: Dot::default(),
+            xdot: Dot::default(),
+            txt: GapBuffer::from(normalize_line_endings(content.into())),
+            cached_rx: 0,
+            last_save: SystemTime::now(),
+            dirty: false,
+            edit_log: EditLog::default(),
+            input_filter: None,
+            ts_state: None,
+            version: AtomicUsize::new(1),
+        }
+    }
+
+    /// Create a new virtual buffer with the given name and content.
+    ///
+    /// The buffer will not be included in the virtual filesystem and it will be removed when it
+    /// loses focus.
+    pub fn new_virtual(id: usize, name: impl Into<String>, content: impl Into<String>) -> Self {
+        let mut content = normalize_line_endings(content.into());
+        if content.ends_with('\n') {
+            content.pop();
+        }
+
+        Self {
+            id,
+            kind: BufferKind::Virtual(name.into()),
+            dot: Dot::default(),
+            xdot: Dot::default(),
+            txt: GapBuffer::from(content),
+            cached_rx: 0,
+            last_save: SystemTime::now(),
+            dirty: false,
+            edit_log: EditLog::default(),
+            input_filter: None,
+            ts_state: None,
+            version: AtomicUsize::new(1),
+        }
+    }
+
+    /// Construct a new +output buffer with the given name which must be a valid output buffer name
+    /// of the form '$dir/+output'.
+    pub(super) fn new_output(id: usize, name: String, content: String) -> Self {
+        Self {
+            id,
+            kind: BufferKind::Output(name),
+            dot: Dot::default(),
+            xdot: Dot::default(),
+            txt: GapBuffer::from(normalize_line_endings(content)),
+            cached_rx: 0,
+            last_save: SystemTime::now(),
+            dirty: false,
+            edit_log: EditLog::default(),
+            input_filter: None,
+            ts_state: None,
+            version: AtomicUsize::new(1),
+        }
+    }
+
     /// Clear any existing tree-sitter state and then attempt to detect and set the state
     /// based on this buffer's BufferKind
     fn try_set_ts_state(&mut self) {
@@ -331,86 +414,6 @@ impl Buffer {
         };
 
         format!("\"{display_path}\" {n_lines}L {n_bytes}B loaded")
-    }
-
-    pub(super) fn new_minibuffer() -> Self {
-        Self {
-            id: usize::MAX,
-            kind: BufferKind::MiniBuffer,
-            dot: Default::default(),
-            xdot: Default::default(),
-            txt: GapBuffer::from(""),
-            cached_rx: 0,
-            last_save: SystemTime::now(),
-            dirty: false,
-            edit_log: Default::default(),
-            input_filter: None,
-            ts_state: None,
-            version: AtomicUsize::new(1),
-        }
-    }
-
-    /// Create a new unnamed buffer with the given content
-    pub fn new_unnamed(id: usize, content: impl Into<String>) -> Self {
-        Self {
-            id,
-            kind: BufferKind::Unnamed,
-            dot: Dot::default(),
-            xdot: Dot::default(),
-            txt: GapBuffer::from(normalize_line_endings(content.into())),
-            cached_rx: 0,
-            last_save: SystemTime::now(),
-            dirty: false,
-            edit_log: EditLog::default(),
-            input_filter: None,
-            ts_state: None,
-            version: AtomicUsize::new(1),
-        }
-    }
-
-    /// Create a new virtual buffer with the given name and content.
-    ///
-    /// The buffer will not be included in the virtual filesystem and it will be removed when it
-    /// loses focus.
-    pub fn new_virtual(id: usize, name: impl Into<String>, content: impl Into<String>) -> Self {
-        let mut content = normalize_line_endings(content.into());
-        if content.ends_with('\n') {
-            content.pop();
-        }
-
-        Self {
-            id,
-            kind: BufferKind::Virtual(name.into()),
-            dot: Dot::default(),
-            xdot: Dot::default(),
-            txt: GapBuffer::from(content),
-            cached_rx: 0,
-            last_save: SystemTime::now(),
-            dirty: false,
-            edit_log: EditLog::default(),
-            input_filter: None,
-            ts_state: None,
-            version: AtomicUsize::new(1),
-        }
-    }
-
-    /// Construct a new +output buffer with the given name which must be a valid output buffer name
-    /// of the form '$dir/+output'.
-    pub(super) fn new_output(id: usize, name: String, content: String) -> Self {
-        Self {
-            id,
-            kind: BufferKind::Output(name),
-            dot: Dot::default(),
-            xdot: Dot::default(),
-            txt: GapBuffer::from(normalize_line_endings(content)),
-            cached_rx: 0,
-            last_save: SystemTime::now(),
-            dirty: false,
-            edit_log: EditLog::default(),
-            input_filter: None,
-            ts_state: None,
-            version: AtomicUsize::new(1),
-        }
     }
 
     /// Short name for displaying in the status line
@@ -546,6 +549,17 @@ impl Buffer {
     #[inline]
     pub fn len_chars(&self) -> usize {
         self.txt.len_chars()
+    }
+
+    /// Fully clear the contents of this buffer, notifying fsys of the change
+    pub fn clear(&mut self) {
+        self.handle_action(Action::DotSet(TextObject::BufferStart, 1), Source::Fsys);
+        self.handle_action(
+            Action::DotExtendForward(TextObject::BufferEnd, 1),
+            Source::Fsys,
+        );
+        self.handle_action(Action::Delete, Source::Fsys);
+        self.xdot.clamp_idx(self.txt.len_chars());
     }
 
     /// Whether or not the buffer is empty.
@@ -1132,6 +1146,15 @@ impl Buffer {
         self.mark_dirty();
 
         (r.start, Some(s))
+    }
+
+    /// Insert a string into the buffer using the current xdot rather than dot.
+    pub(crate) fn insert_xdot(&mut self, s: String) {
+        let dot = self.dot;
+        self.dot = self.xdot;
+        self.handle_action(Action::InsertString { s }, Source::Fsys);
+        (self.xdot, self.dot) = (self.dot, dot);
+        self.dot.clamp_idx(self.txt.len_chars()); // xdot clamped as part of handling the insert
     }
 
     pub(crate) fn find_forward(&mut self, s: &str) {

--- a/src/buffer/tag.rs
+++ b/src/buffer/tag.rs
@@ -6,6 +6,7 @@ use crate::{
     buffer::{ActionOutcome, Buffer},
     dot::{find::find_forward, Cur, Dot},
     editor::Action,
+    fsys::InputFilter,
 };
 use ad_event::Source;
 use std::{iter::repeat_n, mem::swap};
@@ -24,9 +25,9 @@ const GET: &str = " Get";
 #[derive(Debug)]
 pub(crate) struct Tag {
     /// The full tag content including filename and | separator
-    pub(super) b: Buffer,
+    pub(crate) b: Buffer,
     /// Cached UI plaintext lines
-    pub(super) ui_lines: Vec<String>,
+    pub(crate) ui_lines: Vec<String>,
 }
 
 impl Tag {
@@ -48,7 +49,7 @@ impl Tag {
     /// and attempting to preserve any user edited portion of the tag rather than attempting to
     /// modify edits being made to the tag in order to ensure that the invariants are upheld.
     /// This is a similar approach to the one used in Acme.
-    fn set_parent(&mut self, b: &Buffer, tabstop: usize, n_cols: usize) {
+    pub(crate) fn set_parent(&mut self, b: &Buffer, tabstop: usize, n_cols: usize) {
         // parse the current tag content in order to see if we need to change anything
         let (eofname, mut sotag) = parse_tag(&self.b);
         let old_fname = self.b.txt.slice(0, eofname);
@@ -80,10 +81,17 @@ impl Tag {
         self.update_content(&fname, sotag, b, tabstop, n_cols);
     }
 
-    fn update_content(&mut self, fname: &str, sotag: Option<usize>, b: &Buffer, tabstop: usize, n_cols: usize) {
+    fn update_content(
+        &mut self,
+        fname: &str,
+        sotag: Option<usize>,
+        b: &Buffer,
+        tabstop: usize,
+        n_cols: usize,
+    ) {
         // Determine the new tag content and then replace the existing tag if they differ
         let mut new_tag = fname.to_string();
-        new_tag.reserve(self.b.txt.len() - fname.len()); // avoid repeated realloc
+        new_tag.reserve(self.b.txt.len().saturating_sub(fname.len())); // avoid repeated realloc
 
         if b.dirty && !b.kind.is_dir() {
             new_tag.push_str(PUT);
@@ -106,8 +114,23 @@ impl Tag {
         self.compute_ui_lines(tabstop, n_cols);
     }
 
-    pub(crate) fn handle_action(&mut self, a: Action, source: Source) -> Option<ActionOutcome> {
-        todo!("how this works varies depending on whether or not we are editing the filename {a:?} {source:?}")
+    pub(crate) fn handle_action(
+        &mut self,
+        b: &mut Buffer,
+        a: Action,
+        source: Source,
+        tabstop: usize,
+        n_cols: usize,
+    ) -> Option<ActionOutcome> {
+        let action = self.b.handle_action(a, source);
+        self.update_parent(b, tabstop, n_cols);
+
+        action
+    }
+
+    #[inline]
+    pub(crate) fn set_input_filter(&mut self, filter: &InputFilter) {
+        self.b.input_filter = Some(filter.paired_tag_filter());
     }
 
     #[inline]
@@ -115,11 +138,7 @@ impl Tag {
         self.b.input_filter = None;
     }
 
-    pub(crate) fn ui_lines(&self) -> &[String] {
-        &self.ui_lines
-    }
-
-    fn compute_ui_lines(&mut self, tabstop: usize, n_cols: usize) {
+    pub(crate) fn compute_ui_lines(&mut self, tabstop: usize, n_cols: usize) {
         if n_cols == 0 {
             return;
         }

--- a/src/buffer/tag.rs
+++ b/src/buffer/tag.rs
@@ -196,11 +196,9 @@ impl Tag {
             }
         }
 
-        if !buf.is_empty() {
-            debug_assert!(cols <= n_cols, "{cols} vs {n_cols}");
-            buf.extend(repeat_n(' ', n_cols - cols));
-            lines.push(buf);
-        }
+        debug_assert!(cols <= n_cols, "{cols} vs {n_cols}");
+        buf.extend(repeat_n(' ', n_cols - cols));
+        lines.push(buf);
 
         self.gb.clear();
         self.gb.insert_str(0, &lines.join("\n"));
@@ -264,6 +262,27 @@ mod tests {
         "tag with explicit newline"
     )]
     #[test_case(
+        "this is\na test\n",
+        &[
+            "/home/foo/",
+            "bar.txt | ",
+            "this is   ",
+            "a test    ",
+            "          "
+        ];
+        "tag with explicit trailing newline"
+    )]
+    #[test_case(
+        "this is\na test1234",
+        &[
+            "/home/foo/",
+            "bar.txt | ",
+            "this is   ",
+            "a test1234"
+        ];
+        "tag that exactly fits whole UI lines"
+    )]
+    #[test_case(
         "this 🦊 is a test",
         &[
             "/home/foo/",
@@ -294,6 +313,9 @@ mod tests {
         let str_lines: Vec<&str> = string_lines.iter().map(|s| s.as_str()).collect();
 
         assert_eq!(&str_lines, expected);
+
+        let n_iter_lines = tag.line_iter(None).count();
+        assert_eq!(n_iter_lines, expected.len());
     }
 
     #[test_case("/home/foo/bar.txt | ", "/home/foo/bar.txt", Some(" "); "default tag")]

--- a/src/buffer/tag.rs
+++ b/src/buffer/tag.rs
@@ -283,7 +283,14 @@ mod tests {
         tag.b.append(s.to_string(), Source::Fsys);
         tag.compute_ui_lines(4, 10);
 
-        let string_lines: Vec<String> = tag.gb.iter_lines().map(|l| l.to_string()).collect();
+        let string_lines: Vec<String> = tag
+            .gb
+            .iter_lines()
+            .map(|l| {
+                let s = l.to_string();
+                s.trim_end_matches('\n').to_string()
+            })
+            .collect();
         let str_lines: Vec<&str> = string_lines.iter().map(|s| s.as_str()).collect();
 
         assert_eq!(&str_lines, expected);

--- a/src/buffer/tag.rs
+++ b/src/buffer/tag.rs
@@ -3,10 +3,11 @@
 //!
 //! See ../ui/layout.rs:/struct.Window/
 use crate::{
-    buffer::{ActionOutcome, Buffer},
-    dot::{find::find_forward, Cur, Dot},
+    buffer::{ActionOutcome, Buffer, GapBuffer},
+    dot::{find::find_forward, Cur, Dot, Range},
     editor::Action,
     fsys::InputFilter,
+    ts::LineIter,
 };
 use ad_event::Source;
 use std::{iter::repeat_n, mem::swap};
@@ -24,19 +25,23 @@ const GET: &str = " Get";
 ///                                              ... <- uneditable
 #[derive(Debug)]
 pub(crate) struct Tag {
-    /// The full tag content including filename and | separator
+    /// The full editable tag content including filename and | separator
     pub(crate) b: Buffer,
-    /// Cached UI plaintext lines
-    pub(crate) ui_lines: Vec<String>,
+    /// Pre-computed, wrapped UI lines
+    pub(crate) gb: GapBuffer,
+    /// Number of UI tag lines
+    pub(crate) n_lines: usize,
 }
 
 impl Tag {
     /// Construct a new [Tag] associated with a given buffer.
     pub(super) fn new(parent: &Buffer, id: usize, tabstop: usize, n_cols: usize) -> Self {
         let content = format!("{} | ", parent.full_name());
+        let gb = GapBuffer::from(content.as_str());
         let mut tag = Self {
             b: Buffer::new_unnamed(id, content),
-            ui_lines: Vec::new(),
+            gb,
+            n_lines: 0,
         };
         tag.set_parent(parent, tabstop, n_cols);
 
@@ -73,7 +78,7 @@ impl Tag {
     /// the full tag content.
     fn update_parent(&mut self, b: &mut Buffer, tabstop: usize, n_cols: usize) {
         let (eofname, sotag) = parse_tag(&self.b);
-        let fname = self.b.txt.slice(0, eofname).to_string();
+        let fname = self.b.txt.slice(0, eofname + 1).to_string();
         if fname != b.full_name() {
             b.set_filename(&fname);
         }
@@ -114,6 +119,17 @@ impl Tag {
         self.compute_ui_lines(tabstop, n_cols);
     }
 
+    pub(crate) fn line_iter(&self, load_exec_range: Option<(bool, Range)>) -> LineIter<'_> {
+        LineIter::new(
+            0,
+            &self.gb,
+            self.b.dot.as_range(),
+            load_exec_range,
+            &[],
+            &[],
+        )
+    }
+
     pub(crate) fn handle_action(
         &mut self,
         b: &mut Buffer,
@@ -122,10 +138,10 @@ impl Tag {
         tabstop: usize,
         n_cols: usize,
     ) -> Option<ActionOutcome> {
-        let action = self.b.handle_action(a, source);
+        let outcome = self.b.handle_action(a, source);
         self.update_parent(b, tabstop, n_cols);
 
-        action
+        outcome
     }
 
     #[inline]
@@ -186,7 +202,9 @@ impl Tag {
             lines.push(buf);
         }
 
-        self.ui_lines = lines;
+        self.gb.clear();
+        self.gb.insert_str(0, &lines.join("\n"));
+        self.n_lines = lines.len();
     }
 }
 
@@ -203,7 +221,7 @@ fn parse_tag(b: &Buffer) -> (usize, Option<usize>) {
     // the tag is split by either " |" or "\t|"
     let sotag = find_forward(&SPACE_PIPE, Cur::new(0), b)
         .or_else(|| find_forward(&TAB_PIPE, Cur::new(0), b))
-        .map(&|dot: Dot| dot.last_cur().idx + 1); // starts the char after |
+        .map(|dot: Dot| dot.last_cur().idx + 1); // starts the char after |
 
     (eofname.saturating_sub(1), sotag)
 }
@@ -265,7 +283,8 @@ mod tests {
         tag.b.append(s.to_string(), Source::Fsys);
         tag.compute_ui_lines(4, 10);
 
-        let str_lines: Vec<_> = tag.ui_lines.iter().map(|s| s.as_str()).collect();
+        let string_lines: Vec<String> = tag.gb.iter_lines().map(|l| l.to_string()).collect();
+        let str_lines: Vec<&str> = string_lines.iter().map(|s| s.as_str()).collect();
 
         assert_eq!(&str_lines, expected);
     }
@@ -322,7 +341,7 @@ mod tests {
             b.kind = BufferKind::Directory("/home/bar/baz.json".into());
         }
         b.dirty = dirty;
-        tag.set_parent(&b, 4, 10);
+        tag.set_parent(b, 4, 10);
 
         let s_tag = tag.b.txt.to_string();
         assert_eq!(s_tag, format!("/home/bar/baz.json{pre} | {current}"));

--- a/src/buffer/tag.rs
+++ b/src/buffer/tag.rs
@@ -1,0 +1,326 @@
+//! The 'tag' for a given UI window is a buffer with additional semantics such as automatic line
+//! wrapping and enforcement over the structure of its content.
+//!
+//! See ../ui/layout.rs:/struct.Window/
+use crate::{
+    buffer::{ActionOutcome, Buffer},
+    dot::{find::find_forward, Cur, Dot},
+    editor::Action,
+};
+use ad_event::Source;
+use std::{iter::repeat_n, mem::swap};
+use unicode_width::UnicodeWidthChar;
+
+const SPACE_PIPE: &str = " |";
+const TAB_PIPE: &str = "\t|";
+const PUT: &str = " Put";
+const GET: &str = " Get";
+
+/// A tag is a [Buffer] attached to given [Window] that contains specific semantics around how it is
+/// rendered and edited in order to enforce that the window's name is always present
+///
+/// Tag content is always of the form "<filename> | <user defined content>"
+///                                              ... <- uneditable
+#[derive(Debug)]
+pub(crate) struct Tag {
+    /// The full tag content including filename and | separator
+    pub(super) b: Buffer,
+    /// Cached UI plaintext lines
+    pub(super) ui_lines: Vec<String>,
+}
+
+impl Tag {
+    /// Construct a new [Tag] associated with a given buffer.
+    pub(super) fn new(parent: &Buffer, id: usize, tabstop: usize, n_cols: usize) -> Self {
+        let content = format!("{} | ", parent.full_name());
+        let mut tag = Self {
+            b: Buffer::new_unnamed(id, content),
+            ui_lines: Vec::new(),
+        };
+        tag.set_parent(parent, tabstop, n_cols);
+
+        tag
+    }
+
+    /// Update the current state of the tag based on what the current [Buffer] is.
+    ///
+    /// Handling of invariants in the tag is done through reparsing the raw tag buffer content
+    /// and attempting to preserve any user edited portion of the tag rather than attempting to
+    /// modify edits being made to the tag in order to ensure that the invariants are upheld.
+    /// This is a similar approach to the one used in Acme.
+    fn set_parent(&mut self, b: &Buffer, tabstop: usize, n_cols: usize) {
+        // parse the current tag content in order to see if we need to change anything
+        let (eofname, mut sotag) = parse_tag(&self.b);
+        let old_fname = self.b.txt.slice(0, eofname);
+
+        // If the filename has changed then we need to copy over the one from the buffer
+        // -> This is based on the logic in winsettag1
+        let fname = b.full_name();
+        if old_fname == fname {
+            if sotag.is_some() {
+                sotag = Some(self.b.txt.len_chars() - eofname + fname.chars().count());
+            }
+            self.b.xdot = Dot::from_char_indices(0, eofname);
+            self.b.insert_xdot(fname.to_string()); // using xdot handles updating dot for us
+            self.b.input_filter = b.input_filter.as_ref().map(|f| f.paired_tag_filter());
+        }
+
+        self.update_content(fname, sotag, b, tabstop, n_cols);
+    }
+
+    /// Update the filname of the parent buffer if the state within the Tag has modified it and then recompute the
+    /// the full tag content.
+    fn update_parent(&mut self, b: &mut Buffer, tabstop: usize, n_cols: usize) {
+        let (eofname, sotag) = parse_tag(&self.b);
+        let fname = self.b.txt.slice(0, eofname).to_string();
+        if fname != b.full_name() {
+            b.set_filename(&fname);
+        }
+
+        self.update_content(&fname, sotag, b, tabstop, n_cols);
+    }
+
+    fn update_content(&mut self, fname: &str, sotag: Option<usize>, b: &Buffer, tabstop: usize, n_cols: usize) {
+        // Determine the new tag content and then replace the existing tag if they differ
+        let mut new_tag = fname.to_string();
+        new_tag.reserve(self.b.txt.len() - fname.len()); // avoid repeated realloc
+
+        if b.dirty && !b.kind.is_dir() {
+            new_tag.push_str(PUT);
+        }
+        if b.kind.is_dir() {
+            new_tag.push_str(GET);
+        }
+
+        // End of the non-user editable portion of the tag
+        new_tag.push_str(SPACE_PIPE);
+        if let Some(i) = sotag {
+            new_tag.extend(self.b.txt.slice(i, self.b.len_chars()).chars());
+        }
+
+        if self.b.txt != new_tag.as_str() {
+            self.b.txt.clear();
+            self.b.append(new_tag, Source::Fsys);
+        }
+
+        self.compute_ui_lines(tabstop, n_cols);
+    }
+
+    pub(crate) fn handle_action(&mut self, a: Action, source: Source) -> Option<ActionOutcome> {
+        todo!("how this works varies depending on whether or not we are editing the filename {a:?} {source:?}")
+    }
+
+    #[inline]
+    pub(crate) fn clear_input_filter(&mut self) {
+        self.b.input_filter = None;
+    }
+
+    pub(crate) fn ui_lines(&self) -> &[String] {
+        &self.ui_lines
+    }
+
+    fn compute_ui_lines(&mut self, tabstop: usize, n_cols: usize) {
+        if n_cols == 0 {
+            return;
+        }
+
+        let mut lines = Vec::new();
+        let mut buf = String::new();
+        let mut cols = 0;
+
+        for ch in self.b.txt.chars() {
+            if ch == '\n' {
+                buf.extend(repeat_n(' ', n_cols - buf.len()));
+                let mut s = String::new();
+                swap(&mut buf, &mut s);
+                lines.push(s);
+                cols = 0;
+                continue;
+            }
+
+            let w = if ch == '\t' {
+                tabstop
+            } else {
+                UnicodeWidthChar::width(ch).unwrap_or(1)
+            };
+
+            if cols + w <= n_cols {
+                if ch == '\t' {
+                    buf.extend(repeat_n(' ', tabstop));
+                } else {
+                    buf.push(ch);
+                }
+                cols += w;
+            } else {
+                let mut s = String::new();
+                swap(&mut buf, &mut s);
+                lines.push(s);
+                buf.push(ch);
+                cols = w;
+                continue;
+            }
+        }
+
+        if !buf.is_empty() {
+            debug_assert!(cols <= n_cols, "{cols} vs {n_cols}");
+            buf.extend(repeat_n(' ', n_cols - cols));
+            lines.push(buf);
+        }
+
+        self.ui_lines = lines;
+    }
+}
+
+/// Parse the current tag content to determine:
+///   - the end of the filname portion of the tag
+///   - the start of the user defined tag
+fn parse_tag(b: &Buffer) -> (usize, Option<usize>) {
+    // filename portion of the tag ends on the first space or tab encountered
+    let eofname = match find_forward(&|c| c == ' ' || c == '\t', Cur::new(0), b) {
+        Some(dot) => dot.first_cur().idx,
+        None => return (b.len_chars(), None), // entire tag is a filename
+    };
+
+    // the tag is split by either " |" or "\t|"
+    let sotag = find_forward(&SPACE_PIPE, Cur::new(0), b)
+        .or_else(|| find_forward(&TAB_PIPE, Cur::new(0), b))
+        .map(&|dot: Dot| dot.last_cur().idx + 1); // starts the char after |
+
+    (eofname.saturating_sub(1), sotag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buffer::{BufferKind, Buffers};
+    use simple_test_case::test_case;
+    use std::sync::mpsc::channel;
+
+    #[test]
+    fn initial_tag_state_is_correct() {
+        let (tx, _rx) = channel();
+        let mut buffers = Buffers::new_stubbed(&[0], tx);
+        let parent_id = buffers.open_virtual("/home/foo/bar.txt".to_string(), String::new());
+        let tag = buffers.new_tag_buffer(parent_id, 4, 10);
+
+        assert_eq!(tag.b.txt.to_string(), "/home/foo/bar.txt | ");
+    }
+
+    #[test_case(
+        "this is a test",
+        &[
+            "/home/foo/",
+            "bar.txt | ",
+            "this is a ",
+            "test      "
+        ];
+        "simple tag"
+    )]
+    #[test_case(
+        "this is\na test",
+        &[
+            "/home/foo/",
+            "bar.txt | ",
+            "this is   ",
+            "a test    "
+        ];
+        "tag with explicit newline"
+    )]
+    #[test_case(
+        "this 🦊 is a test",
+        &[
+            "/home/foo/",
+            "bar.txt | ",
+            "this 🦊 is",
+            " a test   "
+        ];
+        "tag with multibyte character"
+    )]
+    #[test]
+    fn compute_ui_lines_append_content(s: &str, expected: &[&str]) {
+        let (tx, _rx) = channel();
+        let mut buffers = Buffers::new_stubbed(&[0], tx);
+        let parent_id = buffers.open_virtual("/home/foo/bar.txt".to_string(), String::new());
+        let mut tag = buffers.new_tag_buffer(parent_id, 4, 10);
+
+        tag.b.append(s.to_string(), Source::Fsys);
+        tag.compute_ui_lines(4, 10);
+
+        let str_lines: Vec<_> = tag.ui_lines.iter().map(|s| s.as_str()).collect();
+
+        assert_eq!(&str_lines, expected);
+    }
+
+    #[test_case("/home/foo/bar.txt | ", "/home/foo/bar.txt", Some(" "); "default tag")]
+    #[test_case("+errors | ", "+errors", Some(" "); "default tag non-filepath")]
+    #[test_case("/home/foo/bar.txt | foo bar", "/home/foo/bar.txt", Some(" foo bar"); "with tag")]
+    #[test_case("+errors | foo bar", "+errors", Some(" foo bar"); "non-filepath with tag")]
+    #[test_case("/foo\t|", "/foo", Some(""); "tab pipe no trailing space")]
+    #[test_case("/foo", "/foo", None; "no pipe")]
+    #[test_case("/foo | this 🦊 is a test", "/foo", Some(" this 🦊 is a test"); "unicode tag")]
+    // This one is weird...do we want to do the acme thing and discard input in this instance
+    // or do we want to inject / move the pipe?
+    #[test_case("/foo bar baz | quux", "/foo", Some(" quux"); "text between fname and pipe")]
+    #[test]
+    fn parse_tag(s: &str, expected_fname: &str, expected_tag: Option<&str>) {
+        let b = Buffer::new_virtual(usize::MAX, "test", s);
+        let (eofname, sotag) = parse_tag(&b);
+        let fname = b.txt.slice(0, eofname + 1);
+        let tag = sotag.map(|i| b.txt.slice(i, b.txt.len_chars()).to_string());
+
+        assert_eq!(&fname.to_string(), expected_fname);
+        assert_eq!(tag.as_deref(), expected_tag);
+    }
+
+    #[test_case("", false, false, ""; "no user tag")]
+    #[test_case("foo", false, false, ""; "simple user tag")]
+    #[test_case("", true, false, " Get"; "no user tag dir")]
+    #[test_case("foo", true, false, " Get"; "simple user tag dir")]
+    #[test_case("", false, true, " Put"; "no user tag while dirty")]
+    #[test_case("foo", false, true, " Put"; "simple user tag while dirty")]
+    #[test_case("", true, false, " Get"; "no user tag dir while")]
+    #[test_case("foo", true, false, " Get"; "simple user tag dir while")]
+    #[test_case("", true, true, " Get"; "no user tag dir while dirty")]
+    #[test_case("foo", true, true, " Get"; "simple user tag dir while dirty")]
+    #[test]
+    fn setting_a_new_buffer_works(current: &str, is_dir: bool, dirty: bool, pre: &str) {
+        let (tx, _rx) = channel();
+        let mut buffers = Buffers::new_stubbed(&[0], tx);
+        let parent_id = buffers.open_virtual("/home/foo/bar.txt".to_string(), String::new());
+        let mut tag = buffers.new_tag_buffer(parent_id, 4, 10);
+
+        // set the initial user tag
+        tag.b.append(current.to_string(), Source::Fsys);
+        tag.compute_ui_lines(4, 10);
+
+        let s_tag = tag.b.txt.to_string();
+        assert_eq!(s_tag, format!("/home/foo/bar.txt | {current}"));
+
+        let new_parent_id = buffers.open_virtual("/home/bar/baz.json".to_string(), String::new());
+        let b = buffers.with_id_mut(new_parent_id).unwrap();
+        if is_dir {
+            // Not an actual directory but used for testing
+            b.kind = BufferKind::Directory("/home/bar/baz.json".into());
+        }
+        b.dirty = dirty;
+        tag.set_parent(&b, 4, 10);
+
+        let s_tag = tag.b.txt.to_string();
+        assert_eq!(s_tag, format!("/home/bar/baz.json{pre} | {current}"));
+    }
+
+    #[test]
+    fn update_parent_modifies_parent_filename() {
+        let (tx, _rx) = channel();
+        let mut buffers = Buffers::new_stubbed(&[0], tx);
+        let parent_id = buffers.open_virtual("/home/foo/bar.txt".to_string(), String::new());
+        let mut tag = buffers.new_tag_buffer(parent_id, 4, 10);
+        let b = buffers.with_id_mut(parent_id).unwrap();
+
+        // set an entirely new tag
+        tag.b.txt = "/home/bar/baz".into();
+        tag.update_parent(b, 4, 10);
+
+        assert_eq!(b.full_name(), "/home/bar/baz");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use crate::{
     key::Input,
     term::{Color, Styles},
     trie::Trie,
+    ts::{TK_BAR, TK_DEFAULT, TK_DOT, TK_EXEC, TK_LOAD},
     util::parent_dir_containing,
 };
 use serde::{
@@ -17,11 +18,6 @@ use std::{
 use tracing::{error, warn};
 
 pub const DEFAULT_CONFIG: &str = include_str!("../data/config.toml");
-
-pub const TK_DEFAULT: &str = "default";
-pub const TK_DOT: &str = "dot";
-pub const TK_LOAD: &str = "load";
-pub const TK_EXEC: &str = "exec";
 
 pub(crate) fn config_path() -> String {
     let home = env::var("HOME").unwrap();
@@ -92,6 +88,16 @@ impl Config {
             style.fg = style.fg.or(Some(cfg.colorscheme.fg));
             style.bg = style.bg.or(Some(cfg.colorscheme.bg));
         }
+
+        // Ensure that the bar token styling is set
+        cfg.colorscheme
+            .syntax
+            .entry(TK_BAR.to_string())
+            .or_insert(Styles {
+                fg: Some(cfg.colorscheme.fg),
+                bg: Some(cfg.colorscheme.bar_bg),
+                ..Default::default()
+            });
 
         // Replace "~/" shorthand notation in paths with the user's $HOME
         for s in [
@@ -165,6 +171,7 @@ impl Default for ColorScheme {
     fn default() -> Self {
         let bg: Color = "#1B1720".try_into().unwrap();
         let fg: Color = "#E6D29E".try_into().unwrap();
+        let bar_bg: Color = "#4E415C".try_into().unwrap();
         let dot_bg: Color = "#336677".try_into().unwrap();
         let load_bg: Color = "#957FB8".try_into().unwrap();
         let exec_bg: Color = "#Bf616A".try_into().unwrap();
@@ -181,6 +188,7 @@ impl Default for ColorScheme {
         #[rustfmt::skip]
         let syntax = [
             (TK_DEFAULT,    Styles { fg: Some(fg), bg: Some(bg), ..Default::default() }),
+            (TK_BAR,        Styles { fg: Some(fg), bg: Some(bar_bg), ..Default::default() }),
             (TK_DOT,        Styles { fg: Some(fg), bg: Some(dot_bg), ..Default::default() }),
             (TK_LOAD,       Styles { fg: Some(fg), bg: Some(load_bg), ..Default::default() }),
             (TK_EXEC,       Styles { fg: Some(fg), bg: Some(exec_bg), ..Default::default() }),
@@ -202,7 +210,7 @@ impl Default for ColorScheme {
         Self {
             bg,
             fg,
-            bar_bg: "#4E415C".try_into().unwrap(),
+            bar_bg,
             signcol_fg: "#544863".try_into().unwrap(),
             minibuffer_hl: "#3E3549".try_into().unwrap(),
             syntax,

--- a/src/dot/find.rs
+++ b/src/dot/find.rs
@@ -86,8 +86,11 @@ fn rev_find_between<F: Find>(f: &F, from: usize, to: usize, b: &Buffer) -> Optio
 }
 
 // Functions that check a single character
-impl Find for fn(char) -> bool {
-    type Reversed = fn(char) -> bool;
+impl<F> Find for F
+where
+    F: Fn(char) -> bool + Copy,
+{
+    type Reversed = F;
 
     fn try_find<I>(&self, it: I) -> Option<(usize, usize)>
     where

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -529,7 +529,11 @@ where
     /// materials available at http://acme.cat-v.org/ to learn more about what is possible with
     /// such a system.
     pub(super) fn default_load_dot(&mut self, source: Source, load_in_new_window: bool) {
-        let b = self.layout.active_buffer_mut();
+        // When loading from a tag we take the content from the tag but run the load in the
+        // associated buffer.
+        let id = self.layout.active_buffer().id;
+        let b = self.layout.active_buffer_or_tag_mut();
+
         b.expand_cur_dot();
         if b.notify_load(source) {
             return; // input filter in place
@@ -540,7 +544,6 @@ where
             return;
         }
 
-        let id = b.id;
         self.load_string_in_buffer(id, s, load_in_new_window);
     }
 

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -896,6 +896,7 @@ recv {}({})",
             EditorMode::Headless,
             LogBuffer::default(),
         );
+        ed.update_window_size(400, 800);
         let brx = ed.rx_fsys.take().expect("to have fsys channels");
 
         for file in files {

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -267,7 +267,7 @@ where
             None => warn!("attempt to close unknown buffer, id={id}"),
             _ => {
                 _ = self.tx_fsys.send(LogEvent::Close(id));
-                self.clear_input_filter(id);
+                self.layout.clear_input_filter(id);
                 let was_last_buffer = self.layout.close_buffer(id);
                 self.running = !was_last_buffer;
             }
@@ -513,7 +513,7 @@ where
     }
 
     pub(super) fn expand_current_dot(&mut self) {
-        self.layout.active_buffer_mut().expand_cur_dot();
+        self.layout.active_buffer_or_tag_mut().expand_cur_dot();
     }
 
     /// Default semantics for attempting to load the current dot:
@@ -676,7 +676,7 @@ where
     /// materials available at http://acme.cat-v.org/ to learn more about what is possible with
     /// such a system.
     pub(super) fn default_execute_dot(&mut self, arg: Option<(Range, String)>, source: Source) {
-        let b = self.layout.active_buffer_mut();
+        let b = self.layout.active_buffer_or_tag_mut();
         b.expand_cur_dot();
         if b.notify_execute(source, arg.clone()) {
             return; // input filter in place

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     config_handle, die,
     dot::TextObject,
     exec::{Addr, Address},
-    fsys::{AdFs, InputFilter, LogEvent, Message, Req},
+    fsys::{AdFs, LogEvent, Message, Req},
     input::Event,
     key::{Arrow, Input},
     lsp::{LspManager, LspManagerHandle},
@@ -27,7 +27,7 @@ use std::{
     },
     time::Instant,
 };
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
 mod actions;
 mod built_in_commands;
@@ -331,7 +331,7 @@ where
             }
 
             AddInputEventFilter { id, filter } => {
-                let resp = if self.try_set_input_filter(id, filter) {
+                let resp = if self.layout.try_set_input_filter(id, filter) {
                     Ok("handled".to_string())
                 } else {
                     Err("filter already in place".to_string())
@@ -340,7 +340,7 @@ where
             }
 
             RemoveInputEventFilter { id } => {
-                self.clear_input_filter(id);
+                self.layout.clear_input_filter(id);
                 default_handled();
             }
 
@@ -558,30 +558,6 @@ where
                 ActionOutcome::SetStatusMessage(msg) => self.set_status_message(&msg),
                 ActionOutcome::SetClipboard(s) => self.set_clipboard(s),
             }
-        }
-    }
-
-    /// Returns `true` if the filter was successfully set, false if there was already one in place.
-    pub(crate) fn try_set_input_filter(&mut self, bufid: usize, filter: InputFilter) -> bool {
-        let b = match self.layout.buffer_with_id_mut(bufid) {
-            Some(b) => b,
-            None => return false,
-        };
-
-        if b.input_filter.is_some() {
-            warn!("attempt to set an input filter when one is already in place. id={bufid:?}");
-            return false;
-        }
-
-        b.input_filter = Some(filter);
-
-        true
-    }
-
-    /// Remove the input filter for the given scope if one exists.
-    pub(crate) fn clear_input_filter(&mut self, bufid: usize) {
-        if let Some(b) = self.layout.buffer_with_id_mut(bufid) {
-            b.input_filter = None;
         }
     }
 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -314,21 +314,11 @@ where
                 };
             }),
             SetBufferXDot { id, s } => self.handle_buffer_mutation(id, tx, s, |b, s| {
-                let dot = b.dot;
-                b.dot = b.xdot;
-                b.handle_action(Action::InsertString { s }, Source::Fsys);
-                (b.xdot, b.dot) = (b.dot, dot);
-                b.dot.clamp_idx(b.txt.len_chars()); // xdot clamped as part of handling the insert
+                b.insert_xdot(s);
             }),
 
             ClearBufferBody { id } => self.handle_buffer_mutation(id, tx, String::new(), |b, _| {
-                b.handle_action(Action::DotSet(TextObject::BufferStart, 1), Source::Fsys);
-                b.handle_action(
-                    Action::DotExtendForward(TextObject::BufferEnd, 1),
-                    Source::Fsys,
-                );
-                b.handle_action(Action::Delete, Source::Fsys);
-                b.xdot.clamp_idx(b.txt.len_chars());
+                b.clear();
             }),
 
             AppendBufferBody { id, s } => self.handle_buffer_mutation(id, tx, s, |b, s| {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -537,7 +537,7 @@ where
                     Arrow::Down
                 };
 
-                self.forward_action_to_active_buffer(
+                self.forward_action_to_active_window(
                     DotSet(TextObject::Arr(arr), self.layout.active_window_rows()),
                     Source::Keyboard,
                 );
@@ -546,7 +546,7 @@ where
                 i: Input::Mouse(evt),
             } => self.handle_mouse_event(evt),
 
-            a => self.forward_action_to_active_buffer(a, source),
+            a => self.forward_action_to_active_window(a, source),
         }
     }
 
@@ -562,8 +562,8 @@ where
         }
     }
 
-    fn forward_action_to_active_buffer(&mut self, a: Action, source: Source) {
-        if let Some(o) = self.layout.active_buffer_mut().handle_action(a, source) {
+    fn forward_action_to_active_window(&mut self, a: Action, source: Source) {
+        if let Some(o) = self.layout.handle_action_in_active_window(a, source) {
             match o {
                 ActionOutcome::SetStatusMessage(msg) => self.set_status_message(&msg),
                 ActionOutcome::SetClipboard(s) => self.set_clipboard(s),

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -109,8 +109,8 @@ where
                         return;
                     }
 
-                    let (bufid, cur) = self.layout.cur_from_screen_coords(x, y, false);
-                    if bufid != self.layout.active_buffer().id {
+                    let (is_active, cur) = self.layout.cur_from_screen_coords(x, y);
+                    if !is_active {
                         return;
                     }
                     click.selection.set_active_cursor(cur);
@@ -147,10 +147,10 @@ where
                     return;
                 }
 
-                let (bufid, cur) = self.layout.cur_from_screen_coords(x, y, false);
+                let (is_active, cur) = self.layout.cur_from_screen_coords(x, y);
                 // Support releasing the mouse over a different window as actioning the selection
                 // as it was present in the active buffer
-                if bufid == self.layout.active_buffer().id {
+                if is_active {
                     click.selection.set_active_cursor(cur);
                 }
 
@@ -192,7 +192,7 @@ where
 
             None => {
                 let btn = if is_right { Right } else { Middle };
-                let (id, cur) = self.layout.cur_from_screen_coords(x, y, true);
+                let (id, cur) = self.layout.focus_cur_from_screen_coords(x, y);
                 _ = self.tx_fsys.send(LogEvent::Focus(id));
 
                 self.held_click = Some(Click::new(btn, Range::from_cursors(cur, cur, false)));

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -78,9 +78,9 @@ where
                     return;
                 }
 
-                let click_in_active_buffer = self.layout.set_dot_from_screen_coords(x, y);
-                let b = self.layout.active_buffer_mut();
-                if !click_in_active_buffer {
+                let (click_in_active_buffer, is_buf) = self.layout.set_dot_from_screen_coords(x, y);
+                let b = self.layout.active_buffer_or_tag_mut();
+                if is_buf && !click_in_active_buffer {
                     _ = self.tx_fsys.send(LogEvent::Focus(b.id));
                 }
 
@@ -109,14 +109,13 @@ where
                         return;
                     }
 
-                    let (is_active, cur) = self.layout.cur_from_screen_coords(x, y);
-                    if !is_active {
-                        return;
+                    match self.layout.try_active_cur_from_screen_coords(x, y) {
+                        Some(cur) => click.selection.set_active_cursor(cur),
+                        None => return,
                     }
-                    click.selection.set_active_cursor(cur);
 
                     if click.btn == Left {
-                        self.layout.active_buffer_mut().dot = Dot::from(click.selection);
+                        self.layout.active_buffer_or_tag_mut().dot = Dot::from(click.selection);
                     }
                 }
             }
@@ -147,10 +146,9 @@ where
                     return;
                 }
 
-                let (is_active, cur) = self.layout.cur_from_screen_coords(x, y);
                 // Support releasing the mouse over a different window as actioning the selection
                 // as it was present in the active buffer
-                if is_active {
+                if let Some(cur) = self.layout.try_active_cur_from_screen_coords(x, y) {
                     click.selection.set_active_cursor(cur);
                 }
 
@@ -679,7 +677,8 @@ mod tests {
         // attach an input filter so we can intercept load and execute events
         let (tx, rx) = channel();
         let filter = InputFilter::new(tx);
-        ed.layout.try_set_input_filter(ed.active_buffer_id(), filter);
+        ed.layout
+            .try_set_input_filter(ed.active_buffer_id(), filter);
 
         for evt in evts.iter() {
             ed.handle_mouse_event(*evt);

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -188,7 +188,7 @@ where
                         click.paste_handled = true;
                         self.held_click = Some(click);
                     } else if !is_right && !click.cut_handled {
-                        self.forward_action_to_active_buffer(Action::Delete, Source::Mouse);
+                        self.forward_action_to_active_window(Action::Delete, Source::Mouse);
                         click.selection = self.layout.active_buffer().dot.as_range();
                         click.cut_handled = true;
                         self.held_click = Some(click);

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -297,9 +297,9 @@ mod tests {
 
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
         ],
         None,
         "some",
@@ -310,9 +310,9 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
         ],
         None,
         "some",
@@ -325,9 +325,9 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
         ],
         None,
         "some",
@@ -340,8 +340,8 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
         ],
         Some(Click::new(Left, r(0, 3, false))),
         "some",
@@ -352,8 +352,8 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 1 },
         ],
         Some(Click::new(Right, r(0, 3, false))),
         "t",  // default dot position
@@ -364,8 +364,8 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
         ],
         Some(Click::new(Middle, r(0, 3, false))),
         "t",  // default dot position
@@ -376,10 +376,10 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 4, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 4, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 4, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 4, y: 1 },
         ],
         None,
         "some",
@@ -392,10 +392,10 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 4, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 4, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 4, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 4, y: 1 },
         ],
         None,
         "some",
@@ -408,12 +408,12 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 12, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 12, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 12, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 12, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
         ],
         None,
         "text",
@@ -427,11 +427,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
         ],
         None,
         " ",
@@ -444,11 +444,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
         ],
         None,
         " ",
@@ -462,13 +462,13 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
         ],
         None,
         " ",
@@ -484,13 +484,13 @@ mod tests {
     // selection and clipboard end up as
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
         ],
         None,
         "t",
@@ -505,13 +505,13 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
         ],
         None,
         " ",
@@ -524,13 +524,13 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
         ],
         None,
         " ",
@@ -544,12 +544,12 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 3, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 3, y: 1 },
         ],
         None,
         " ",
@@ -563,12 +563,12 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 2, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 2, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 2, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 2, y: 1 },
         ],
         None,
         " ",
@@ -581,11 +581,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
         ],
         None,
         "t",
@@ -596,11 +596,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
         ],
         None,
         "t",
@@ -611,11 +611,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
         ],
         None,
         "t",
@@ -626,11 +626,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 0 },
-            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
+            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
         ],
         None,
         "t",
@@ -641,10 +641,10 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 9, y: 0 },
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 0 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 9, y: 0 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 9, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 1 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 9, y: 1 },
         ],
         None,
         "text",
@@ -679,7 +679,7 @@ mod tests {
         // attach an input filter so we can intercept load and execute events
         let (tx, rx) = channel();
         let filter = InputFilter::new(tx);
-        ed.try_set_input_filter(ed.active_buffer_id(), filter);
+        ed.layout.try_set_input_filter(ed.active_buffer_id(), filter);
 
         for evt in evts.iter() {
             ed.handle_mouse_event(*evt);

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -150,7 +150,7 @@ where
                 let (bufid, cur) = self.layout.cur_from_screen_coords(x, y, false);
                 // Support releasing the mouse over a different window as actioning the selection
                 // as it was present in the active buffer
-                if bufid == self.active_buffer_id() {
+                if bufid == self.layout.active_buffer().id {
                     click.selection.set_active_cursor(cur);
                 }
 
@@ -164,14 +164,6 @@ where
 
             _ => (),
         }
-    }
-
-    #[inline]
-    fn click_from_button(&mut self, btn: MouseButton, x: usize, y: usize) -> Click {
-        let (id, cur) = self.layout.cur_from_screen_coords(x, y, true);
-        _ = self.tx_fsys.send(LogEvent::Focus(id));
-
-        Click::new(btn, Range::from_cursors(cur, cur, false))
     }
 
     #[inline]
@@ -200,7 +192,10 @@ where
 
             None => {
                 let btn = if is_right { Right } else { Middle };
-                self.held_click = Some(self.click_from_button(btn, x, y));
+                let (id, cur) = self.layout.cur_from_screen_coords(x, y, true);
+                _ = self.tx_fsys.send(LogEvent::Focus(id));
+
+                self.held_click = Some(Click::new(btn, Range::from_cursors(cur, cur, false)));
             }
         };
     }

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use ad_event::Source;
 use std::time::Instant;
+use tracing::trace;
 
 /// Transient state that we hold to track the last mouse click we saw while
 /// we wait for it to be released or if the buffer changes.
@@ -69,6 +70,7 @@ where
 
         let last_click_time = self.last_click_time;
         self.last_click_time = Instant::now();
+        trace!("handling mouse event: {k:?} {b:?} ({m:?}) @ ({x}, {y})");
 
         match (k, m, b) {
             (Press, NoMod, Left) => {
@@ -210,17 +212,17 @@ where
             // For Middle clicks, if there is also a range dot in the buffer then that is
             // used as an argument to the command being executed.
             if is_right {
-                self.layout.active_buffer_mut().dot = Dot::from(click.selection);
+                self.layout.active_buffer_or_tag_mut().dot = Dot::from(click.selection);
                 self.default_load_dot(Source::Mouse, load_in_new_window);
             } else {
-                let dot = self.layout.active_buffer().dot;
-                self.layout.active_buffer_mut().dot = Dot::from(click.selection);
+                let dot = self.layout.active_buffer_or_tag().dot;
+                self.layout.active_buffer_or_tag_mut().dot = Dot::from(click.selection);
 
                 if dot.is_range() {
                     // Execute as if the click selection was dot then reset dot
                     let arg = dot.content(self.layout.active_buffer()).trim().to_string();
                     self.default_execute_dot(Some((dot.as_range(), arg)), Source::Mouse);
-                    self.layout.active_buffer_mut().dot = dot;
+                    self.layout.active_buffer_or_tag_mut().dot = dot;
                 } else {
                     self.default_execute_dot(None, Source::Mouse);
                 }
@@ -231,11 +233,11 @@ where
             // dot (and allow smart expand to handle generating the selection) before we Load/Execute
             if !self
                 .layout
-                .active_buffer()
+                .active_buffer_or_tag()
                 .dot
                 .contains(&click.selection.start)
             {
-                self.layout.active_buffer_mut().dot = Dot::from(click.selection.start);
+                self.layout.active_buffer_or_tag_mut().dot = Dot::from(click.selection.start);
             }
 
             if is_right {
@@ -295,9 +297,9 @@ mod tests {
 
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
         ],
         None,
         "some",
@@ -308,9 +310,9 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 2 },
         ],
         None,
         "some",
@@ -323,9 +325,9 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
         ],
         None,
         "some",
@@ -338,8 +340,8 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 2 },
         ],
         Some(Click::new(Left, r(0, 3, false))),
         "some",
@@ -350,8 +352,8 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 2 },
         ],
         Some(Click::new(Right, r(0, 3, false))),
         "t",  // default dot position
@@ -362,8 +364,8 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 2 },
         ],
         Some(Click::new(Middle, r(0, 3, false))),
         "t",  // default dot position
@@ -374,10 +376,10 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 4, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 4, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 4, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 4, y: 2 },
         ],
         None,
         "some",
@@ -390,10 +392,10 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 4, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 4, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 4, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 4, y: 2 },
         ],
         None,
         "some",
@@ -406,12 +408,12 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 12, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 12, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 12, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 12, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
         ],
         None,
         "text",
@@ -425,11 +427,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
         ],
         None,
         " ",
@@ -442,11 +444,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
         ],
         None,
         " ",
@@ -460,13 +462,13 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
         ],
         None,
         " ",
@@ -482,13 +484,13 @@ mod tests {
     // selection and clipboard end up as
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
         ],
         None,
         "t",
@@ -503,13 +505,13 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
         ],
         None,
         " ",
@@ -522,13 +524,13 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
         ],
         None,
         " ",
@@ -542,12 +544,12 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 3, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 3, y: 2 },
         ],
         None,
         " ",
@@ -561,12 +563,12 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Left, x: 2, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 2, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Left, x: 2, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 2, y: 2 },
         ],
         None,
         " ",
@@ -579,11 +581,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 2 },
         ],
         None,
         "t",
@@ -594,11 +596,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 2 },
         ],
         None,
         "t",
@@ -609,11 +611,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
         ],
         None,
         "t",
@@ -624,11 +626,11 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
-            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 2 },
+            MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Right, x: 7, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Middle, x: 7, y: 2 },
         ],
         None,
         "t",
@@ -639,10 +641,10 @@ mod tests {
     )]
     #[test_case(
         &[
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 9, y: 1 },
-            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 1 },
-            MouseEvent { k: Release, m: NoMod, b: Left, x: 9, y: 1 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 9, y: 2 },
+            MouseEvent { k: Press, m: NoMod, b: Left, x: 9, y: 2 },
+            MouseEvent { k: Release, m: NoMod, b: Left, x: 9, y: 2 },
         ],
         None,
         "text",
@@ -672,7 +674,7 @@ mod tests {
         ed.update_window_size(100, 80); // Needed in order to keep clicks in bounds
         ed.layout
             .open_virtual("test", "some text to test with", false);
-        ed.layout.active_buffer_mut().dot = Dot::Cur { c: Cur { idx: 5 } };
+        ed.layout.active_buffer_or_tag_mut().dot = Dot::Cur { c: Cur { idx: 5 } };
 
         // attach an input filter so we can intercept load and execute events
         let (tx, rx) = channel();
@@ -685,8 +687,9 @@ mod tests {
         }
 
         let recvd_fsys_events: Vec<_> = rx.try_iter().collect();
-        let b = ed.layout.active_buffer();
+        let b = ed.layout.active_buffer_or_tag();
 
+        assert_eq!(ed.layout.active_buffer_or_tag().id, 1);
         assert_eq!(ed.held_click, click, "click");
         assert_eq!(b.dot.content(b), dot, "dot content");
         assert_eq!(b.str_contents(), content, "buffer content");

--- a/src/fsys/event.rs
+++ b/src/fsys/event.rs
@@ -19,25 +19,52 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct InputFilter {
     tx: Sender<FsysEvent>,
+    is_buffer: bool,
 }
 
 impl InputFilter {
     pub(crate) fn new(tx: Sender<FsysEvent>) -> Self {
-        Self { tx }
+        Self {
+            tx,
+            is_buffer: true,
+        }
+    }
+
+    /// Create a copy of this filter for events coming from the tag
+    pub(crate) fn paired_tag_filter(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            is_buffer: false,
+        }
     }
 
     pub fn notify_insert(&self, source: Source, ch_from: usize, ch_to: usize, txt: &str) {
-        let evt = FsysEvent::new(source, Kind::InsertBody, ch_from, ch_to, txt);
+        let k = if self.is_buffer {
+            Kind::InsertBody
+        } else {
+            Kind::InsertTag
+        };
+        let evt = FsysEvent::new(source, k, ch_from, ch_to, txt);
         _ = self.tx.send(evt);
     }
 
     pub fn notify_delete(&self, source: Source, ch_from: usize, ch_to: usize) {
-        let evt = FsysEvent::new(source, Kind::DeleteBody, ch_from, ch_to, "");
+        let k = if self.is_buffer {
+            Kind::DeleteBody
+        } else {
+            Kind::DeleteTag
+        };
+        let evt = FsysEvent::new(source, k, ch_from, ch_to, "");
         _ = self.tx.send(evt);
     }
 
     pub fn notify_load(&self, source: Source, ch_from: usize, ch_to: usize, txt: &str) {
-        let evt = FsysEvent::new(source, Kind::LoadBody, ch_from, ch_to, txt);
+        let k = if self.is_buffer {
+            Kind::LoadBody
+        } else {
+            Kind::LoadTag
+        };
+        let evt = FsysEvent::new(source, k, ch_from, ch_to, txt);
         _ = self.tx.send(evt);
     }
 
@@ -55,7 +82,12 @@ impl InputFilter {
             _ = self.tx.send(evt);
         }
 
-        let evt = FsysEvent::new(source, Kind::ExecuteBody, ch_from, ch_to, txt);
+        let k = if self.is_buffer {
+            Kind::ExecuteBody
+        } else {
+            Kind::ExecuteTag
+        };
+        let evt = FsysEvent::new(source, k, ch_from, ch_to, txt);
         _ = self.tx.send(evt);
     }
 }

--- a/src/ts.rs
+++ b/src/ts.rs
@@ -38,6 +38,7 @@ use tracing::{error, info};
 use tree_sitter::{self as ts, ffi::TSLanguage};
 
 pub const TK_DEFAULT: &str = "default";
+pub const TK_BAR: &str = "bar";
 pub const TK_DOT: &str = "dot";
 pub const TK_LOAD: &str = "load";
 pub const TK_EXEC: &str = "exec";

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -35,14 +35,15 @@ impl Layout {
         screen_cols: usize,
         lsp_handle: Arc<LspManagerHandle>,
     ) -> Self {
-        let buffers = Buffers::new(lsp_handle);
+        let mut buffers = Buffers::new(lsp_handle);
         let id = buffers.active().id;
+        let cols = ziplist![Column::new(screen_rows, screen_cols, &[id], &mut buffers)];
 
         Self {
             buffers,
             screen_rows,
             screen_cols,
-            cols: ziplist![Column::new(screen_rows, screen_cols, &[id])],
+            cols,
             views: vec![],
         }
     }
@@ -179,7 +180,8 @@ impl Layout {
             self.cols = ziplist![Column::new(
                 self.screen_rows,
                 self.screen_cols,
-                &[focused_id]
+                &[focused_id],
+                &mut self.buffers,
             )];
             if let Some(view) = existing_view {
                 self.cols.focus.wins.focus.view = view;
@@ -369,7 +371,12 @@ impl Layout {
                 return;
             }
             let win = self.cols.focus.wins.remove_focused_unchecked();
-            let mut col = Column::new(self.screen_rows, self.screen_cols, &[win.view.bufid]);
+            let mut col = Column::new(
+                self.screen_rows,
+                self.screen_cols,
+                &[win.view.bufid],
+                &mut self.buffers,
+            );
             col.wins.focus = win;
             self.cols.insert_at(Position::Head, col);
             self.cols.focus_up();
@@ -397,7 +404,7 @@ impl Layout {
                 return;
             }
             let win = self.cols.focus.wins.remove_focused_unchecked();
-            let mut col = Column::new(self.screen_rows, self.screen_cols, &[0]);
+            let mut col = Column::new(self.screen_rows, self.screen_cols, &[0], &mut self.buffers);
             col.wins.focus = win;
             self.cols.insert_at(Position::Tail, col);
             self.cols.focus_down();
@@ -466,7 +473,12 @@ impl Layout {
     /// current active window.
     pub(crate) fn new_column(&mut self) {
         let view = self.focused_view().clone();
-        let mut col = Column::new(self.screen_rows, self.screen_cols, &[view.bufid]);
+        let mut col = Column::new(
+            self.screen_rows,
+            self.screen_cols,
+            &[view.bufid],
+            &mut self.buffers,
+        );
         col.wins.last_mut().view = view;
         self.cols.insert_at(Position::Tail, col);
         self.cols.focus_tail();
@@ -483,7 +495,7 @@ impl Layout {
             Window {
                 n_rows: 0,
                 view,
-                tag: Buffer::new_unnamed(0, ""),
+                tag: self.buffers.new_tag_buffer(),
                 buffer_focused: true,
             },
         );
@@ -503,7 +515,7 @@ impl Layout {
         };
 
         if self.cols.len() == 1 {
-            let mut col = Column::new(self.screen_rows, self.screen_cols, &[id]);
+            let mut col = Column::new(self.screen_rows, self.screen_cols, &[id], &mut self.buffers);
             col.wins.last_mut().view = view;
             self.cols.insert_at(Position::Tail, col);
         } else {
@@ -513,7 +525,7 @@ impl Layout {
                 Window {
                     n_rows: 0,
                     view,
-                    tag: Buffer::new_unnamed(0, ""),
+                    tag: self.buffers.new_tag_buffer(),
                     buffer_focused: true,
                 },
             );
@@ -665,6 +677,16 @@ impl Layout {
         } else {
             self.buffer_for_screen_coords(x, y)
         };
+
+        self.cur_from_screen_coords_and_bufid(x, y, bufid)
+    }
+
+    fn cur_from_screen_coords_and_bufid(
+        &mut self,
+        x: usize,
+        y: usize,
+        bufid: BufferId,
+    ) -> (BufferId, Cur) {
         let (x_offset, y_offset) = self.xy_offsets();
         let b = self
             .buffers
@@ -724,13 +746,22 @@ pub(crate) struct Column {
 }
 
 impl Column {
-    pub(crate) fn new(n_rows: usize, n_cols: usize, buf_ids: &[BufferId]) -> Self {
+    pub(crate) fn new(
+        n_rows: usize,
+        n_cols: usize,
+        buf_ids: &[BufferId],
+        buffers: &mut Buffers,
+    ) -> Self {
         if buf_ids.is_empty() {
             panic!("cant have an empty column");
         }
         let win_rows = n_rows / buf_ids.len();
-        let mut wins =
-            ZipList::try_from_iter(buf_ids.iter().map(|id| Window::new(win_rows, *id))).unwrap();
+        let mut wins = ZipList::try_from_iter(
+            buf_ids
+                .iter()
+                .map(|id| Window::new(win_rows, *id, buffers.new_tag_buffer())),
+        )
+        .unwrap();
 
         let slop = n_rows - (win_rows * buf_ids.len()) + buf_ids.len() - 1;
         wins.focus.n_rows += slop;
@@ -776,11 +807,11 @@ pub(crate) struct Window {
 }
 
 impl Window {
-    pub(crate) fn new(n_rows: usize, buf_id: BufferId) -> Self {
+    pub(crate) fn new(n_rows: usize, buf_id: BufferId, tag: Buffer) -> Self {
         Self {
             n_rows,
             view: View::new(buf_id),
-            tag: Buffer::new_unnamed(0, ""),
+            tag,
             buffer_focused: true,
         }
     }
@@ -1004,21 +1035,32 @@ mod tests {
     use simple_test_case::test_case;
     use std::sync::mpsc::channel;
 
-    fn test_windows(col_wins: &[usize], n_rows: usize, n_cols: usize) -> Layout {
+    fn test_layout(col_wins: &[usize], n_rows: usize, n_cols: usize) -> Layout {
         let mut cols = Vec::with_capacity(col_wins.len());
         let mut n = 0;
         let mut all_ids = Vec::new();
 
+        // Build up the list of all IDs first so we can construct the Buffers instance needed for
+        // calling Column::new
         for m in col_wins.iter() {
             let ids: Vec<usize> = (n..(n + m)).collect();
             n += m;
-            cols.push(Column::new(n_rows, n_cols, &ids));
             all_ids.extend(ids);
         }
 
         let (tx, _) = channel();
+        let mut buffers = Buffers::new_stubbed(&all_ids, tx);
+        n = 0;
+
+        // Now create the columns
+        for m in col_wins.iter() {
+            let ids: Vec<usize> = (n..(n + m)).collect();
+            n += m;
+            cols.push(Column::new(n_rows, n_cols, &ids, &mut buffers));
+        }
+
         let mut ws = Layout {
-            buffers: Buffers::new_stubbed(&all_ids, tx),
+            buffers,
             screen_rows: n_rows,
             screen_cols: n_cols,
             cols: ZipList::try_from_iter(cols).unwrap(),
@@ -1038,7 +1080,7 @@ mod tests {
 
     #[test]
     fn drag_left_works() {
-        let mut ws = test_windows(&[1, 1, 2], 80, 100);
+        let mut ws = test_layout(&[1, 1, 2], 80, 100);
         ws.next_column();
         assert_eq!(ws.active_buffer().id, 1);
         ws.drag_left();
@@ -1065,7 +1107,7 @@ mod tests {
 
     #[test]
     fn drag_right_works() {
-        let mut ws = test_windows(&[1, 1, 2], 80, 100);
+        let mut ws = test_layout(&[1, 1, 2], 80, 100);
         assert_eq!(ws.active_buffer().id, 0);
         ws.drag_right();
 
@@ -1091,7 +1133,7 @@ mod tests {
 
     #[test]
     fn next_prev_column_methods_work() {
-        let mut ws = test_windows(&[1, 1, 2], 80, 100);
+        let mut ws = test_layout(&[1, 1, 2], 80, 100);
         assert_eq!(ws.focused_view().bufid, 0);
 
         // next wrapping
@@ -1113,7 +1155,7 @@ mod tests {
 
     #[test]
     fn next_prev_window_methods_work() {
-        let mut ws = test_windows(&[3, 1], 80, 100);
+        let mut ws = test_layout(&[3, 1], 80, 100);
         assert_eq!(ws.focused_view().bufid, 0);
 
         // next wrapping
@@ -1144,7 +1186,7 @@ mod tests {
     #[test_case(&[1, 4], 60, 70, 4; "two cols second with four click in fourth window")]
     #[test]
     fn buffer_for_screen_coords_works(col_wins: &[usize], x: usize, y: usize, expected: BufferId) {
-        let mut ws = test_windows(col_wins, 80, 100);
+        let mut ws = test_layout(col_wins, 80, 100);
         println!("{ws:#?}");
 
         assert_eq!(
@@ -1174,7 +1216,7 @@ mod tests {
     #[test_case(4, &[0, 1, 2, 3]; "4")]
     #[test]
     fn close_buffer_works(id: usize, expected: &[usize]) {
-        let mut ws = test_windows(&[1, 4], 80, 100);
+        let mut ws = test_layout(&[1, 4], 80, 100);
         assert_eq!(&ordered_window_ids(&ws), &[0, 1, 2, 3, 4], "initial ids");
 
         ws.close_buffer(id);
@@ -1201,7 +1243,7 @@ mod tests {
     fn focus_buffer_for_screen_coords_doesnt_reorder_windows() {
         let (x, y) = (60, 70);
         let expected = 4;
-        let mut ws = test_windows(&[1, 4], 80, 100);
+        let mut ws = test_layout(&[1, 4], 80, 100);
 
         assert_eq!(
             &ordered_window_ids(&ws),

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,6 +1,6 @@
 //! Layout of UI windows
 use crate::{
-    buffer::{ActionOutcome, Buffer, BufferId, Buffers},
+    buffer::{ActionOutcome, Buffer, BufferId, Buffers, Tag},
     config_handle,
     dot::{Cur, Dot},
     editor::{Action, ViewPort},
@@ -9,7 +9,7 @@ use crate::{
     ziplist::{Position, ZipList},
 };
 use ad_event::Source;
-use std::{cmp::min, io, iter::repeat_n, mem::swap, path::Path, sync::Arc};
+use std::{cmp::min, io, mem::swap, path::Path, sync::Arc};
 use tracing::debug;
 use unicode_width::UnicodeWidthChar;
 
@@ -488,14 +488,18 @@ impl Layout {
     /// Create a new window at the end of the current column showing the same view
     /// found in the current active window.
     pub(crate) fn new_window(&mut self) {
+        let tabstop = config_handle!().tabstop;
+        let n_cols = self.cols.focus.n_cols;
         let view = self.focused_view().clone();
+        let tag = self.buffers.new_tag_buffer(view.bufid, tabstop, n_cols);
+
         let wins = &mut self.cols.focus.wins;
         wins.insert_at(
             Position::Tail,
             Window {
                 n_rows: 0,
                 view,
-                tag: self.buffers.new_tag_buffer(),
+                tag,
                 buffer_focused: true,
             },
         );
@@ -519,13 +523,16 @@ impl Layout {
             col.wins.last_mut().view = view;
             self.cols.insert_at(Position::Tail, col);
         } else {
+            let tabstop = config_handle!().tabstop;
+            let n_cols = self.cols.last().n_cols;
+            let tag = self.buffers.new_tag_buffer(view.bufid, tabstop, n_cols);
             let wins = &mut self.cols.last_mut().wins;
             wins.insert_at(
                 Position::Tail,
                 Window {
                     n_rows: 0,
                     view,
-                    tag: self.buffers.new_tag_buffer(),
+                    tag,
                     buffer_focused: true,
                 },
             );
@@ -666,27 +673,35 @@ impl Layout {
         self.active_buffer().id
     }
 
-    pub(crate) fn cur_from_screen_coords(
-        &mut self,
-        x: usize,
-        y: usize,
-        set_focus: bool,
-    ) -> (BufferId, Cur) {
-        let bufid = if set_focus {
-            self.focus_buffer_for_screen_coords(x, y)
-        } else {
-            self.buffer_for_screen_coords(x, y)
-        };
+    pub(crate) fn cur_from_screen_coords(&mut self, x: usize, y: usize) -> (bool, Cur) {
+        let bufid = self.buffer_for_screen_coords(x, y);
+        let is_active = bufid == self.active_buffer().id;
+        let cur = self.cur_from_screen_coords_and_bufid(x, y, bufid);
 
-        self.cur_from_screen_coords_and_bufid(x, y, bufid)
+        (is_active, cur)
     }
 
-    fn cur_from_screen_coords_and_bufid(
-        &mut self,
-        x: usize,
-        y: usize,
-        bufid: BufferId,
-    ) -> (BufferId, Cur) {
+    pub(crate) fn focus_cur_from_screen_coords(&mut self, x: usize, y: usize) -> (BufferId, Cur) {
+        let bufid = self.focus_buffer_for_screen_coords(x, y);
+        let cur = self.cur_from_screen_coords_and_bufid(x, y, bufid);
+
+        (bufid, cur)
+    }
+
+    /// Set the active buffer and dot based on a mouse click.
+    ///
+    /// Returns true if the click was in the currently active buffer and false if this click has
+    /// changed the active buffer.
+    pub(crate) fn set_dot_from_screen_coords(&mut self, x: usize, y: usize) -> bool {
+        let current_bufid = self.buffers.active().id;
+        let bufid = self.focus_buffer_for_screen_coords(x, y);
+        let c = self.cur_from_screen_coords_and_bufid(x, y, bufid);
+        self.buffers.active_mut().dot = Dot::Cur { c };
+
+        bufid == current_bufid
+    }
+
+    fn cur_from_screen_coords_and_bufid(&mut self, x: usize, y: usize, bufid: BufferId) -> Cur {
         let (x_offset, y_offset) = self.xy_offsets();
         let b = self
             .buffers
@@ -698,6 +713,7 @@ impl Layout {
             .saturating_sub(w_sgncol)
             .saturating_sub(x_offset);
 
+        // TODO: should this be happening here? Or should it only be in focus_cur_from_screen_coords?
         let view = self.cols.focus.focused_view_mut();
         view.rx = rx;
         b.cached_rx = rx;
@@ -706,19 +722,7 @@ impl Layout {
         let mut cur = Cur::from_yx(y, b.x_from_provided_rx(y, view.rx), b);
         cur.clamp_idx(b.txt.len_chars());
 
-        (bufid, cur)
-    }
-
-    /// Set the active buffer and dot based on a mouse click.
-    ///
-    /// Returns true if the click was in the currently active buffer and false if this click has
-    /// changed the active buffer.
-    pub(crate) fn set_dot_from_screen_coords(&mut self, x: usize, y: usize) -> bool {
-        let current_bufid = self.buffers.active().id;
-        let (bufid, c) = self.cur_from_screen_coords(x, y, true);
-        self.buffers.active_mut().dot = Dot::Cur { c };
-
-        bufid == current_bufid
+        cur
     }
 
     pub(crate) fn update_visible_ts_state(&mut self) {
@@ -755,13 +759,13 @@ impl Column {
         if buf_ids.is_empty() {
             panic!("cant have an empty column");
         }
+        let tabstop = config_handle!().tabstop;
         let win_rows = n_rows / buf_ids.len();
-        let mut wins = ZipList::try_from_iter(
-            buf_ids
-                .iter()
-                .map(|id| Window::new(win_rows, *id, buffers.new_tag_buffer())),
-        )
-        .unwrap();
+        let mut wins =
+            ZipList::try_from_iter(buf_ids.iter().map(|id| {
+                Window::new(win_rows, *id, buffers.new_tag_buffer(*id, tabstop, n_cols))
+            }))
+            .unwrap();
 
         let slop = n_rows - (win_rows * buf_ids.len()) + buf_ids.len() - 1;
         wins.focus.n_rows += slop;
@@ -801,13 +805,13 @@ pub(crate) struct Window {
     /// Buffer view details currently shown in this window
     pub(crate) view: View,
     /// The current user defined tag content
-    pub(crate) tag: Buffer,
+    pub(crate) tag: Tag,
     /// Whether or not the buffer or tag is currently focused
     pub(crate) buffer_focused: bool,
 }
 
 impl Window {
-    pub(crate) fn new(n_rows: usize, buf_id: BufferId, tag: Buffer) -> Self {
+    pub(crate) fn new(n_rows: usize, buf_id: BufferId, tag: Tag) -> Self {
         Self {
             n_rows,
             view: View::new(buf_id),
@@ -816,55 +820,16 @@ impl Window {
         }
     }
 
-    pub(crate) fn tag_lines(&self, tabstop: usize, n_cols: usize, buf_name: &str) -> Vec<String> {
-        let it = buf_name
-            .chars()
-            .chain(" | ".chars())
-            .chain(self.tag.txt.chars());
-        let mut lines = Vec::new();
-        let mut buf = String::new();
-        let mut cols = 0;
+    // /// For a given y offset from the top of the window, check whether are we inside of the tag or
+    // /// inside of the buffer itself and return the appropriate buffer ID
+    // fn bufid_for_y_offset(&self, y: usize) -> BufferId {
+    //     todo!()
+    // }
 
-        for ch in it {
-            if ch == '\n' {
-                buf.extend(repeat_n(' ', n_cols - buf.len()));
-                let mut s = String::new();
-                swap(&mut buf, &mut s);
-                lines.push(s);
-                cols = 0;
-                continue;
-            }
-
-            let w = if ch == '\t' {
-                tabstop
-            } else {
-                UnicodeWidthChar::width(ch).unwrap_or(1)
-            };
-
-            if cols + w <= n_cols {
-                if ch == '\t' {
-                    buf.extend(repeat_n(' ', tabstop));
-                } else {
-                    buf.push(ch);
-                }
-                cols += w;
-            } else {
-                let mut s = String::new();
-                swap(&mut buf, &mut s);
-                lines.push(s);
-                buf.push(ch);
-                cols = w;
-                continue;
-            }
-        }
-
-        if !buf.is_empty() {
-            buf.extend(repeat_n(' ', n_cols - buf.len()));
-            lines.push(buf);
-        }
-
-        lines
-    }
+    // /// Same as bufid_for_y_offset but also set the buffer_focused flag
+    // fn focus_y_offset(&mut self, y: usize) -> BufferId {
+    //     todo!()
+    // }
 }
 
 #[derive(Debug, Clone)]
@@ -1304,54 +1269,5 @@ mod tests {
             view.clamp_scroll(&mut b, 80, 80);
             offset += widths[idx];
         }
-    }
-
-    #[test_case(
-        "this is a test",
-        &[
-            "/home/foo/",
-            "bar.txt | ",
-            "this is a ",
-            "test      "
-        ];
-        "simple tag"
-    )]
-    #[test_case(
-        "this is\na test",
-        &[
-            "/home/foo/",
-            "bar.txt | ",
-            "this is   ",
-            "a test    "
-        ];
-        "tag with explicit newline"
-    )]
-    #[test_case(
-        "this 🦊 is a test",
-        &[
-            "/home/foo/",
-            "bar.txt | ",
-            "this 🦊 is",
-            " a test   "
-        ];
-        "tag with multibyte character"
-    )]
-    #[test]
-    fn tag_lines_works(tag: &str, expected: &[&str]) {
-        let (tx, _rx) = channel();
-        let mut buffers = Buffers::new_stubbed(&[0], tx);
-        buffers.open_virtual("/home/foo/bar.txt".to_string(), String::new());
-
-        let win = Window {
-            n_rows: 10,
-            view: View::new(0),
-            tag: Buffer::new_unnamed(0, tag),
-            buffer_focused: true,
-        };
-
-        let lines = win.tag_lines(4, 10, "/home/foo/bar.txt");
-        let str_lines: Vec<_> = lines.iter().map(|s| s.as_str()).collect();
-
-        assert_eq!(&str_lines, expected);
     }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use ad_event::Source;
 use std::{cmp::min, io, mem::swap, path::Path, sync::Arc};
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 use unicode_width::UnicodeWidthChar;
 
 /// Layout is a screen layout of the windows available for displaying buffer
@@ -79,6 +79,15 @@ impl Layout {
     /// will return the Buffer the tag is attached to, not the tag itself.
     pub(crate) fn active_buffer_mut(&mut self) -> &mut Buffer {
         self.buffers.active_mut()
+    }
+
+    pub(crate) fn active_buffer_or_tag(&self) -> &Buffer {
+        let win = &self.cols.focus.wins.focus;
+        if win.buffer_focused {
+            self.buffers.active()
+        } else {
+            &win.tag.b
+        }
     }
 
     pub(crate) fn active_buffer_or_tag_mut(&mut self) -> &mut Buffer {
@@ -648,9 +657,16 @@ impl Layout {
     }
 
     /// Locate the absolute cursor position based on the current window layout
-    pub(crate) fn ui_xy(&self, b: &Buffer) -> (usize, usize) {
+    pub(crate) fn ui_xy(&self) -> (usize, usize) {
         let (x_offset, y_offset) = xy_offsets(&self.cols);
-        let (x, y) = self.focused_view().ui_xy(b);
+
+        let win = &self.cols.focus.wins.focus;
+        let (x, y) = if win.buffer_focused {
+            self.focused_view()
+                .ui_xy(self.buffers.active(), win.tag.n_lines)
+        } else {
+            self.focused_view().tag_ui_xy(&win.tag.b)
+        };
 
         (x + x_offset, y + y_offset)
     }
@@ -714,18 +730,25 @@ impl Layout {
         }
     }
 
-    pub(crate) fn cur_from_screen_coords(&mut self, x: usize, y: usize) -> (bool, Cur) {
+    /// Determine the cursor position for a given set of coordinates and report whether or not
+    /// these coordinates are inside of the currently active buffer (or tag).
+    pub(crate) fn try_active_cur_from_screen_coords(&mut self, x: usize, y: usize) -> Option<Cur> {
         let bt = self.buffer_for_screen_coords(x, y);
         let is_active = self.bufortag_as_id(bt) == self.active_buffer().id;
-        let cur = self.cur_from_screen_coords_and_bufortag(x, y, bt);
 
-        (is_active, cur)
+        if is_active {
+            Some(self.cur_from_screen_coords(x, y))
+        } else {
+            None
+        }
     }
 
+    /// Focus the buffer (or tag) containing the given screen coordinates and return the current
+    /// cursor position for updating held mouse state.
     pub(crate) fn focus_cur_from_screen_coords(&mut self, x: usize, y: usize) -> (BufferId, Cur) {
         let bt = self.focus_buffer_for_screen_coords(x, y);
         let bufid = self.bufortag_as_id(bt);
-        let cur = self.cur_from_screen_coords_and_bufortag(x, y, bt);
+        let cur = self.cur_from_screen_coords(x, y);
 
         (bufid, cur)
     }
@@ -734,43 +757,42 @@ impl Layout {
     ///
     /// Returns true if the click was in the currently active buffer and false if this click has
     /// changed the active buffer.
-    pub(crate) fn set_dot_from_screen_coords(&mut self, x: usize, y: usize) -> bool {
-        let current_bufid = self.buffers.active().id;
+    pub(crate) fn set_dot_from_screen_coords(&mut self, x: usize, y: usize) -> (bool, bool) {
+        let current_bufid = self.active_buffer_or_tag().id;
         let bt = self.focus_buffer_for_screen_coords(x, y);
         let bufid = self.bufortag_as_id(bt);
-        let c = self.cur_from_screen_coords_and_bufortag(x, y, bt);
-        self.buffers.active_mut().dot = Dot::Cur { c };
+        let c = self.cur_from_screen_coords(x, y);
+        self.active_buffer_or_tag_mut().dot = Dot::Cur { c };
 
-        bufid == current_bufid
+        (bufid == current_bufid, matches!(bt, BufOrTag::Buf(_)))
     }
 
-    fn cur_from_screen_coords_and_bufortag(&mut self, x: usize, y: usize, bt: BufOrTag) -> Cur {
+    /// Map a given (x, y) point into a Cur for the active buffer or tag
+    fn cur_from_screen_coords(&mut self, x: usize, y: usize) -> Cur {
         let (x_offset, y_offset) = xy_offsets(&self.cols);
-        // We need this later to compute cur.y but b is potentially borrowed from self.cols so we need
-        // to grab it here first. (Same for assigning rx later)
-        let row_off = self.cols.focus.wins.focus.view.row_off;
+        let win = &mut self.cols.focus.wins.focus;
+        let tag_lines = win.tag.n_lines;
+        let row_off = win.view.row_off;
 
-        let b = match bt {
-            BufOrTag::Buf(id) => self
-                .buffers
-                .with_id_mut(id)
-                .expect("layout state is stale"),
-            BufOrTag::Tag(c, w) => &mut self.cols[c].wins[w].tag.b,
+        let (is_buf, b) = if win.buffer_focused {
+            (true, self.buffers.active_mut())
+        } else {
+            (false, &mut win.tag.b)
         };
 
         let (_, w_sgncol) = b.sign_col_dims();
-        let rx = x
-            .saturating_sub(1)
-            .saturating_sub(w_sgncol)
-            .saturating_sub(x_offset);
+        let mut rx = x.saturating_sub(1).saturating_sub(x_offset);
+        let mut y = min(y.saturating_sub(y_offset) + row_off, b.len_lines()).saturating_sub(1);
 
-        b.cached_rx = rx;
+        if is_buf {
+            rx = rx.saturating_sub(w_sgncol);
+            win.view.rx = rx;
+            b.cached_rx = rx;
+            y -= tag_lines;
+        }
 
-        let y = min(y.saturating_sub(y_offset) + row_off, b.len_lines()).saturating_sub(1);
         let mut cur = Cur::from_yx(y, b.x_from_provided_rx(y, rx), b);
         cur.clamp_idx(b.len_chars());
-
-        self.cols.focus.wins.focus.view.rx = rx;
 
         cur
     }
@@ -881,14 +903,15 @@ impl Column {
     }
 
     fn update_size(&mut self, n_rows: usize, n_cols: usize) {
+        let tabstop = config_handle!().tabstop;
         self.n_cols = n_cols;
 
         if self.wins.len() == 1 {
             self.wins.focus.n_rows = n_rows;
+            self.wins.focus.tag.compute_ui_lines(tabstop, n_cols);
             return;
         }
 
-        let tabstop = config_handle!().tabstop;
         let (h_win, slop) = calculate_dims(n_rows, self.wins.len());
         for (i, (_, win)) in self.wins.iter_mut().enumerate() {
             let mut h = h_win;
@@ -940,7 +963,7 @@ impl Window {
     /// Callers are then expected to build a [BufOrTag] to identify the current position of this Window
     /// in cols for accessing the tag Buffer.
     fn bufid_for_y_offset(&self, y: usize) -> Option<BufOrTag> {
-        if y < self.tag.ui_lines.len() {
+        if y < self.tag.n_lines {
             None
         } else {
             Some(BufOrTag::Buf(self.view.bufid))
@@ -949,10 +972,19 @@ impl Window {
 
     /// Same as bufid_for_y_offset but also set the buffer_focused flag
     fn focus_y_offset(&mut self, y: usize) -> Option<BufOrTag> {
-        if y < self.tag.ui_lines.len() {
+        let n_lines = self.tag.n_lines;
+        if y <= n_lines {
+            trace!(
+                "focusing tag bufid={} y={y} n_lines={n_lines}",
+                self.view.bufid,
+            );
             self.buffer_focused = false;
             None
         } else {
+            trace!(
+                "focusing tag bufid={} y={y} n_lines={n_lines}",
+                self.view.bufid,
+            );
             self.buffer_focused = true;
             Some(BufOrTag::Buf(self.view.bufid))
         }
@@ -980,13 +1012,19 @@ impl View {
     }
 
     /// provides an (x, y) coordinate assuming that this window is in the top left
-    fn ui_xy(&self, b: &Buffer) -> (usize, usize) {
+    fn ui_xy(&self, b: &Buffer, tag_lines: usize) -> (usize, usize) {
         let (_, w_sgncol) = b.sign_col_dims();
         let (y, _) = b.dot.active_cur().as_yx(b);
         let x = self.rx - self.col_off + w_sgncol;
-        let y = y - self.row_off;
+        let y = y - self.row_off + tag_lines;
 
         (x, y)
+    }
+
+    fn tag_ui_xy(&self, b: &Buffer) -> (usize, usize) {
+        let (y, x) = b.dot.active_cur().as_yx(b);
+
+        (x - self.col_off, y)
     }
 
     pub(crate) fn rx_from_x(&self, b: &Buffer, y: usize, x: usize) -> usize {
@@ -1151,16 +1189,16 @@ mod tests {
             cols.push(Column::new(n_rows, n_cols, &ids, &mut buffers));
         }
 
-        let mut ws = Layout {
+        let mut l = Layout {
             buffers,
             screen_rows: n_rows,
             screen_cols: n_cols,
             cols: ZipList::try_from_iter(cols).unwrap(),
             views: vec![],
         };
-        ws.update_screen_size(n_rows, n_cols);
+        l.update_screen_size(n_rows, n_cols);
 
-        ws
+        l
     }
 
     fn ordered_window_ids(ws: &Layout) -> Vec<usize> {
@@ -1296,8 +1334,7 @@ mod tests {
             "bufid with mutation"
         );
         assert_eq!(
-            ws.cols.focus.wins.focus.view.bufid,
-            expected,
+            ws.cols.focus.wins.focus.view.bufid, expected,
             "focused id after mutation"
         );
     }
@@ -1387,7 +1424,7 @@ mod tests {
             assert_eq!(b.dot_contents(), ch.to_string());
             assert_eq!(b.dot, Dot::Cur { c: Cur { idx } });
             assert_eq!(
-                view.ui_xy(&b),
+                view.ui_xy(&b, 0),
                 (3 + offset, 0),
                 "idx={idx} content={:?}",
                 b.dot_contents()

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -685,7 +685,6 @@ impl Layout {
                     y_offset += win.n_rows + 1;
                     continue;
                 }
-                println!("CHECKING Y OFFSET {y}");
                 return win
                     .bufid_for_y_offset(y - y_offset)
                     .unwrap_or(BufOrTag::Tag(i, j));

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -685,7 +685,10 @@ impl Layout {
                     y_offset += win.n_rows + 1;
                     continue;
                 }
-                return win.bufid_for_y_offset(y).unwrap_or(BufOrTag::Tag(i, j));
+                println!("CHECKING Y OFFSET {y}");
+                return win
+                    .bufid_for_y_offset(y - y_offset)
+                    .unwrap_or(BufOrTag::Tag(i, j));
             }
         }
 
@@ -715,7 +718,9 @@ impl Layout {
                     continue;
                 }
                 self.buffers.focus_id(win.view.bufid);
-                return win.focus_y_offset(y).unwrap_or(BufOrTag::Tag(i, j));
+                return win
+                    .focus_y_offset(y - y_offset)
+                    .unwrap_or(BufOrTag::Tag(i, j));
             }
         }
 
@@ -782,7 +787,7 @@ impl Layout {
 
         let (_, w_sgncol) = b.sign_col_dims();
         let mut rx = x.saturating_sub(1).saturating_sub(x_offset);
-        let mut y = min(y.saturating_sub(y_offset) + row_off, b.len_lines()).saturating_sub(1);
+        let mut y = min(y.saturating_sub(y_offset) + row_off, b.len_lines());
 
         if is_buf {
             rx = rx.saturating_sub(w_sgncol);
@@ -790,6 +795,8 @@ impl Layout {
             b.cached_rx = rx;
             y -= tag_lines;
         }
+
+        y = y.saturating_sub(1);
 
         let mut cur = Cur::from_yx(y, b.x_from_provided_rx(y, rx), b);
         cur.clamp_idx(b.len_chars());
@@ -963,7 +970,7 @@ impl Window {
     /// Callers are then expected to build a [BufOrTag] to identify the current position of this Window
     /// in cols for accessing the tag Buffer.
     fn bufid_for_y_offset(&self, y: usize) -> Option<BufOrTag> {
-        if y < self.tag.n_lines {
+        if y <= self.tag.n_lines {
             None
         } else {
             Some(BufOrTag::Buf(self.view.bufid))
@@ -1201,8 +1208,8 @@ mod tests {
         l
     }
 
-    fn ordered_window_ids(ws: &Layout) -> Vec<usize> {
-        ws.cols
+    fn ordered_window_ids(l: &Layout) -> Vec<usize> {
+        l.cols
             .iter()
             .flat_map(|(_, c)| c.wins.iter().map(|(_, w)| w.view.bufid))
             .collect::<Vec<_>>()
@@ -1210,20 +1217,20 @@ mod tests {
 
     #[test]
     fn drag_left_works() {
-        let mut ws = test_layout(&[1, 1, 2], 80, 100);
-        ws.next_column();
-        assert_eq!(ws.active_buffer().id, 1);
-        ws.drag_left();
+        let mut l = test_layout(&[1, 1, 2], 80, 100);
+        l.next_column();
+        assert_eq!(l.active_buffer().id, 1);
+        l.drag_left();
 
-        assert_eq!(ws.cols.len(), 2);
-        let first_col: Vec<usize> = ws
+        assert_eq!(l.cols.len(), 2);
+        let first_col: Vec<usize> = l
             .cols
             .head()
             .wins
             .iter()
             .map(|(_, w)| w.view.bufid)
             .collect();
-        let second_col: Vec<usize> = ws
+        let second_col: Vec<usize> = l
             .cols
             .last()
             .wins
@@ -1237,19 +1244,19 @@ mod tests {
 
     #[test]
     fn drag_right_works() {
-        let mut ws = test_layout(&[1, 1, 2], 80, 100);
-        assert_eq!(ws.active_buffer().id, 0);
-        ws.drag_right();
+        let mut l = test_layout(&[1, 1, 2], 80, 100);
+        assert_eq!(l.active_buffer().id, 0);
+        l.drag_right();
 
-        assert_eq!(ws.cols.len(), 2);
-        let first_col: Vec<usize> = ws
+        assert_eq!(l.cols.len(), 2);
+        let first_col: Vec<usize> = l
             .cols
             .head()
             .wins
             .iter()
             .map(|(_, w)| w.view.bufid)
             .collect();
-        let second_col: Vec<usize> = ws
+        let second_col: Vec<usize> = l
             .cols
             .last()
             .wins
@@ -1263,78 +1270,86 @@ mod tests {
 
     #[test]
     fn next_prev_column_methods_work() {
-        let mut ws = test_layout(&[1, 1, 2], 80, 100);
-        assert_eq!(ws.focused_view().bufid, 0);
+        let mut l = test_layout(&[1, 1, 2], 80, 100);
+        assert_eq!(l.focused_view().bufid, 0);
 
         // next wrapping
-        ws.next_column();
-        assert_eq!(ws.focused_view().bufid, 1);
-        ws.next_column();
-        assert_eq!(ws.focused_view().bufid, 2);
-        ws.next_column();
-        assert_eq!(ws.focused_view().bufid, 0);
+        l.next_column();
+        assert_eq!(l.focused_view().bufid, 1);
+        l.next_column();
+        assert_eq!(l.focused_view().bufid, 2);
+        l.next_column();
+        assert_eq!(l.focused_view().bufid, 0);
 
         // prev wrapping
-        ws.prev_column();
-        assert_eq!(ws.focused_view().bufid, 2);
-        ws.prev_column();
-        assert_eq!(ws.focused_view().bufid, 1);
-        ws.prev_column();
-        assert_eq!(ws.focused_view().bufid, 0);
+        l.prev_column();
+        assert_eq!(l.focused_view().bufid, 2);
+        l.prev_column();
+        assert_eq!(l.focused_view().bufid, 1);
+        l.prev_column();
+        assert_eq!(l.focused_view().bufid, 0);
     }
 
     #[test]
     fn next_prev_window_methods_work() {
-        let mut ws = test_layout(&[3, 1], 80, 100);
-        assert_eq!(ws.focused_view().bufid, 0);
+        let mut l = test_layout(&[3, 1], 80, 100);
+        assert_eq!(l.focused_view().bufid, 0);
 
         // next wrapping
-        ws.next_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 1);
-        ws.next_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 2);
-        ws.next_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 0);
+        l.next_window_in_column();
+        assert_eq!(l.focused_view().bufid, 1);
+        l.next_window_in_column();
+        assert_eq!(l.focused_view().bufid, 2);
+        l.next_window_in_column();
+        assert_eq!(l.focused_view().bufid, 0);
 
         // prev wrapping
-        ws.prev_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 2);
-        ws.prev_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 1);
-        ws.prev_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 0);
+        l.prev_window_in_column();
+        assert_eq!(l.focused_view().bufid, 2);
+        l.prev_window_in_column();
+        assert_eq!(l.focused_view().bufid, 1);
+        l.prev_window_in_column();
+        assert_eq!(l.focused_view().bufid, 0);
     }
 
-    #[test_case(&[1], 30, 40, 0; "one col one win")]
-    #[test_case(&[1, 1], 30, 40, 0; "two cols one win each click in first")]
-    #[test_case(&[1, 1], 60, 40, 1; "two cols one win each click in second")]
-    #[test_case(&[1, 2], 60, 40, 1; "two cols second with two click in second window")]
-    #[test_case(&[1, 2], 60, 60, 2; "two cols second with two click in third window")]
-    #[test_case(&[1, 3], 60, 15, 1; "two cols second with three click in first window")]
-    #[test_case(&[1, 3], 60, 35, 2; "two cols second with three click in second window")]
-    #[test_case(&[1, 3], 60, 60, 3; "two cols second with three click in third window")]
-    #[test_case(&[1, 4], 60, 70, 4; "two cols second with four click in fourth window")]
+    #[test_case(&[1], 30, 40, BufOrTag::Buf(0), 0; "one col one win")]
+    #[test_case(&[1, 1], 30, 40, BufOrTag::Buf(0), 0; "two cols one win each click in first")]
+    #[test_case(&[1, 1], 60, 40, BufOrTag::Buf(1), 1; "two cols one win each click in second")]
+    #[test_case(&[1, 2], 60, 40, BufOrTag::Buf(1), 1; "two cols second with two click in second window")]
+    #[test_case(&[1, 2], 60, 60, BufOrTag::Buf(2), 2; "two cols second with two click in third window")]
+    #[test_case(&[1, 3], 60, 15, BufOrTag::Buf(1), 1; "two cols second with three click in first window")]
+    #[test_case(&[1, 3], 60, 35, BufOrTag::Buf(2), 2; "two cols second with three click in second window")]
+    #[test_case(&[1, 3], 60, 60, BufOrTag::Buf(3), 3; "two cols second with three click in third window")]
+    #[test_case(&[1, 4], 60, 70, BufOrTag::Buf(4), 4; "two cols second with four click in fourth window")]
+    #[test_case(&[1], 30, 2, BufOrTag::Buf(0), 0; "one col one win click on first buffer line")]
+    #[test_case(&[1], 30, 1, BufOrTag::Tag(0, 0), usize::MAX; "one col one win click on first tag line")]
+    #[test_case(&[2], 30, 40, BufOrTag::Buf(0), 0; "one col two wins click on last line of first window")]
+    #[test_case(&[2], 30, 41, BufOrTag::Tag(0, 1), usize::MAX - 1; "one col two wins click on second tag line")]
     #[test]
-    fn buffer_for_screen_coords_works(col_wins: &[usize], x: usize, y: usize, expected: BufferId) {
-        let mut ws = test_layout(col_wins, 80, 100);
-        println!("{ws:#?}");
+    fn buffer_for_screen_coords_works(
+        col_wins: &[usize],
+        x: usize,
+        y: usize,
+        bufortag: BufOrTag,
+        expected: BufferId,
+    ) {
+        let mut l = test_layout(col_wins, 80, 100);
 
         assert_eq!(
-            ws.buffer_for_screen_coords(x, y),
-            BufOrTag::Buf(expected),
-            "bufid without mutation"
+            l.buffer_for_screen_coords(x, y),
+            bufortag,
+            "bufortag without mutation"
+        );
+        assert_eq!(l.active_buffer_or_tag().id, 0, "focused id before mutation");
+
+        assert_eq!(
+            l.focus_buffer_for_screen_coords(x, y),
+            bufortag,
+            "bufortag with mutation"
         );
         assert_eq!(
-            ws.cols.focus.wins.focus.view.bufid, 0,
-            "focused id before mutation"
-        );
-        assert_eq!(
-            ws.focus_buffer_for_screen_coords(x, y),
-            BufOrTag::Buf(expected),
-            "bufid with mutation"
-        );
-        assert_eq!(
-            ws.cols.focus.wins.focus.view.bufid, expected,
+            l.active_buffer_or_tag().id,
+            expected,
             "focused id after mutation"
         );
     }
@@ -1346,24 +1361,21 @@ mod tests {
     #[test_case(4, &[0, 1, 2, 3]; "4")]
     #[test]
     fn close_buffer_works(id: usize, expected: &[usize]) {
-        let mut ws = test_layout(&[1, 4], 80, 100);
-        assert_eq!(&ordered_window_ids(&ws), &[0, 1, 2, 3, 4], "initial ids");
+        let mut l = test_layout(&[1, 4], 80, 100);
+        assert_eq!(&ordered_window_ids(&l), &[0, 1, 2, 3, 4], "initial ids");
 
-        ws.close_buffer(id);
-        assert!(
-            !ws.buffers.contains_bufid(id),
-            "buffer id should be removed"
-        );
+        l.close_buffer(id);
+        assert!(!l.buffers.contains_bufid(id), "buffer id should be removed");
 
         for bufid in expected.iter() {
             assert!(
-                ws.buffers.contains_bufid(*bufid),
+                l.buffers.contains_bufid(*bufid),
                 "other buffers should still be there"
             );
         }
 
         assert_eq!(
-            &ordered_window_ids(&ws),
+            &ordered_window_ids(&l),
             expected,
             "ids for each window should be correct"
         );
@@ -1373,34 +1385,34 @@ mod tests {
     fn focus_buffer_for_screen_coords_doesnt_reorder_windows() {
         let (x, y) = (60, 70);
         let expected = 4;
-        let mut ws = test_layout(&[1, 4], 80, 100);
+        let mut l = test_layout(&[1, 4], 80, 100);
 
         assert_eq!(
-            &ordered_window_ids(&ws),
+            &ordered_window_ids(&l),
             &[0, 1, 2, 3, 4],
             "before first click"
         );
 
         assert_eq!(
-            ws.focus_buffer_for_screen_coords(x, y),
+            l.focus_buffer_for_screen_coords(x, y),
             BufOrTag::Buf(expected),
             "bufid with mutation"
         );
 
         assert_eq!(
-            &ordered_window_ids(&ws),
+            &ordered_window_ids(&l),
             &[0, 1, 2, 3, 4],
             "after first click"
         );
 
         assert_eq!(
-            ws.focus_buffer_for_screen_coords(x, y),
+            l.focus_buffer_for_screen_coords(x, y),
             BufOrTag::Buf(expected),
             "bufid with mutation"
         );
 
         assert_eq!(
-            &ordered_window_ids(&ws),
+            &ordered_window_ids(&l),
             &[0, 1, 2, 3, 4],
             "after second click"
         );

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -4,13 +4,14 @@ use crate::{
     config_handle,
     dot::{Cur, Dot},
     editor::{Action, ViewPort},
+    fsys::InputFilter,
     lsp::LspManagerHandle,
     ziplist,
     ziplist::{Position, ZipList},
 };
 use ad_event::Source;
 use std::{cmp::min, io, mem::swap, path::Path, sync::Arc};
-use tracing::debug;
+use tracing::{debug, warn};
 use unicode_width::UnicodeWidthChar;
 
 /// Layout is a screen layout of the windows available for displaying buffer
@@ -66,12 +67,27 @@ impl Layout {
             .any(|(_, c)| c.wins.iter().any(|(_, w)| w.view.bufid == id))
     }
 
+    /// The semantics of active_buffer are to always return the active Buffer held within the
+    /// active Window. This means that if currently a tag has input focus then this method
+    /// will return the Buffer the tag is attached to, not the tag itself.
     pub(crate) fn active_buffer(&self) -> &Buffer {
         self.buffers.active()
     }
 
+    /// The semantics of active_buffer_mut are to always return the active Buffer held within
+    /// the active Window. This means that if currently a tag has input focus then this method
+    /// will return the Buffer the tag is attached to, not the tag itself.
     pub(crate) fn active_buffer_mut(&mut self) -> &mut Buffer {
         self.buffers.active_mut()
+    }
+
+    pub(crate) fn active_buffer_or_tag_mut(&mut self) -> &mut Buffer {
+        let win = &mut self.cols.focus.wins.focus;
+        if win.buffer_focused {
+            self.buffers.active_mut()
+        } else {
+            &mut win.tag.b
+        }
     }
 
     pub(crate) fn buffer_with_id(&self, id: BufferId) -> Option<&Buffer> {
@@ -94,11 +110,19 @@ impl Layout {
         a: Action,
         source: Source,
     ) -> Option<ActionOutcome> {
+        let n_cols = self.cols.focus.n_cols;
         let win = &mut self.cols.focus.wins.focus;
         if win.buffer_focused {
             self.buffers.active_mut().handle_action(a, source)
         } else {
-            win.tag.handle_action(a, source)
+            let tabstop = config_handle!().tabstop;
+            win.tag.handle_action(
+                self.buffers.with_id_mut(win.view.bufid)?,
+                a,
+                source,
+                tabstop,
+                n_cols,
+            )
         }
     }
 
@@ -347,11 +371,13 @@ impl Layout {
     /// Drag the focused window up through the column containing it (wrapping)
     pub(crate) fn drag_up(&mut self) {
         self.cols.focus.wins.swap_up();
+        self.cols.focus.update_tag_lines(config_handle!().tabstop);
     }
 
     /// Drag the focused window down through the column containing it (wrapping)
     pub(crate) fn drag_down(&mut self) {
         self.cols.focus.wins.swap_down();
+        self.cols.focus.update_tag_lines(config_handle!().tabstop);
     }
 
     /// Drag the focused window to the column on the left.
@@ -393,6 +419,11 @@ impl Layout {
             self.cols.focus.wins.insert(win);
         }
         self.update_screen_size(self.screen_rows, self.screen_cols);
+
+        let tabstop = config_handle!().tabstop;
+        for (_, col) in self.cols.iter_mut() {
+            col.update_tag_lines(tabstop);
+        }
     }
 
     /// Drag the focused window to the column on the right.
@@ -417,16 +448,16 @@ impl Layout {
             self.cols.focus.wins.insert(win);
         }
         self.update_screen_size(self.screen_rows, self.screen_cols);
+
+        let tabstop = config_handle!().tabstop;
+        for (_, col) in self.cols.iter_mut() {
+            col.update_tag_lines(tabstop);
+        }
     }
 
     #[inline]
     pub(crate) fn focused_view(&self) -> &View {
         &self.cols.focus.wins.focus.view
-    }
-
-    #[inline]
-    pub(crate) fn focused_view_mut(&mut self) -> &mut View {
-        &mut self.cols.focus.wins.focus.view
     }
 
     pub(crate) fn active_window_rows(&self) -> usize {
@@ -459,14 +490,27 @@ impl Layout {
         if self.focused_view().bufid == id {
             return;
         }
+        let b = match self.buffers.with_id(id) {
+            Some(b) => b,
+            None => return,
+        };
 
         let mut view = match self.views.iter().position(|v| v.bufid == id) {
             Some(idx) => self.views.remove(idx),
             None => View::new(id),
         };
 
-        swap(self.focused_view_mut(), &mut view);
+        swap(&mut self.cols.focus.wins.focus.view, &mut view);
         self.views.push(view);
+
+        let tabstop = config_handle!().tabstop;
+        let n_cols = self.cols.focus.n_cols;
+        self.cols
+            .focus
+            .wins
+            .focus
+            .tag
+            .set_parent(b, tabstop, n_cols);
     }
 
     /// Create a new column containing a single window showing the same view found in the
@@ -603,52 +647,42 @@ impl Layout {
             .set_viewport(b, vp, rows, cols);
     }
 
-    /// Coordinate offsets from the top left of the window layout to the top left of the active window.
-    fn xy_offsets(&self) -> (usize, usize) {
-        let cols_before = &self.cols.up;
-        let wins_above = &self.cols.focus.wins.up;
-        let x_offset = cols_before.iter().map(|c| c.n_cols).sum::<usize>() + cols_before.len();
-        let y_offset = wins_above.iter().map(|w| w.n_rows).sum::<usize>() + wins_above.len();
-
-        (x_offset, y_offset)
-    }
-
     /// Locate the absolute cursor position based on the current window layout
     pub(crate) fn ui_xy(&self, b: &Buffer) -> (usize, usize) {
-        let (x_offset, y_offset) = self.xy_offsets();
+        let (x_offset, y_offset) = xy_offsets(&self.cols);
         let (x, y) = self.focused_view().ui_xy(b);
 
         (x + x_offset, y + y_offset)
     }
 
-    fn buffer_for_screen_coords(&self, x: usize, y: usize) -> BufferId {
+    fn buffer_for_screen_coords(&self, x: usize, y: usize) -> BufOrTag {
         let mut x_offset = 0;
         let mut y_offset = 0;
 
-        for (_, col) in self.cols.iter() {
+        for (i, (_, col)) in self.cols.iter().enumerate() {
             if x > x_offset + col.n_cols {
                 x_offset += col.n_cols + 1;
                 continue;
             }
-            for (_, win) in col.wins.iter() {
+            for (j, (_, win)) in col.wins.iter().enumerate() {
                 if y > y_offset + win.n_rows {
                     y_offset += win.n_rows + 1;
                     continue;
                 }
-                return win.view.bufid;
+                return win.bufid_for_y_offset(y).unwrap_or(BufOrTag::Tag(i, j));
             }
         }
 
         debug!("click out of bounds (x, y)=({x}, {y})");
-        self.active_buffer().id
+        BufOrTag::Buf(self.active_buffer().id)
     }
 
-    pub(crate) fn focus_buffer_for_screen_coords(&mut self, x: usize, y: usize) -> BufferId {
+    fn focus_buffer_for_screen_coords(&mut self, x: usize, y: usize) -> BufOrTag {
         let mut x_offset = 0;
         let mut y_offset = 0;
 
         self.cols.focus_head();
-        for _ in 0..self.cols.len() {
+        for i in 0..self.cols.len() {
             let col = &self.cols.focus;
             if x > x_offset + col.n_cols {
                 x_offset += col.n_cols + 1;
@@ -657,33 +691,41 @@ impl Layout {
             }
 
             self.cols.focus.wins.focus_head();
-            for _ in 0..self.cols.focus.wins.len() {
-                let win = &self.cols.focus.wins.focus;
+            for j in 0..self.cols.focus.wins.len() {
+                let win = &mut self.cols.focus.wins.focus;
                 if y > y_offset + win.n_rows {
                     y_offset += win.n_rows + 1;
                     self.cols.focus.wins.focus_down();
                     continue;
                 }
                 self.buffers.focus_id(win.view.bufid);
-                return win.view.bufid;
+                return win.focus_y_offset(y).unwrap_or(BufOrTag::Tag(i, j));
             }
         }
 
         debug!("click out of bounds (x, y)=({x}, {y})");
-        self.active_buffer().id
+        BufOrTag::Buf(self.active_buffer().id)
+    }
+
+    fn bufortag_as_id(&self, bt: BufOrTag) -> BufferId {
+        match bt {
+            BufOrTag::Buf(id) => id,
+            BufOrTag::Tag(c, w) => self.cols[c].wins[w].tag.b.id,
+        }
     }
 
     pub(crate) fn cur_from_screen_coords(&mut self, x: usize, y: usize) -> (bool, Cur) {
-        let bufid = self.buffer_for_screen_coords(x, y);
-        let is_active = bufid == self.active_buffer().id;
-        let cur = self.cur_from_screen_coords_and_bufid(x, y, bufid);
+        let bt = self.buffer_for_screen_coords(x, y);
+        let is_active = self.bufortag_as_id(bt) == self.active_buffer().id;
+        let cur = self.cur_from_screen_coords_and_bufortag(x, y, bt);
 
         (is_active, cur)
     }
 
     pub(crate) fn focus_cur_from_screen_coords(&mut self, x: usize, y: usize) -> (BufferId, Cur) {
-        let bufid = self.focus_buffer_for_screen_coords(x, y);
-        let cur = self.cur_from_screen_coords_and_bufid(x, y, bufid);
+        let bt = self.focus_buffer_for_screen_coords(x, y);
+        let bufid = self.bufortag_as_id(bt);
+        let cur = self.cur_from_screen_coords_and_bufortag(x, y, bt);
 
         (bufid, cur)
     }
@@ -694,33 +736,41 @@ impl Layout {
     /// changed the active buffer.
     pub(crate) fn set_dot_from_screen_coords(&mut self, x: usize, y: usize) -> bool {
         let current_bufid = self.buffers.active().id;
-        let bufid = self.focus_buffer_for_screen_coords(x, y);
-        let c = self.cur_from_screen_coords_and_bufid(x, y, bufid);
+        let bt = self.focus_buffer_for_screen_coords(x, y);
+        let bufid = self.bufortag_as_id(bt);
+        let c = self.cur_from_screen_coords_and_bufortag(x, y, bt);
         self.buffers.active_mut().dot = Dot::Cur { c };
 
         bufid == current_bufid
     }
 
-    fn cur_from_screen_coords_and_bufid(&mut self, x: usize, y: usize, bufid: BufferId) -> Cur {
-        let (x_offset, y_offset) = self.xy_offsets();
-        let b = self
-            .buffers
-            .with_id_mut(bufid)
-            .expect("layout state is stale");
+    fn cur_from_screen_coords_and_bufortag(&mut self, x: usize, y: usize, bt: BufOrTag) -> Cur {
+        let (x_offset, y_offset) = xy_offsets(&self.cols);
+        // We need this later to compute cur.y but b is potentially borrowed from self.cols so we need
+        // to grab it here first. (Same for assigning rx later)
+        let row_off = self.cols.focus.wins.focus.view.row_off;
+
+        let b = match bt {
+            BufOrTag::Buf(id) => self
+                .buffers
+                .with_id_mut(id)
+                .expect("layout state is stale"),
+            BufOrTag::Tag(c, w) => &mut self.cols[c].wins[w].tag.b,
+        };
+
         let (_, w_sgncol) = b.sign_col_dims();
         let rx = x
             .saturating_sub(1)
             .saturating_sub(w_sgncol)
             .saturating_sub(x_offset);
 
-        // TODO: should this be happening here? Or should it only be in focus_cur_from_screen_coords?
-        let view = self.cols.focus.focused_view_mut();
-        view.rx = rx;
         b.cached_rx = rx;
 
-        let y = min(y.saturating_sub(y_offset) + view.row_off, b.len_lines()).saturating_sub(1);
-        let mut cur = Cur::from_yx(y, b.x_from_provided_rx(y, view.rx), b);
-        cur.clamp_idx(b.txt.len_chars());
+        let y = min(y.saturating_sub(y_offset) + row_off, b.len_lines()).saturating_sub(1);
+        let mut cur = Cur::from_yx(y, b.x_from_provided_rx(y, rx), b);
+        cur.clamp_idx(b.len_chars());
+
+        self.cols.focus.wins.focus.view.rx = rx;
 
         cur
     }
@@ -739,6 +789,63 @@ impl Layout {
                 .update_ts_state(from, n_rows);
         }
     }
+    /// Returns `true` if the filter was successfully set, false if there was already one in place.
+    pub(crate) fn try_set_input_filter(&mut self, bufid: BufferId, filter: InputFilter) -> bool {
+        let b = match self.buffer_with_id_mut(bufid) {
+            Some(b) => b,
+            None => return false,
+        };
+
+        if b.input_filter.is_some() {
+            warn!("attempt to set an input filter when one is already in place. id={bufid:?}");
+            return false;
+        }
+
+        b.input_filter = Some(filter.clone());
+
+        for (_, col) in self.cols.iter_mut() {
+            for (_, win) in col.wins.iter_mut() {
+                if win.view.bufid == bufid {
+                    win.tag.set_input_filter(&filter)
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Remove the input filter for the given buffer if one exists.
+    pub(crate) fn clear_input_filter(&mut self, bufid: usize) {
+        if let Some(b) = self.buffer_with_id_mut(bufid) {
+            b.input_filter = None;
+        }
+
+        for (_, col) in self.cols.iter_mut() {
+            for (_, win) in col.wins.iter_mut() {
+                if win.view.bufid == bufid {
+                    win.tag.clear_input_filter();
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum BufOrTag {
+    /// ID of the buffer in Buffers
+    Buf(BufferId),
+    /// (col, win) indices for accessing the tag in cols
+    Tag(usize, usize),
+}
+
+/// Coordinate offsets from the top left of the window layout to the top left of the active window.
+fn xy_offsets(cols: &ZipList<Column>) -> (usize, usize) {
+    let cols_before = &cols.up;
+    let wins_above = &cols.focus.wins.up;
+    let x_offset = cols_before.iter().map(|c| c.n_cols).sum::<usize>() + cols_before.len();
+    let y_offset = wins_above.iter().map(|w| w.n_rows).sum::<usize>() + wins_above.len();
+
+    (x_offset, y_offset)
 }
 
 #[derive(Debug)]
@@ -781,6 +888,7 @@ impl Column {
             return;
         }
 
+        let tabstop = config_handle!().tabstop;
         let (h_win, slop) = calculate_dims(n_rows, self.wins.len());
         for (i, (_, win)) in self.wins.iter_mut().enumerate() {
             let mut h = h_win;
@@ -788,6 +896,13 @@ impl Column {
                 h += 1;
             }
             win.n_rows = h;
+            win.tag.compute_ui_lines(tabstop, n_cols);
+        }
+    }
+
+    fn update_tag_lines(&mut self, tabstop: usize) {
+        for (_, win) in self.wins.iter_mut() {
+            win.tag.compute_ui_lines(tabstop, self.n_cols);
         }
     }
 
@@ -820,16 +935,28 @@ impl Window {
         }
     }
 
-    // /// For a given y offset from the top of the window, check whether are we inside of the tag or
-    // /// inside of the buffer itself and return the appropriate buffer ID
-    // fn bufid_for_y_offset(&self, y: usize) -> BufferId {
-    //     todo!()
-    // }
+    /// For a given y offset from the top of the window, check whether are we inside of the tag or
+    /// inside of the buffer itself and return our view's buffer ID if it is focused, otherwise None.
+    /// Callers are then expected to build a [BufOrTag] to identify the current position of this Window
+    /// in cols for accessing the tag Buffer.
+    fn bufid_for_y_offset(&self, y: usize) -> Option<BufOrTag> {
+        if y < self.tag.ui_lines.len() {
+            None
+        } else {
+            Some(BufOrTag::Buf(self.view.bufid))
+        }
+    }
 
-    // /// Same as bufid_for_y_offset but also set the buffer_focused flag
-    // fn focus_y_offset(&mut self, y: usize) -> BufferId {
-    //     todo!()
-    // }
+    /// Same as bufid_for_y_offset but also set the buffer_focused flag
+    fn focus_y_offset(&mut self, y: usize) -> Option<BufOrTag> {
+        if y < self.tag.ui_lines.len() {
+            self.buffer_focused = false;
+            None
+        } else {
+            self.buffer_focused = true;
+            Some(BufOrTag::Buf(self.view.bufid))
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1156,7 +1283,7 @@ mod tests {
 
         assert_eq!(
             ws.buffer_for_screen_coords(x, y),
-            expected,
+            BufOrTag::Buf(expected),
             "bufid without mutation"
         );
         assert_eq!(
@@ -1165,11 +1292,12 @@ mod tests {
         );
         assert_eq!(
             ws.focus_buffer_for_screen_coords(x, y),
-            expected,
+            BufOrTag::Buf(expected),
             "bufid with mutation"
         );
         assert_eq!(
-            ws.cols.focus.wins.focus.view.bufid, expected,
+            ws.cols.focus.wins.focus.view.bufid,
+            expected,
             "focused id after mutation"
         );
     }
@@ -1218,7 +1346,7 @@ mod tests {
 
         assert_eq!(
             ws.focus_buffer_for_screen_coords(x, y),
-            expected,
+            BufOrTag::Buf(expected),
             "bufid with mutation"
         );
 
@@ -1230,7 +1358,7 @@ mod tests {
 
         assert_eq!(
             ws.focus_buffer_for_screen_coords(x, y),
-            expected,
+            BufOrTag::Buf(expected),
             "bufid with mutation"
         );
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,14 +1,15 @@
 //! Layout of UI windows
 use crate::{
-    buffer::{Buffer, BufferId, Buffers},
+    buffer::{ActionOutcome, Buffer, BufferId, Buffers},
     config_handle,
     dot::{Cur, Dot},
-    editor::ViewPort,
+    editor::{Action, ViewPort},
     lsp::LspManagerHandle,
     ziplist,
     ziplist::{Position, ZipList},
 };
-use std::{cmp::min, io, mem::swap, path::Path, sync::Arc};
+use ad_event::Source;
+use std::{cmp::min, io, iter::repeat_n, mem::swap, path::Path, sync::Arc};
 use tracing::debug;
 use unicode_width::UnicodeWidthChar;
 
@@ -83,6 +84,21 @@ impl Layout {
     fn focus_first_window_with_buffer(&mut self, id: BufferId) {
         self.cols
             .focus_element_by_mut(|c| c.wins.focus_element_by_mut(|w| w.view.bufid == id));
+    }
+
+    /// Handle an action in the active window, targeting either the buffer or its tag depending on
+    /// what currently has focus
+    pub(crate) fn handle_action_in_active_window(
+        &mut self,
+        a: Action,
+        source: Source,
+    ) -> Option<ActionOutcome> {
+        let win = &mut self.cols.focus.wins.focus;
+        if win.buffer_focused {
+            self.buffers.active_mut().handle_action(a, source)
+        } else {
+            win.tag.handle_action(a, source)
+        }
     }
 
     pub(crate) fn open_or_focus<P: AsRef<Path>>(
@@ -462,7 +478,15 @@ impl Layout {
     pub(crate) fn new_window(&mut self) {
         let view = self.focused_view().clone();
         let wins = &mut self.cols.focus.wins;
-        wins.insert_at(Position::Tail, Window { n_rows: 0, view });
+        wins.insert_at(
+            Position::Tail,
+            Window {
+                n_rows: 0,
+                view,
+                tag: Buffer::new_unnamed(0, ""),
+                buffer_focused: true,
+            },
+        );
         wins.focus_tail();
         self.update_screen_size(self.screen_rows, self.screen_cols);
     }
@@ -484,7 +508,15 @@ impl Layout {
             self.cols.insert_at(Position::Tail, col);
         } else {
             let wins = &mut self.cols.last_mut().wins;
-            wins.insert_at(Position::Tail, Window { n_rows: 0, view });
+            wins.insert_at(
+                Position::Tail,
+                Window {
+                    n_rows: 0,
+                    view,
+                    tag: Buffer::new_unnamed(0, ""),
+                    buffer_focused: true,
+                },
+            );
             wins.focus_tail();
         }
 
@@ -637,7 +669,7 @@ impl Layout {
         let b = self
             .buffers
             .with_id_mut(bufid)
-            .expect("windows state is stale");
+            .expect("layout state is stale");
         let (_, w_sgncol) = b.sign_col_dims();
         let rx = x
             .saturating_sub(1)
@@ -675,14 +707,15 @@ impl Layout {
         });
 
         for (bufid, from, n_rows) in it {
-            // SAFETY: we know this id is valid
-            let b = unsafe { self.buffers.with_id_mut(bufid).unwrap_unchecked() };
-            b.update_ts_state(from, n_rows);
+            self.buffers
+                .with_id_mut(bufid)
+                .expect("layout state is stale")
+                .update_ts_state(from, n_rows);
         }
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct Column {
     /// Number of character columns wide
     pub(crate) n_cols: usize,
@@ -730,20 +763,76 @@ impl Column {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct Window {
     /// Number of character rows high
     pub(crate) n_rows: usize,
     /// Buffer view details currently shown in this window
     pub(crate) view: View,
+    /// The current user defined tag content
+    pub(crate) tag: Buffer,
+    /// Whether or not the buffer or tag is currently focused
+    pub(crate) buffer_focused: bool,
 }
 
 impl Window {
-    pub(crate) fn new(n_rows: usize, bufid: BufferId) -> Self {
+    pub(crate) fn new(n_rows: usize, buf_id: BufferId) -> Self {
         Self {
             n_rows,
-            view: View::new(bufid),
+            view: View::new(buf_id),
+            tag: Buffer::new_unnamed(0, ""),
+            buffer_focused: true,
         }
+    }
+
+    pub(crate) fn tag_lines(&self, tabstop: usize, n_cols: usize, buf_name: &str) -> Vec<String> {
+        let it = buf_name
+            .chars()
+            .chain(" | ".chars())
+            .chain(self.tag.txt.chars());
+        let mut lines = Vec::new();
+        let mut buf = String::new();
+        let mut cols = 0;
+
+        for ch in it {
+            if ch == '\n' {
+                buf.extend(repeat_n(' ', n_cols - buf.len()));
+                let mut s = String::new();
+                swap(&mut buf, &mut s);
+                lines.push(s);
+                cols = 0;
+                continue;
+            }
+
+            let w = if ch == '\t' {
+                tabstop
+            } else {
+                UnicodeWidthChar::width(ch).unwrap_or(1)
+            };
+
+            if cols + w <= n_cols {
+                if ch == '\t' {
+                    buf.extend(repeat_n(' ', tabstop));
+                } else {
+                    buf.push(ch);
+                }
+                cols += w;
+            } else {
+                let mut s = String::new();
+                swap(&mut buf, &mut s);
+                lines.push(s);
+                buf.push(ch);
+                cols = w;
+                continue;
+            }
+        }
+
+        if !buf.is_empty() {
+            buf.extend(repeat_n(' ', n_cols - buf.len()));
+            lines.push(buf);
+        }
+
+        lines
     }
 }
 
@@ -1173,5 +1262,54 @@ mod tests {
             view.clamp_scroll(&mut b, 80, 80);
             offset += widths[idx];
         }
+    }
+
+    #[test_case(
+        "this is a test",
+        &[
+            "/home/foo/",
+            "bar.txt | ",
+            "this is a ",
+            "test      "
+        ];
+        "simple tag"
+    )]
+    #[test_case(
+        "this is\na test",
+        &[
+            "/home/foo/",
+            "bar.txt | ",
+            "this is   ",
+            "a test    "
+        ];
+        "tag with explicit newline"
+    )]
+    #[test_case(
+        "this 🦊 is a test",
+        &[
+            "/home/foo/",
+            "bar.txt | ",
+            "this 🦊 is",
+            " a test   "
+        ];
+        "tag with multibyte character"
+    )]
+    #[test]
+    fn tag_lines_works(tag: &str, expected: &[&str]) {
+        let (tx, _rx) = channel();
+        let mut buffers = Buffers::new_stubbed(&[0], tx);
+        buffers.open_virtual("/home/foo/bar.txt".to_string(), String::new());
+
+        let win = Window {
+            n_rows: 10,
+            view: View::new(0),
+            tag: Buffer::new_unnamed(0, tag),
+            buffer_focused: true,
+        };
+
+        let lines = win.tag_lines(4, 10, "/home/foo/bar.txt");
+        let str_lines: Vec<_> = lines.iter().map(|s| s.as_str()).collect();
+
+        assert_eq!(&str_lines, expected);
     }
 }

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -13,7 +13,7 @@ use crate::{
         get_termsize, register_signal_handler, win_size_changed, CurShape, Cursor, Style, Styles,
         RESET_STYLE,
     },
-    ts::{LineIter, RangeToken},
+    ts::{LineIter, RangeToken, TK_BAR, TK_DEFAULT},
     ui::{
         layout::{Column, Window},
         Layout, StateChange, UserInterface,
@@ -341,7 +341,7 @@ impl UserInterface for Tui {
         let (x, y) = if w_minibuffer {
             (mb.cx, self.screen_rows + mb.n_visible_lines + 1)
         } else {
-            layout.ui_xy(active_buffer)
+            layout.ui_xy()
         };
         lines.push(format!("{}{}", Cursor::To(x + 1, y + 1), Cursor::Show));
 
@@ -477,15 +477,27 @@ impl<'a> ColIter<'a> {
             .expect("valid buffer id");
 
         let (w_lnum, _) = b.sign_col_dims();
-        let rng = if is_focus { self.load_exec_range } else { None };
+        let (rng, tag_rng) = if is_focus {
+            if w.buffer_focused {
+                (self.load_exec_range, None)
+            } else {
+                (None, self.load_exec_range)
+            }
+        } else {
+            (None, None)
+        };
         let it = b.iter_tokenized_lines_from(w.view.row_off, rng);
+        let tag_it = w.tag.line_iter(tag_rng);
 
         Some(WinIter {
             y: 0,
             w_lnum,
             n_cols: self.n_cols,
             tabstop: self.tabstop,
+            n_tag_lines: w.tag.n_lines,
+            tag_it,
             it,
+            tag_gb: &w.tag.gb,
             gb: &b.txt,
             w,
             cs: self.cs,
@@ -523,7 +535,10 @@ struct WinIter<'a> {
     w_lnum: usize,
     n_cols: usize,
     tabstop: usize,
+    n_tag_lines: usize,
+    tag_it: LineIter<'a>,
     it: LineIter<'a>,
+    tag_gb: &'a GapBuffer,
     gb: &'a GapBuffer,
     w: &'a Window,
     cs: &'a ColorScheme,
@@ -537,7 +552,24 @@ impl Iterator for WinIter<'_> {
         if self.y >= self.w.n_rows {
             return None;
         }
-        let file_row = self.y + self.w.view.row_off;
+        if let Some(it) = self.tag_it.next() {
+            self.y += 1;
+            return Some(render_line(
+                self.tag_gb,
+                it.map(|mut t| {
+                    if t.tag == TK_DEFAULT {
+                        t.tag = TK_BAR;
+                    }
+                    t
+                }),
+                0,
+                self.n_cols,
+                self.tabstop,
+                self.cs,
+                &mut self.style_cache,
+            ));
+        }
+        let file_row = self.y + self.w.view.row_off - self.n_tag_lines;
         self.y += 1;
 
         let next = self.it.next();

--- a/src/ziplist.rs
+++ b/src/ziplist.rs
@@ -6,6 +6,7 @@ use std::{
     fmt,
     iter::{once, IntoIterator},
     mem::{swap, take},
+    ops::{Index, IndexMut},
 };
 
 #[macro_export]
@@ -633,6 +634,34 @@ impl<T: PartialEq> ZipList<T> {
     }
 }
 
+impl<T> Index<usize> for ZipList<T> {
+    type Output = T;
+
+    fn index(&self, i: usize) -> &Self::Output {
+        let nup = self.up.len();
+        if i < nup {
+            &self.up[nup - i - 1]
+        } else if i == nup {
+            &self.focus
+        } else {
+            &self.down[i - nup - 1]
+        }
+    }
+}
+
+impl<T> IndexMut<usize> for ZipList<T> {
+    fn index_mut(&mut self, i: usize) -> &mut Self::Output {
+        let nup = self.up.len();
+        if i < nup {
+            &mut self.up[nup - i - 1]
+        } else if i == nup {
+            &mut self.focus
+        } else {
+            &mut self.down[i - nup - 1]
+        }
+    }
+}
+
 // Iteration
 
 /// An owned iterator over a [ZipList].
@@ -998,5 +1027,29 @@ mod tests {
         s.insert_at(pos, 6);
 
         assert_eq!(s, expected);
+    }
+
+    #[test_case(ziplist!([1,2,3,4], 5, []); "up and focus")]
+    #[test_case(ziplist!([], 1, [2,3,4,5]); "focus and down")]
+    #[test_case(ziplist!([1,2], 3, [4,5]); "all")]
+    #[test_case(ziplist!([], 1, []); "focus only")]
+    #[test]
+    fn index(zl: ZipList<usize>) {
+        for i in 0..zl.len() {
+            assert_eq!(zl[i], i + 1, "i={i}");
+        }
+    }
+
+    #[test_case(ziplist!([1,2,3,4], 5, []); "up and focus")]
+    #[test_case(ziplist!([], 1, [2,3,4,5]); "focus and down")]
+    #[test_case(ziplist!([1,2], 3, [4,5]); "all")]
+    #[test_case(ziplist!([], 1, []); "focus only")]
+    #[test]
+    fn index_mut(mut zl: ZipList<usize>) {
+        let expected = zl.clone().map(|_| 6);
+        for i in 0..zl.len() {
+            zl[i] = 6;
+        }
+        assert_eq!(zl, expected);
     }
 }

--- a/src/ziplist.rs
+++ b/src/ziplist.rs
@@ -2,6 +2,7 @@
 //!
 //! Really this should be published as its own crate.
 use std::{
+    cmp::Ordering,
     collections::vec_deque::{self, VecDeque},
     fmt,
     iter::{once, IntoIterator},
@@ -639,12 +640,10 @@ impl<T> Index<usize> for ZipList<T> {
 
     fn index(&self, i: usize) -> &Self::Output {
         let nup = self.up.len();
-        if i < nup {
-            &self.up[nup - i - 1]
-        } else if i == nup {
-            &self.focus
-        } else {
-            &self.down[i - nup - 1]
+        match i.cmp(&nup) {
+            Ordering::Less => &self.up[nup - i - 1],
+            Ordering::Equal => &self.focus,
+            Ordering::Greater => &self.down[i - nup - 1],
         }
     }
 }
@@ -652,12 +651,10 @@ impl<T> Index<usize> for ZipList<T> {
 impl<T> IndexMut<usize> for ZipList<T> {
     fn index_mut(&mut self, i: usize) -> &mut Self::Output {
         let nup = self.up.len();
-        if i < nup {
-            &mut self.up[nup - i - 1]
-        } else if i == nup {
-            &mut self.focus
-        } else {
-            &mut self.down[i - nup - 1]
+        match i.cmp(&nup) {
+            Ordering::Less => &mut self.up[nup - i - 1],
+            Ordering::Equal => &mut self.focus,
+            Ordering::Greater => &mut self.down[i - nup - 1],
         }
     }
 }


### PR DESCRIPTION
See #26 for details

There will be more that needs to be done in order to fully replicate acme's tag behaviour with fsys for example this at least gets the "basic" functionality in place.

That said, now that I have an in initial implementation of this working, I'm not fully convinced that it is the right idea...The tag always being visible and taking up screen space doesn't fit super well with the rest of the UI (which is more vim like) and really what I want from this is a per-buffer (or per-window) scratchpad for things like notes, commands to run, terms to search for etc. So I might repurpose what I have with this and instead implement a sort of persistent scratchpad instead 🤔 

## With acme style tags
![2025-04-25_13-16](https://github.com/user-attachments/assets/6aa2a31a-2a8e-4051-9f49-9a73070bda07)
