### PR TITLE
Adding a scratch buffer #26

### DIFF
--- a/crates/ad_event/src/lib.rs
+++ b/crates/ad_event/src/lib.rs
@@ -29,13 +29,13 @@ pub enum Kind {
     #[serde(rename = "L")]
     LoadBody,
     #[serde(rename = "i")]
-    InsertTag,
+    InsertScratch,
     #[serde(rename = "d")]
-    DeleteTag,
+    DeleteScratch,
     #[serde(rename = "x")]
-    ExecuteTag,
+    ExecuteScratch,
     #[serde(rename = "l")]
-    LoadTag,
+    LoadScratch,
     #[serde(rename = "A")]
     ChordedArgument,
 }
@@ -57,7 +57,7 @@ impl FsysEvent {
     /// and will be truncated if larger. Delete events are always truncated to zero length.
     pub fn new(source: Source, kind: Kind, ch_from: usize, ch_to: usize, raw_txt: &str) -> Self {
         let (txt, truncated) = match kind {
-            Kind::DeleteTag | Kind::DeleteBody => (String::new(), true),
+            Kind::DeleteScratch | Kind::DeleteBody => (String::new(), true),
             _ => {
                 let txt = raw_txt.chars().take(MAX_CHARS).collect();
                 let truncated = txt != raw_txt;
@@ -127,7 +127,7 @@ mod tests {
     }
 
     #[test_case(Kind::DeleteBody; "delete in body")]
-    #[test_case(Kind::DeleteTag; "delete in tag")]
+    #[test_case(Kind::DeleteScratch; "delete in tag")]
     #[test]
     fn txt_is_removed_for_delete_events_if_provided(kind: Kind) {
         let e = FsysEvent::new(Source::Keyboard, kind, 42, 42 + 17, "some deleted text");

--- a/docs/demos/scratch-buffer/fsys
+++ b/docs/demos/scratch-buffer/fsys
@@ -1,0 +1,20 @@
+The scratch buffer can be interacted with from the filesystem interface.
+
+  - try running "ad -9p ls ad"
+
+    -> you should see a "scratch" file listed
+
+
+  - you can read the current content of the scratch buffer like so:
+
+    -> ad -9p read ad/scratch
+
+
+  - you can append to the scratch buffer in the same way as appending to any other buffer body:
+
+    -> echo "hello from the shell" | ad -9p write ad/scratch
+
+
+  - you can clear the scratch buffer using the "clear-scratch" command
+
+    -> try running it from this buffer, the scratch or writing it to the "ad/ctl" file

--- a/docs/demos/scratch-buffer/index
+++ b/docs/demos/scratch-buffer/index
@@ -1,0 +1,3 @@
+overview
+load-exec
+fsys

--- a/docs/demos/scratch-buffer/load-exec
+++ b/docs/demos/scratch-buffer/load-exec
@@ -1,0 +1,16 @@
+The scratch buffer behaves as though it is the active buffer for the purposes of
+loading and executing text:
+
+  - If you search in the scratch buffer the search will take place in the active buffer instead
+
+    -> try loading the string "load" from the scrach buffer
+
+
+  - If you load a file path it will be treated as relative to the active buffer
+
+    -> try copying "../../../README.md" to the scrach buffer and loading it
+
+
+  - The same is true for executing text
+
+    -> try running ls from the scratch buffer: you should see the contents of this tour directory

--- a/docs/demos/scratch-buffer/overview
+++ b/docs/demos/scratch-buffer/overview
@@ -1,0 +1,11 @@
+This is a quick demo of the new scratch buffer behaviour being added to ad
+
+  - Conceptually the scratch buffer is similar to acme's per-window "tag"
+
+  - Instead of having a tag per buffer you have a single shared scratch buffer
+
+  - You can show and hide the scrach buffer using 'Alt-;'
+
+  - You can interact with the content of the scratch buffer in the same way as any other buffer
+
+    -> You can even run the NextSlide command from there, try it out!

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -49,6 +49,7 @@ pub enum Action {
     AppendToOutputBuffer { bufid: usize, content: String },
     ChangeDirectory { path: Option<String> },
     CleanupChild { id: u32 },
+    ClearScratch,
     CommandMode,
     Delete,
     DeleteBuffer { force: bool },

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -198,11 +198,15 @@ where
             }
 
             Ok(None) => {
-                match self.layout.active_buffer().state_changed_on_disk() {
+                match self
+                    .layout
+                    .active_buffer_ignoring_scratch()
+                    .state_changed_on_disk()
+                {
                     Ok(true) => {
                         let res = self.minibuffer_prompt("File changed on disk, reload? [y/n]: ");
                         if let Some("y" | "Y" | "yes") = res.as_deref() {
-                            let b = self.layout.active_buffer_mut();
+                            let b = self.layout.active_buffer_mut_ignoring_scratch();
                             let msg = b.reload_from_disk();
                             self.lsp_manager.document_changed(b);
                             self.set_status_message(&msg);
@@ -232,7 +236,7 @@ where
     pub(crate) fn find_file(&mut self, new_window: bool) {
         let d = self
             .layout
-            .active_buffer()
+            .active_buffer_ignoring_scratch()
             .dir()
             .unwrap_or(&self.cwd)
             .to_owned();
@@ -243,7 +247,7 @@ where
     pub(crate) fn find_repo_file(&mut self, new_window: bool) {
         let d = self
             .layout
-            .active_buffer()
+            .active_buffer_ignoring_scratch()
             .dir()
             .unwrap_or(&self.cwd)
             .to_owned();
@@ -303,7 +307,7 @@ where
             None => return,
         };
 
-        let b = self.layout.active_buffer_mut();
+        let b = self.layout.active_buffer_mut_ignoring_scratch();
         let msg = b.save_to_disk_at(p, force);
         self.lsp_manager.document_changed(b);
         self.set_status_message(msg);
@@ -314,7 +318,7 @@ where
     fn get_buffer_save_path(&mut self, fname: Option<String>) -> Option<PathBuf> {
         use BufferKind as Bk;
 
-        let desired_path = match (fname, &self.layout.active_buffer().kind) {
+        let desired_path = match (fname, &self.layout.active_buffer_ignoring_scratch().kind) {
             // File has a known name which is either where we loaded it from or a
             // path that has been set and verified from the Some(s) case that follows
             (None, Bk::File(ref p)) => return Some(p.clone()),
@@ -343,7 +347,8 @@ where
             }
         }
 
-        self.layout.active_buffer_mut().kind = BufferKind::File(desired_path.clone());
+        self.layout.active_buffer_mut_ignoring_scratch().kind =
+            BufferKind::File(desired_path.clone());
 
         Some(desired_path)
     }
@@ -374,7 +379,11 @@ where
     }
 
     pub(super) fn reload_active_buffer(&mut self) {
-        let msg = self.layout.active_buffer_mut().reload_from_disk();
+        let msg = self
+            .layout
+            .active_buffer_mut_ignoring_scratch()
+            .reload_from_disk();
+
         self.set_status_message(msg);
     }
 
@@ -423,7 +432,7 @@ where
     pub(super) fn search_in_current_buffer(&mut self) {
         let numbered_lines = self
             .layout
-            .active_buffer()
+            .active_buffer_ignoring_scratch()
             .string_lines()
             .into_iter()
             .enumerate()
@@ -432,8 +441,8 @@ where
 
         let selection = self.minibuffer_select_from("> ", numbered_lines);
         if let MiniBufferSelection::Line { cy, .. } = selection {
-            self.layout.active_buffer_mut().dot = Dot::Cur {
-                c: Cur::from_yx(cy, 0, self.layout.active_buffer()),
+            self.layout.active_buffer_mut_ignoring_scratch().dot = Dot::Cur {
+                c: Cur::from_yx(cy, 0, self.layout.active_buffer_ignoring_scratch()),
             };
             self.handle_action(Action::DotSet(TextObject::Line, 1), Source::Fsys);
             self.handle_action(Action::SetViewPort(ViewPort::Center), Source::Fsys);
@@ -486,7 +495,7 @@ where
         self.minibuffer_select_from(
             "<RAW BUFFER> ",
             self.layout
-                .active_buffer()
+                .active_buffer_ignoring_scratch()
                 .string_lines()
                 .into_iter()
                 .map(|l| format!("{:?}", l))
@@ -500,7 +509,11 @@ where
     }
 
     pub(super) fn show_active_ts_tree(&mut self) {
-        match self.layout.active_buffer().pretty_print_ts_tree() {
+        match self
+            .layout
+            .active_buffer_ignoring_scratch()
+            .pretty_print_ts_tree()
+        {
             Some(s) => self.layout.open_virtual("+ts-tree", s, false),
             None => self.set_status_message("no tree-sitter tree for current buffer"),
         }
@@ -737,17 +750,10 @@ where
         };
 
         let mut buf = Vec::new();
-        let fname = self
-            .layout
-            .active_buffer_ignoring_scratch()
-            .full_name()
-            .to_string();
+        let b = self.layout.active_buffer_mut_ignoring_scratch();
+        let fname = b.full_name().to_string();
 
-        match prog.execute(
-            self.layout.active_buffer_mut_ignoring_scratch(),
-            &fname,
-            &mut buf,
-        ) {
+        match prog.execute(b, &fname, &mut buf) {
             Ok(new_dot) => {
                 self.layout.record_jump_position();
                 self.layout.active_buffer_mut_ignoring_scratch().dot = new_dot;
@@ -816,8 +822,9 @@ where
     }
 
     pub(super) fn replace_dot_with_shell_cmd(&mut self, raw_cmd_str: &str) {
-        let d = self.layout.active_buffer().dir().unwrap_or(&self.cwd);
-        let id = self.active_buffer_id();
+        let b = self.layout.active_buffer_ignoring_scratch();
+        let d = b.dir().unwrap_or(&self.cwd);
+        let id = b.id;
         let res = self.system.run_command_blocking(raw_cmd_str, d, id);
 
         match res {
@@ -827,8 +834,9 @@ where
     }
 
     pub(super) fn run_shell_cmd(&mut self, raw_cmd_str: &str) {
-        let d = self.layout.active_buffer().dir().unwrap_or(&self.cwd);
-        let id = self.active_buffer_id();
+        let b = self.layout.active_buffer_ignoring_scratch();
+        let d = b.dir().unwrap_or(&self.cwd);
+        let id = b.id;
         let res = self
             .system
             .run_command(raw_cmd_str, d, id, self.tx_events.clone());

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -530,6 +530,9 @@ where
     /// materials available at http://acme.cat-v.org/ to learn more about what is possible with
     /// such a system.
     pub(super) fn default_load_dot(&mut self, source: Source, load_in_new_window: bool) {
+        // Grabbing the ID in this way allows us to treat loads in the scratch buffer as being from
+        // the active buffer.
+        let id = self.layout.active_buffer_ignoring_scratch().id;
         let b = self.layout.active_buffer_mut();
         b.expand_cur_dot();
         if b.notify_load(source) {
@@ -541,12 +544,11 @@ where
             return;
         }
 
-        let id = b.id;
         self.load_string_in_buffer(id, s, load_in_new_window);
     }
 
     pub(super) fn plumb(&mut self, txt: String, load_in_new_window: bool) {
-        let id = self.layout.active_buffer().id;
+        let id = self.layout.active_buffer_ignoring_scratch().id;
         self.load_string_in_buffer(id, txt, load_in_new_window);
     }
 
@@ -734,11 +736,20 @@ where
         };
 
         let mut buf = Vec::new();
-        let fname = self.layout.active_buffer().full_name().to_string();
-        match prog.execute(self.layout.active_buffer_mut(), &fname, &mut buf) {
+        let fname = self
+            .layout
+            .active_buffer_ignoring_scratch()
+            .full_name()
+            .to_string();
+
+        match prog.execute(
+            self.layout.active_buffer_mut_ignoring_scratch(),
+            &fname,
+            &mut buf,
+        ) {
             Ok(new_dot) => {
                 self.layout.record_jump_position();
-                self.layout.active_buffer_mut().dot = new_dot;
+                self.layout.active_buffer_mut_ignoring_scratch().dot = new_dot;
             }
 
             Err(e) => self.set_status_message(format!("Error running edit command: {e:?}")),

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -268,7 +268,7 @@ where
             None => warn!("attempt to close unknown buffer, id={id}"),
             _ => {
                 _ = self.tx_fsys.send(LogEvent::Close(id));
-                self.clear_input_filter(id);
+                self.layout.clear_input_filter(id);
                 let was_last_buffer = self.layout.close_buffer(id);
                 self.running = !was_last_buffer;
             }

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -123,6 +123,7 @@ pub enum Action {
     ShellRun { cmd: String },
     ShellSend { cmd: String },
     ShowHelp,
+    ToggleScratch,
     TsShowTree,
     Undo,
     UpdateConfig { input: String },

--- a/src/editor/built_in_commands.rs
+++ b/src/editor/built_in_commands.rs
@@ -5,16 +5,20 @@ pub fn built_in_commands() -> Vec<(Vec<&'static str>, &'static str)> {
             "switch to the buffer with the given ID ('buffer 5')",
         ),
         (
-            vec!["bn", "buffer-next"],
+            vec!["bn", "next-buffer"],
             "switch to the next available open buffer in the buffer list",
         ),
         (
-            vec!["bp", "buffer-prev"],
+            vec!["bp", "prev-buffer"],
             "switch to the previous available open buffer in the buffer list",
         ),
         (
             vec!["cd", "change-directory"],
             "change ad's working directory ('cd ../src')",
+        ),
+        (
+            vec!["clear-scratch"],
+            "clear the contents of the scratch buffer",
         ),
         (
             vec!["db", "delete-buffer"],
@@ -108,6 +112,10 @@ pub fn built_in_commands() -> Vec<(Vec<&'static str>, &'static str)> {
         (
             vec!["set"],
             "set a config property ('set bg-color=#ebdbb2')",
+        ),
+        (
+            vec!["toggle-scratch"],
+            "toggle the visibility of the scratch buffer",
         ),
         (vec!["view-logs"], "open ad's internal logs in a new buffer"),
         (

--- a/src/editor/commands.rs
+++ b/src/editor/commands.rs
@@ -190,7 +190,8 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
         "viewport-center" => Ok(Single(SetViewPort(ViewPort::Center))),
 
         "" => Err(String::new()),
-        _ => Err(format!("Not an editor command: {command}")),
+        _ => Err(String::new()),
+        // _ => Err(format!("Not an editor command: {command}")),
     }
 }
 

--- a/src/editor/commands.rs
+++ b/src/editor/commands.rs
@@ -25,8 +25,8 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
             Ok(id) => Ok(Single(FocusBuffer { id })),
             Err(_) => Err(format!("'{args}' is not a valid buffer id")),
         },
-        "bn" | "buffer-next" => Ok(Single(NextBuffer)),
-        "bp" | "buffer-prev" => Ok(Single(PreviousBuffer)),
+        "bn" | "next-buffer" => Ok(Single(NextBuffer)),
+        "bp" | "prev-buffer" => Ok(Single(PreviousBuffer)),
         "next-column" => Ok(Single(NextColumn)),
         "next-window" => Ok(Single(NextWindowInColumn)),
         "prev-column" => Ok(Single(PreviousColumn)),
@@ -146,6 +146,9 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
         "set" => Ok(Single(UpdateConfig {
             input: input.to_string(),
         })),
+
+        "clear-scratch" => Ok(Single(ClearScratch)),
+        "toggle-scratch" => Ok(Single(ToggleScratch)),
 
         "ts-show-tree" => Ok(Single(TsShowTree)),
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     config_handle, die,
     dot::TextObject,
     exec::{Addr, Address},
-    fsys::{AdFs, InputFilter, LogEvent, Message, Req},
+    fsys::{AdFs, LogEvent, Message, Req},
     input::Event,
     key::{Arrow, Input},
     lsp::{LspManager, LspManagerHandle},
@@ -27,7 +27,7 @@ use std::{
     },
     time::Instant,
 };
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
 mod actions;
 mod built_in_commands;
@@ -331,7 +331,7 @@ where
             }
 
             AddInputEventFilter { id, filter } => {
-                let resp = if self.try_set_input_filter(id, filter) {
+                let resp = if self.layout.try_set_input_filter(id, filter) {
                     Ok("handled".to_string())
                 } else {
                     Err("filter already in place".to_string())
@@ -340,7 +340,7 @@ where
             }
 
             RemoveInputEventFilter { id } => {
-                self.clear_input_filter(id);
+                self.layout.clear_input_filter(id);
                 default_handled();
             }
 
@@ -559,30 +559,6 @@ where
                 ActionOutcome::SetStatusMessage(msg) => self.set_status_message(&msg),
                 ActionOutcome::SetClipboard(s) => self.set_clipboard(s),
             }
-        }
-    }
-
-    /// Returns `true` if the filter was successfully set, false if there was already one in place.
-    pub(crate) fn try_set_input_filter(&mut self, bufid: usize, filter: InputFilter) -> bool {
-        let b = match self.layout.buffer_with_id_mut(bufid) {
-            Some(b) => b,
-            None => return false,
-        };
-
-        if b.input_filter.is_some() {
-            warn!("attempt to set an input filter when one is already in place. id={bufid:?}");
-            return false;
-        }
-
-        b.input_filter = Some(filter);
-
-        true
-    }
-
-    /// Remove the input filter for the given scope if one exists.
-    pub(crate) fn clear_input_filter(&mut self, bufid: usize) {
-        if let Some(b) = self.layout.buffer_with_id_mut(bufid) {
-            b.input_filter = None;
         }
     }
 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     set_config,
     system::{DefaultSystem, System},
     term::CurShape,
-    ui::{Layout, StateChange, Ui, UserInterface},
+    ui::{Layout, StateChange, Ui, UserInterface, SCRATCH_ID},
     LogBuffer,
 };
 use ad_event::Source;
@@ -243,6 +243,11 @@ where
         tx: Sender<Result<String, String>>,
         f: fn(&Buffer) -> String,
     ) {
+        if id == SCRATCH_ID {
+            _ = tx.send(Ok((f)(&self.layout.scratch.b)));
+            return;
+        }
+
         match self.layout.buffer_with_id(id) {
             Some(b) => _ = tx.send(Ok((f)(b))),
             None => {
@@ -259,6 +264,12 @@ where
         s: String,
         f: F,
     ) {
+        if id == SCRATCH_ID {
+            (f)(&mut self.layout.scratch.b, s);
+            _ = tx.send(Ok("handled".to_string()));
+            return;
+        }
+
         match self.layout.buffer_with_id_mut(id) {
             Some(b) => {
                 (f)(b, s);
@@ -393,6 +404,7 @@ where
                 .write_output_for_buffer(bufid, content, &self.cwd),
             ChangeDirectory { path } => self.change_directory(path),
             CleanupChild { id } => self.system.cleanup_child(id),
+            ClearScratch => self.layout.scratch.b.clear(),
             CommandMode => self.command_mode(),
             DeleteBuffer { force } => self.delete_buffer(self.active_buffer_id(), force),
             DeleteColumn { force } => self.delete_active_column(force),

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -144,7 +144,7 @@ where
     /// The id of the currently active buffer
     #[inline]
     pub fn active_buffer_id(&self) -> usize {
-        self.layout.active_buffer().id
+        self.layout.active_buffer_ignoring_scratch().id
     }
 
     /// Update the stored window size, accounting for the status and message bars

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -117,7 +117,10 @@ where
         let lsp_manager = Arc::new(LspManager::spawn(tx_events.clone()));
         let mut layout = Layout::new(0, 0, lsp_manager.clone());
         if show_splash && layout.is_empty_scratch() {
-            layout.active_buffer_mut().txt.insert_str(0, SPLASH);
+            layout
+                .active_buffer_mut_ignoring_scratch()
+                .txt
+                .insert_str(0, SPLASH);
         }
 
         Self {
@@ -439,7 +442,7 @@ where
             LspShowCapabilities => {
                 if let Some((name, txt)) = self
                     .lsp_manager
-                    .show_server_capabilities(self.layout.active_buffer())
+                    .show_server_capabilities(self.layout.active_buffer_ignoring_scratch())
                 {
                     self.layout.open_virtual(name, txt, true)
                 }
@@ -447,7 +450,7 @@ where
             LspShowDiagnostics => {
                 let action = self
                     .lsp_manager
-                    .show_diagnostics(self.layout.active_buffer());
+                    .show_diagnostics(self.layout.active_buffer_ignoring_scratch());
                 self.handle_action(action, Source::Fsys);
             }
             LspStart => {
@@ -455,20 +458,24 @@ where
                     self.set_status_message(msg);
                 }
             }
-            LspStop => self.lsp_manager.stop_client(self.layout.active_buffer()),
+            LspStop => self
+                .lsp_manager
+                .stop_client(self.layout.active_buffer_ignoring_scratch()),
             LspGotoDeclaration => self
                 .lsp_manager
-                .goto_declaration(self.layout.active_buffer()),
+                .goto_declaration(self.layout.active_buffer_ignoring_scratch()),
             LspGotoDefinition => self
                 .lsp_manager
-                .goto_definition(self.layout.active_buffer()),
+                .goto_definition(self.layout.active_buffer_ignoring_scratch()),
             LspGotoTypeDefinition => self
                 .lsp_manager
-                .goto_type_definition(self.layout.active_buffer()),
-            LspHover => self.lsp_manager.hover(self.layout.active_buffer()),
+                .goto_type_definition(self.layout.active_buffer_ignoring_scratch()),
+            LspHover => self
+                .lsp_manager
+                .hover(self.layout.active_buffer_ignoring_scratch()),
             LspReferences => self
                 .lsp_manager
-                .find_references(self.layout.active_buffer()),
+                .find_references(self.layout.active_buffer_ignoring_scratch()),
             MarkClean { bufid } => self.mark_clean(bufid),
             MbSelect(selector) => selector.run(self),
             NewEditLogTransaction => self.layout.active_buffer_mut().new_edit_log_transaction(),

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -512,6 +512,7 @@ where
             ShellReplace { cmd } => self.replace_dot_with_shell_cmd(&cmd),
             ShellRun { cmd } => self.run_shell_cmd(&cmd),
             ShowHelp => self.show_help(),
+            ToggleScratch => self.layout.toggle_scratch(),
             TsShowTree => self.show_active_ts_tree(),
             UpdateConfig { input } => self.update_config(&input),
             ViewLogs => self.view_logs(),

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -676,7 +676,8 @@ mod tests {
         // attach an input filter so we can intercept load and execute events
         let (tx, rx) = channel();
         let filter = InputFilter::new(tx);
-        ed.try_set_input_filter(ed.active_buffer_id(), filter);
+        ed.layout
+            .try_set_input_filter(ed.active_buffer_id(), filter);
 
         for evt in evts.iter() {
             ed.handle_mouse_event(*evt);

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -6,6 +6,7 @@ use crate::{
     fsys::LogEvent,
     key::{MouseButton, MouseEvent, MouseEventKind, MouseMod},
     system::System,
+    ui::SCRATCH_ID,
 };
 use ad_event::Source;
 use std::time::Instant;
@@ -80,7 +81,7 @@ where
 
                 let click_in_active_buffer = self.layout.set_dot_from_screen_coords(x, y);
                 let b = self.layout.active_buffer_mut();
-                if !click_in_active_buffer {
+                if !click_in_active_buffer && b.id != SCRATCH_ID {
                     _ = self.tx_fsys.send(LogEvent::Focus(b.id));
                 }
 

--- a/src/fsys/buffer.rs
+++ b/src/fsys/buffer.rs
@@ -476,8 +476,8 @@ mod tests {
     use simple_test_case::test_case;
 
     #[test_case(CURRENT_BUFFER_QID + 1 + 1, CURRENT_BUFFER_QID + 1, FILENAME; "filename first buffer")]
-    #[test_case(9, 7, DOT; "dot second buffer")]
-    #[test_case(22, 16, BODY; "body second buffer")]
+    #[test_case(10, 8, DOT; "dot second buffer")]
+    #[test_case(23, 17, BODY; "body second buffer")]
     #[test]
     fn parent_and_fname_works(qid: u64, parent: u64, fname: &str) {
         let (p, f) = parent_and_fname(qid);

--- a/src/fsys/event.rs
+++ b/src/fsys/event.rs
@@ -19,25 +19,52 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct InputFilter {
     tx: Sender<FsysEvent>,
+    is_scratch: bool,
 }
 
 impl InputFilter {
     pub(crate) fn new(tx: Sender<FsysEvent>) -> Self {
-        Self { tx }
+        Self {
+            tx,
+            is_scratch: false,
+        }
+    }
+
+    /// Create a copy of this filter for events coming from the scratch buffer
+    pub(crate) fn paired_tag_filter(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            is_scratch: true,
+        }
     }
 
     pub fn notify_insert(&self, source: Source, ch_from: usize, ch_to: usize, txt: &str) {
-        let evt = FsysEvent::new(source, Kind::InsertBody, ch_from, ch_to, txt);
+        let k = if self.is_scratch {
+            Kind::InsertScratch
+        } else {
+            Kind::InsertBody
+        };
+        let evt = FsysEvent::new(source, k, ch_from, ch_to, txt);
         _ = self.tx.send(evt);
     }
 
     pub fn notify_delete(&self, source: Source, ch_from: usize, ch_to: usize) {
-        let evt = FsysEvent::new(source, Kind::DeleteBody, ch_from, ch_to, "");
+        let k = if self.is_scratch {
+            Kind::DeleteScratch
+        } else {
+            Kind::DeleteBody
+        };
+        let evt = FsysEvent::new(source, k, ch_from, ch_to, "");
         _ = self.tx.send(evt);
     }
 
     pub fn notify_load(&self, source: Source, ch_from: usize, ch_to: usize, txt: &str) {
-        let evt = FsysEvent::new(source, Kind::LoadBody, ch_from, ch_to, txt);
+        let k = if self.is_scratch {
+            Kind::LoadScratch
+        } else {
+            Kind::LoadBody
+        };
+        let evt = FsysEvent::new(source, k, ch_from, ch_to, txt);
         _ = self.tx.send(evt);
     }
 
@@ -54,8 +81,13 @@ impl InputFilter {
             let evt = FsysEvent::new(source, Kind::ChordedArgument, from, to, &arg);
             _ = self.tx.send(evt);
         }
+        let k = if self.is_scratch {
+            Kind::ExecuteScratch
+        } else {
+            Kind::ExecuteBody
+        };
 
-        let evt = FsysEvent::new(source, Kind::ExecuteBody, ch_from, ch_to, txt);
+        let evt = FsysEvent::new(source, k, ch_from, ch_to, txt);
         _ = self.tx.send(evt);
     }
 }
@@ -111,8 +143,8 @@ pub fn send_event_to_editor(id: usize, s: &str, tx: &Sender<Event>) -> Result<us
 
     let evt = FsysEvent::try_from_str(s)?;
     let req = match evt.kind {
-        Kind::LoadBody | Kind::LoadTag => Req::LoadInBuffer { id, txt: evt.txt },
-        Kind::ExecuteBody | Kind::ExecuteTag => Req::ExecuteInBuffer { id, txt: evt.txt },
+        Kind::LoadBody | Kind::LoadScratch => Req::LoadInBuffer { id, txt: evt.txt },
+        Kind::ExecuteBody | Kind::ExecuteScratch => Req::ExecuteInBuffer { id, txt: evt.txt },
         _ => return Ok(n_bytes_written),
     };
 

--- a/src/fsys/mod.rs
+++ b/src/fsys/mod.rs
@@ -18,8 +18,11 @@
 //! $HOME/.ad/mnt/
 //!   ctl
 //!   minibuffer
+//!   scratch
 //!   log
 //!   buffers/
+//!     current
+//!     index
 //!     [n]/
 //!       filename
 //!       dot
@@ -27,7 +30,7 @@
 //!       body
 //!       event
 //! ```
-use crate::{config_handle, editor::Action, input::Event};
+use crate::{config_handle, editor::Action, input::Event, ui::SCRATCH_ID};
 use ninep::{
     fs::{FileMeta, IoUnit, Mode, Perm, Stat},
     sync::server::{socket_path, ClientId, ReadOutcome, Serve9p, Server},
@@ -77,14 +80,17 @@ const LOG_FILE: &str = "log";
 ///   3    /minibuffer  -> control file for selecting text using the minibuffer
 const MINIBUFFER_QID: u64 = 3;
 const MINIBUFFER: &str = "minibuffer";
+///   4    /scratch     -> control file for reading and appending to the scratch buffer
+const SCRATCH_QID: u64 = 4;
+const SCRATCH: &str = "scratch";
 ///   4    /buffers/    -> parent directory for buffers
-const BUFFERS_QID: u64 = 4;
+const BUFFERS_QID: u64 = 5;
 const BUFFERS_DIR: &str = "buffers";
 //    5      /index     -> a listing of all of the currently open buffers
-const INDEX_BUFFER_QID: u64 = 5;
+const INDEX_BUFFER_QID: u64 = 6;
 const INDEX_BUFFER: &str = "index";
 //    6      /current   -> the fsys filename of the current buffer
-const CURRENT_BUFFER_QID: u64 = 6;
+const CURRENT_BUFFER_QID: u64 = 7;
 const CURRENT_BUFFER: &str = "current";
 
 /// The number of qids required to serve both the directory and contents
@@ -101,10 +107,11 @@ const CURRENT_BUFFER: &str = "current";
 ///   9.   output       -> Write only output connected to stdout/err of commands run within the buffer
 const QID_OFFSET: u64 = 9;
 
-const TOP_LEVEL_QIDS: [u64; 7] = [
+const TOP_LEVEL_QIDS: [u64; 8] = [
     MOUNT_ROOT_QID,
     CONTROL_FILE_QID,
     MINIBUFFER_QID,
+    SCRATCH_QID,
     LOG_FILE_QID,
     BUFFERS_QID,
     INDEX_BUFFER_QID,
@@ -160,6 +167,7 @@ struct State {
     mount_dir_stat: Stat,
     control_file_stat: Stat,
     minibuffer_stat: Stat,
+    scratch_stat: Stat,
     log_file_stat: Stat,
     mount_path: String,
     auto_mount: bool,
@@ -207,19 +215,6 @@ impl State {
         self.open_cids.get(&qid).and_then(|cids| cids.read_locked)
     }
 
-    /// Writing data to the minibuffer causes fsys to buffer the writes internally until the client
-    /// is done. When a client then attempts to read back the selection the full buffer is sent to
-    /// the editor for rendering and the reads block until the user makes a selection.
-    fn minibuffer_write(&mut self, lines: String) -> Result<usize> {
-        let n_bytes = lines.len();
-        match &mut self.minibuffer_content {
-            MiniBufferContent::Buffering(buffer) => buffer.extend_from_slice(lines.as_bytes()),
-            _ => self.minibuffer_content = MiniBufferContent::Buffering(lines.into_bytes()),
-        }
-
-        Ok(n_bytes)
-    }
-
     fn set_active_buffer(&mut self, s: String) -> Result<usize> {
         let id: usize = match s.trim().parse() {
             Ok(n) => n,
@@ -235,6 +230,29 @@ impl State {
         }
 
         Ok(s.len())
+    }
+
+    fn scratch_read(&self, offset: usize, count: usize) -> ReadOutcome {
+        let req = Req::ReadBufferBody { id: SCRATCH_ID };
+        match Message::send(req, &self.tx) {
+            Ok(s) => ReadOutcome::Immediate(apply_offset(s.as_bytes(), offset, count)),
+            Err(e) => {
+                error!("fsys failed to read file content: {e}");
+                ReadOutcome::Immediate(Vec::new())
+            }
+        }
+    }
+
+    fn scratch_write(&mut self, s: String) -> Result<usize> {
+        let n_bytes = s.len();
+        let req = Req::AppendBufferBody { id: SCRATCH_ID, s };
+
+        match Message::send(req, &self.tx) {
+            Ok(_) => Ok(n_bytes),
+            Err(e) => Err(format!(
+                "unable to write to scratch buffer (n_bytes={n_bytes}): {e}",
+            )),
+        }
     }
 
     fn minibuffer_read(&mut self, offset: usize, count: usize) -> ReadOutcome {
@@ -297,6 +315,19 @@ impl State {
             },
         }
     }
+
+    /// Writing data to the minibuffer causes fsys to buffer the writes internally until the client
+    /// is done. When a client then attempts to read back the selection the full buffer is sent to
+    /// the editor for rendering and the reads block until the user makes a selection.
+    fn minibuffer_write(&mut self, lines: String) -> Result<usize> {
+        let n_bytes = lines.len();
+        match &mut self.minibuffer_content {
+            MiniBufferContent::Buffering(buffer) => buffer.extend_from_slice(lines.as_bytes()),
+            _ => self.minibuffer_content = MiniBufferContent::Buffering(lines.into_bytes()),
+        }
+
+        Ok(n_bytes)
+    }
 }
 
 /// The filesystem interface for ad
@@ -332,6 +363,7 @@ impl AdFs {
                 mount_dir_stat: empty_dir_stat(MOUNT_ROOT_QID, "/"),
                 control_file_stat: empty_file_stat(CONTROL_FILE_QID, CONTROL_FILE),
                 minibuffer_stat: empty_file_stat(MINIBUFFER_QID, MINIBUFFER),
+                scratch_stat: empty_file_stat(SCRATCH_QID, SCRATCH),
                 log_file_stat: empty_file_stat(LOG_FILE_QID, LOG_FILE),
                 mount_path,
                 auto_mount,
@@ -399,6 +431,7 @@ impl Serve9p for AdFs {
             MOUNT_ROOT_QID => Ok(s.mount_dir_stat.clone()),
             CONTROL_FILE_QID => Ok(s.control_file_stat.clone()),
             MINIBUFFER_QID => Ok(s.minibuffer_stat.clone()),
+            SCRATCH_QID => Ok(s.scratch_stat.clone()),
             LOG_FILE_QID => Ok(s.log_file_stat.clone()),
             BUFFERS_QID => Ok(s.buffer_nodes.stat().clone()),
             qid => match s.buffer_nodes.get_stat_for_qid(qid) {
@@ -433,6 +466,7 @@ impl Serve9p for AdFs {
             MOUNT_ROOT_QID => match child {
                 CONTROL_FILE => Ok(s.control_file_stat.fm.clone()),
                 MINIBUFFER => Ok(s.minibuffer_stat.fm.clone()),
+                SCRATCH => Ok(s.scratch_stat.fm.clone()),
                 LOG_FILE => Ok(s.log_file_stat.fm.clone()),
                 BUFFERS_DIR => Ok(s.buffer_nodes.stat().fm.clone()),
                 _ => match s.buffer_nodes.lookup_file_stat(parent_qid, child) {
@@ -500,6 +534,8 @@ impl Serve9p for AdFs {
             return Ok(ReadOutcome::Immediate(Vec::new()));
         } else if qid == MINIBUFFER_QID {
             return Ok(s.minibuffer_read(offset, count));
+        } else if qid == SCRATCH_QID {
+            return Ok(s.scratch_read(offset, count));
         } else if qid == LOG_FILE_QID {
             return Ok(s.buffer_nodes.log.events_since_last_read(cid));
         }
@@ -532,6 +568,7 @@ impl Serve9p for AdFs {
             MOUNT_ROOT_QID => Ok(vec![
                 s.log_file_stat.clone(),
                 s.minibuffer_stat.clone(),
+                s.scratch_stat.clone(),
                 s.control_file_stat.clone(),
                 s.buffer_nodes.stat().clone(),
             ]),
@@ -577,6 +614,7 @@ impl Serve9p for AdFs {
             },
 
             MINIBUFFER_QID => s.minibuffer_write(str),
+            SCRATCH_QID => s.scratch_write(str),
             CURRENT_BUFFER_QID => s.set_active_buffer(str),
 
             LOG_FILE_QID | INDEX_BUFFER_QID => Err(E_NOT_ALLOWED.to_string()),

--- a/src/mode/insert.rs
+++ b/src/mode/insert.rs
@@ -14,6 +14,9 @@ pub(crate) fn insert_mode() -> (Mode, Vec<(String, &'static str)>) {
     let (keymap, docs) = keymap! {
         "return to NORMAL mode";
         [ Esc ] => [ SetMode { m: "NORMAL" }, NewEditLogTransaction ],
+        "toggle the visibility of the scratch buffer";
+        [ Alt(';') ] => [ ToggleScratch ],
+
         "backspace";
         [ Backspace ] => [ DotSet(Arr(Left), 1), Delete ],
         "delete";

--- a/src/mode/normal.rs
+++ b/src/mode/normal.rs
@@ -24,6 +24,8 @@ pub(crate) fn normal_mode() -> (Mode, Vec<(String, &'static str)>) {
         [ leader, Char('b') ] => [ SelectBuffer ],
         "search in current buffer";
         [ Char('/') ] => [ SearchInCurrentBuffer ],
+        "toggle the visibility of the scratch buffer";
+        [ Alt(';') ] => [ ToggleScratch ],
         "enter COMMAND mode";
         [ Char(':') ] => [ CommandMode ],
         "enter RUN mode";

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -12,12 +12,18 @@ use std::{cmp::min, io, mem::swap, path::Path, sync::Arc};
 use tracing::debug;
 use unicode_width::UnicodeWidthChar;
 
+const SCRATCH_ID: usize = usize::MAX;
+
 /// Layout is a screen layout of the windows available for displaying buffer
 /// content to the user. The available screen space is split into a number of
 /// columns each containing a vertical stack of windows.
 #[derive(Debug)]
 pub(crate) struct Layout {
+    /// The managed buffer state
     buffers: Buffers,
+    /// An anonymous buffer that sits outside of the main buffer state and acts as though it is the
+    /// active buffer for the purposes of Load/Execute.
+    pub(super) scratch: Scratch,
     /// Available screen width in terms of characters
     pub(crate) screen_rows: usize,
     /// Available screen height in terms of characters
@@ -39,6 +45,7 @@ impl Layout {
 
         Self {
             buffers,
+            scratch: Scratch::new(config_handle!().minibuffer_lines),
             screen_rows,
             screen_cols,
             cols: ziplist![Column::new(screen_rows, screen_cols, &[id])],
@@ -68,14 +75,22 @@ impl Layout {
     /// active Window. This means that if currently a tag has input focus then this method
     /// will return the Buffer the tag is attached to, not the tag itself.
     pub(crate) fn active_buffer(&self) -> &Buffer {
-        self.buffers.active()
+        if self.scratch.is_focused {
+            &self.scratch.b
+        } else {
+            self.buffers.active()
+        }
     }
 
     /// The semantics of active_buffer_mut are to always return the active Buffer held within
     /// the active Window. This means that if currently a tag has input focus then this method
     /// will return the Buffer the tag is attached to, not the tag itself.
     pub(crate) fn active_buffer_mut(&mut self) -> &mut Buffer {
-        self.buffers.active_mut()
+        if self.scratch.is_focused {
+            &mut self.scratch.b
+        } else {
+            self.buffers.active_mut()
+        }
     }
 
     pub(crate) fn buffer_with_id(&self, id: BufferId) -> Option<&Buffer> {
@@ -87,8 +102,13 @@ impl Layout {
     }
 
     fn focus_first_window_with_buffer(&mut self, id: BufferId) {
+        self.scratch.is_focused = false;
         self.cols
             .focus_element_by_mut(|c| c.wins.focus_element_by_mut(|w| w.view.bufid == id));
+    }
+
+    pub(crate) fn toggle_scratch(&mut self) {
+        self.scratch.toggle();
     }
 
     pub(crate) fn open_or_focus<P: AsRef<Path>>(
@@ -96,6 +116,7 @@ impl Layout {
         path: P,
         mut new_window: bool,
     ) -> io::Result<Option<BufferId>> {
+        self.scratch.is_focused = false;
         if self.buffers.is_empty_scratch() {
             // in the case where we only have an empty scratch buffer present, we always
             // replace the current buffer with the one that is newly opened.
@@ -125,6 +146,7 @@ impl Layout {
         content: impl Into<String>,
         new_window: bool,
     ) {
+        self.scratch.is_focused = false;
         let id = self.buffers.open_virtual(name.into(), content.into());
 
         if self.buffer_is_visible(id) {
@@ -146,6 +168,12 @@ impl Layout {
     ///   - if there are no other columns then the "next buffer" is placed in the
     ///     first column
     pub(crate) fn close_buffer(&mut self, id: BufferId) -> bool {
+        self.scratch.is_focused = false;
+        if id == self.scratch.b.id {
+            self.scratch.is_visible = false;
+            return false;
+        }
+
         if self.buffers.len() == 1 {
             // We could have been asked to close a non-existant buffer.
             // If this was the last buffer then Editor::delete_buffer will exit
@@ -193,6 +221,14 @@ impl Layout {
     }
 
     pub(crate) fn focus_id(&mut self, id: BufferId, force_active: bool) {
+        if id == self.scratch.b.id {
+            self.scratch.is_focused = true;
+            self.scratch.is_visible = true;
+            return;
+        }
+
+        self.scratch.is_focused = false;
+
         if let Some(id) = self.buffers.focus_id(id) {
             if !force_active && self.buffer_is_visible(id) {
                 self.focus_first_window_with_buffer(id);
@@ -208,6 +244,7 @@ impl Layout {
     }
 
     pub(crate) fn focus_next_buffer(&mut self) -> BufferId {
+        self.scratch.is_focused = false;
         self.buffers.next();
         let id = self.active_buffer().id;
         self.show_buffer_in_active_window(id);
@@ -216,6 +253,7 @@ impl Layout {
     }
 
     pub(crate) fn focus_previous_buffer(&mut self) -> BufferId {
+        self.scratch.is_focused = false;
         self.buffers.previous();
         let id = self.active_buffer().id;
         self.show_buffer_in_active_window(id);
@@ -226,6 +264,11 @@ impl Layout {
     /// Close the active window, if this was the last remaining window then
     /// Editor::delete_active_window will exit.
     pub(crate) fn close_active_window(&mut self) -> bool {
+        if self.scratch.is_focused {
+            self.scratch.toggle();
+            return false;
+        }
+
         if self.cols.len() == 1 && self.cols.focus.wins.len() == 1 {
             return true;
         }
@@ -246,6 +289,11 @@ impl Layout {
     /// Close the active column, if this was the last remaining column then
     /// Editor::delete_active_column will exit.
     pub(crate) fn close_active_column(&mut self) -> bool {
+        if self.scratch.is_focused {
+            self.scratch.toggle();
+            return false;
+        }
+
         if self.cols.len() == 1 {
             return true;
         }
@@ -306,6 +354,7 @@ impl Layout {
 
     /// Move focus to the column to the right of current focus (wrapping)
     pub(crate) fn next_column(&mut self) {
+        self.scratch.is_focused = false;
         self.cols.focus_down();
         self.buffers.focus_id(self.focused_view().bufid);
         self.force_cursor_to_be_in_view();
@@ -313,6 +362,7 @@ impl Layout {
 
     /// Move focus to the column to the left of current focus (wrapping)
     pub(crate) fn prev_column(&mut self) {
+        self.scratch.is_focused = false;
         self.cols.focus_up();
         self.buffers.focus_id(self.focused_view().bufid);
         self.force_cursor_to_be_in_view();
@@ -320,6 +370,7 @@ impl Layout {
 
     /// Move focus to the window below in the current column (wrapping)
     pub(crate) fn next_window_in_column(&mut self) {
+        self.scratch.is_focused = false;
         self.cols.focus.wins.focus_down();
         self.buffers.focus_id(self.focused_view().bufid);
         self.force_cursor_to_be_in_view();
@@ -327,6 +378,7 @@ impl Layout {
 
     /// Move focus to the window above in the current column (wrapping)
     pub(crate) fn prev_window_in_column(&mut self) {
+        self.scratch.is_focused = false;
         self.cols.focus.wins.focus_up();
         self.buffers.focus_id(self.focused_view().bufid);
         self.force_cursor_to_be_in_view();
@@ -334,11 +386,13 @@ impl Layout {
 
     /// Drag the focused window up through the column containing it (wrapping)
     pub(crate) fn drag_up(&mut self) {
+        self.scratch.is_focused = false;
         self.cols.focus.wins.swap_up();
     }
 
     /// Drag the focused window down through the column containing it (wrapping)
     pub(crate) fn drag_down(&mut self) {
+        self.scratch.is_focused = false;
         self.cols.focus.wins.swap_down();
     }
 
@@ -354,6 +408,7 @@ impl Layout {
     ///   direction is towards other columns then the window is moved to that column
     ///   and the previous column is removed.
     pub(crate) fn drag_left(&mut self) {
+        self.scratch.is_focused = false;
         if self.cols.len() == 1 || self.cols.up.is_empty() {
             if self.cols.focus.wins.len() == 1 {
                 return;
@@ -382,6 +437,7 @@ impl Layout {
     ///
     /// See [Layout::drag_left] for semantics.
     pub(crate) fn drag_right(&mut self) {
+        self.scratch.is_focused = false;
         if self.cols.len() == 1 || self.cols.down.is_empty() {
             if self.cols.focus.wins.len() == 1 {
                 return;
@@ -413,7 +469,11 @@ impl Layout {
     }
 
     pub(crate) fn active_window_rows(&self) -> usize {
-        self.cols.focus.wins.focus.n_rows
+        if self.scratch.is_focused {
+            self.scratch.w.n_rows
+        } else {
+            self.cols.focus.wins.focus.n_rows
+        }
     }
 
     pub(crate) fn update_screen_size(&mut self, rows: usize, cols: usize) {
@@ -439,6 +499,7 @@ impl Layout {
 
     /// Set the currently focused window to contain the given buffer
     pub(crate) fn show_buffer_in_active_window(&mut self, id: BufferId) {
+        self.scratch.is_focused = false;
         if self.focused_view().bufid == id {
             return;
         }
@@ -455,6 +516,7 @@ impl Layout {
     /// Create a new column containing a single window showing the same view found in the
     /// current active window.
     pub(crate) fn new_column(&mut self) {
+        self.scratch.is_focused = false;
         let view = self.focused_view().clone();
         let mut col = Column::new(self.screen_rows, self.screen_cols, &[view.bufid]);
         col.wins.last_mut().view = view;
@@ -466,6 +528,7 @@ impl Layout {
     /// Create a new window at the end of the current column showing the same view
     /// found in the current active window.
     pub(crate) fn new_window(&mut self) {
+        self.scratch.is_focused = false;
         let view = self.focused_view().clone();
         let wins = &mut self.cols.focus.wins;
         wins.insert_at(Position::Tail, Window { n_rows: 0, view });
@@ -475,6 +538,7 @@ impl Layout {
 
     /// Set the currently focused window to contain the given buffer
     pub(crate) fn show_buffer_in_new_window(&mut self, id: BufferId) {
+        self.scratch.is_focused = false;
         let view = if self.focused_view().bufid == id {
             self.focused_view().clone()
         } else {
@@ -498,68 +562,71 @@ impl Layout {
         self.update_screen_size(self.screen_rows, self.screen_cols);
     }
 
-    pub(crate) fn scroll_view(&mut self, x: usize, y: usize, up: bool) {
-        let mut x_offset = 0;
-        let mut y_offset = 0;
-
-        for (focused_col, col) in self.cols.iter_mut() {
-            if x > x_offset + col.n_cols {
-                x_offset += col.n_cols + 1;
-                continue;
-            }
-            for (focused_win, win) in col.wins.iter_mut() {
-                if y > y_offset + win.n_rows {
-                    y_offset += win.n_rows + 1;
-                    continue;
-                }
-
-                let b = self.buffers.with_id_mut(win.view.bufid).unwrap();
-                apply_scroll(b, win, col.n_cols, focused_col && focused_win, up);
-                return;
-            }
-        }
-
-        let n_cols = self.cols.focus.n_cols;
-        let win = &mut self.cols.focus.wins.focus;
-        let b = self.buffers.with_id_mut(win.view.bufid).unwrap();
-        apply_scroll(b, win, n_cols, true, up);
-    }
-
     pub(crate) fn force_cursor_to_be_in_view(&mut self) {
-        let b = self.buffers.active_mut();
-        let cols = self.cols.focus.n_cols;
-        let rows = self.cols.focus.wins.focus.n_rows;
+        if self.scratch.is_focused {
+            self.scratch.w.view.force_cursor_to_be_in_view(
+                &mut self.scratch.b,
+                self.scratch.w.n_rows,
+                self.screen_cols,
+            );
+        } else {
+            let b = self.buffers.active_mut();
+            let cols = self.cols.focus.n_cols;
+            let rows = self.cols.focus.wins.focus.n_rows;
 
-        self.cols
-            .focus
-            .focused_view_mut()
-            .force_cursor_to_be_in_view(b, rows, cols);
+            self.cols
+                .focus
+                .focused_view_mut()
+                .force_cursor_to_be_in_view(b, rows, cols);
+        }
     }
 
     pub(crate) fn clamp_scroll(&mut self) {
-        let b = self.buffers.active_mut();
-        let cols = self.cols.focus.n_cols;
-        let rows = self.cols.focus.wins.focus.n_rows;
+        if self.scratch.is_focused {
+            self.scratch.w.view.clamp_scroll(
+                &mut self.scratch.b,
+                self.scratch.w.n_rows,
+                self.screen_cols,
+            );
+        } else {
+            let b = self.buffers.active_mut();
+            let cols = self.cols.focus.n_cols;
+            let rows = self.cols.focus.wins.focus.n_rows;
 
-        self.cols
-            .focus
-            .focused_view_mut()
-            .clamp_scroll(b, rows, cols);
+            self.cols
+                .focus
+                .focused_view_mut()
+                .clamp_scroll(b, rows, cols);
+        }
     }
 
     pub(crate) fn set_viewport(&mut self, vp: ViewPort) {
-        let b = self.buffers.active_mut();
-        let cols = self.cols.focus.n_cols;
-        let rows = self.cols.focus.wins.focus.n_rows;
+        if self.scratch.is_focused {
+            self.scratch.w.view.set_viewport(
+                &mut self.scratch.b,
+                vp,
+                self.scratch.w.n_rows,
+                self.screen_cols,
+            );
+        } else {
+            let b = self.buffers.active_mut();
+            let cols = self.cols.focus.n_cols;
+            let rows = self.cols.focus.wins.focus.n_rows;
 
-        self.cols
-            .focus
-            .focused_view_mut()
-            .set_viewport(b, vp, rows, cols);
+            self.cols
+                .focus
+                .focused_view_mut()
+                .set_viewport(b, vp, rows, cols);
+        }
     }
 
     /// Coordinate offsets from the top left of the window layout to the top left of the active window.
     fn xy_offsets(&self) -> (usize, usize) {
+        if self.scratch.is_focused {
+            let y_offset = self.screen_rows - self.scratch.w.n_rows + 1; // +1 for status line
+            return (0, y_offset);
+        }
+
         let cols_before = &self.cols.up;
         let wins_above = &self.cols.focus.wins.up;
         let x_offset = cols_before.iter().map(|c| c.n_cols).sum::<usize>() + cols_before.len();
@@ -569,16 +636,40 @@ impl Layout {
     }
 
     /// Locate the absolute cursor position based on the current window layout
-    pub(crate) fn ui_xy(&self, b: &Buffer) -> (usize, usize) {
+    pub(crate) fn ui_xy(&self) -> (usize, usize) {
         let (x_offset, y_offset) = self.xy_offsets();
-        let (x, y) = self.focused_view().ui_xy(b);
+        let (x, y) = if self.scratch.is_focused {
+            self.scratch.w.view.ui_xy(&self.scratch.b)
+        } else {
+            self.focused_view().ui_xy(self.active_buffer())
+        };
 
         (x + x_offset, y + y_offset)
     }
 
+    // TODO: the scratch buffer needs to be taken into account for mouse interactions:
+    // - Load / Exec is going to need to be behave differently but that is driven by pulling the
+    //   active buffer from Layout so it should be possible without messing with Buffer
+    // - The stub event types for the Tag instead need to be used for the scratch buffer
+
+    /// Whether or not the given screen row is within a visible scratch buffer
+    fn row_is_scratch(&self, y: usize) -> bool {
+        if !self.scratch.is_visible {
+            return false;
+        }
+
+        y > (self.screen_rows - self.scratch.w.n_rows + 1)
+    }
+
+    /// If the given coordinates lie within the scratch buffer return None, otherwise return the ID
+    /// of the buffer containing the point.
     fn buffer_for_screen_coords(&self, x: usize, y: usize) -> BufferId {
         let mut x_offset = 0;
         let mut y_offset = 0;
+
+        if self.row_is_scratch(y) {
+            return SCRATCH_ID;
+        }
 
         for (_, col) in self.cols.iter() {
             if x > x_offset + col.n_cols {
@@ -601,6 +692,13 @@ impl Layout {
     fn focus_buffer_for_screen_coords(&mut self, x: usize, y: usize) -> BufferId {
         let mut x_offset = 0;
         let mut y_offset = 0;
+
+        if self.row_is_scratch(y) {
+            self.scratch.is_focused = true;
+            return SCRATCH_ID;
+        }
+
+        self.scratch.is_focused = false;
 
         self.cols.focus_head();
         for _ in 0..self.cols.len() {
@@ -628,35 +726,16 @@ impl Layout {
         self.active_buffer().id
     }
 
-    /// Determine the cursor position for a given set of coordinates and report whether or not
-    /// these coordinates are inside of the currently active buffer (or tag).
-    pub(crate) fn try_active_cur_from_screen_coords(&mut self, x: usize, y: usize) -> Option<Cur> {
-        let id = self.buffer_for_screen_coords(x, y);
-        let is_active = id == self.active_buffer().id;
-
-        if is_active {
-            Some(self.cur_from_screen_coords(x, y))
-        } else {
-            None
-        }
-    }
-
-    /// Focus the buffer (or tag) containing the given screen coordinates and return the current
-    /// cursor position for updating held mouse state.
-    pub(crate) fn focus_cur_from_screen_coords(&mut self, x: usize, y: usize) -> (BufferId, Cur) {
-        let bufid = self.focus_buffer_for_screen_coords(x, y);
-        let cur = self.cur_from_screen_coords(x, y);
-
-        (bufid, cur)
-    }
-
     /// Map a given (x, y) point into a Cur for the active buffer or tag
     fn cur_from_screen_coords(&mut self, x: usize, y: usize) -> Cur {
         let (x_offset, y_offset) = self.xy_offsets();
-        let win = &mut self.cols.focus.wins.focus;
-        let row_off = win.view.row_off;
+        let (b, win) = if self.scratch.is_focused {
+            (&mut self.scratch.b, &mut self.scratch.w)
+        } else {
+            (self.buffers.active_mut(), &mut self.cols.focus.wins.focus)
+        };
 
-        let b = self.buffers.active_mut();
+        let row_off = win.view.row_off;
 
         let (_, w_sgncol) = b.sign_col_dims();
         let rx = x
@@ -674,17 +753,75 @@ impl Layout {
         cur
     }
 
+    /// Determine the cursor position for a given set of coordinates and report whether or not
+    /// these coordinates are inside of the currently active buffer (or tag).
+    pub(crate) fn try_active_cur_from_screen_coords(&mut self, x: usize, y: usize) -> Option<Cur> {
+        let id = self.buffer_for_screen_coords(x, y);
+        if id == self.active_buffer().id {
+            Some(self.cur_from_screen_coords(x, y))
+        } else {
+            None
+        }
+    }
+
+    /// Focus the buffer (or tag) containing the given screen coordinates and return the current
+    /// cursor position for updating held mouse state.
+    pub(crate) fn focus_cur_from_screen_coords(&mut self, x: usize, y: usize) -> (BufferId, Cur) {
+        let bufid = self.focus_buffer_for_screen_coords(x, y);
+        let cur = self.cur_from_screen_coords(x, y);
+
+        (bufid, cur)
+    }
+
     /// Set the active buffer and dot based on a mouse click.
     ///
     /// Returns true if the click was in the currently active buffer and false if this click has
     /// changed the active buffer.
     pub(crate) fn set_dot_from_screen_coords(&mut self, x: usize, y: usize) -> bool {
-        let current_bufid = self.buffers.active().id;
+        let current_bufid = self.active_buffer().id;
         let bufid = self.focus_buffer_for_screen_coords(x, y);
         let c = self.cur_from_screen_coords(x, y);
-        self.buffers.active_mut().dot = Dot::Cur { c };
+        self.active_buffer_mut().dot = Dot::Cur { c };
 
         bufid == current_bufid
+    }
+
+    /// Scroll the [View] under the given cursor coordinates up or down by a single line
+    pub(crate) fn scroll_view(&mut self, x: usize, y: usize, up: bool) {
+        let mut x_offset = 0;
+        let mut y_offset = 0;
+
+        if self.row_is_scratch(y) {
+            return apply_scroll(
+                &mut self.scratch.b,
+                &mut self.scratch.w,
+                self.screen_cols,
+                self.scratch.is_focused,
+                up,
+            );
+        }
+
+        for (focused_col, col) in self.cols.iter_mut() {
+            if x > x_offset + col.n_cols {
+                x_offset += col.n_cols + 1;
+                continue;
+            }
+            for (focused_win, win) in col.wins.iter_mut() {
+                if y > y_offset + win.n_rows {
+                    y_offset += win.n_rows + 1;
+                    continue;
+                }
+
+                let b = self.buffers.with_id_mut(win.view.bufid).unwrap();
+                apply_scroll(b, win, col.n_cols, focused_col && focused_win, up);
+                return;
+            }
+        }
+
+        let n_cols = self.cols.focus.n_cols;
+        let win = &mut self.cols.focus.wins.focus;
+        let b = self.buffers.with_id_mut(win.view.bufid).unwrap();
+        apply_scroll(b, win, n_cols, true, up);
     }
 
     pub(crate) fn update_visible_ts_state(&mut self) {
@@ -747,6 +884,33 @@ impl Column {
     #[inline]
     fn focused_view_mut(&mut self) -> &mut View {
         &mut self.wins.focus.view
+    }
+}
+
+/// State for the scratch buffer
+#[derive(Debug)]
+pub(super) struct Scratch {
+    pub(super) b: Buffer,
+    pub(super) w: Window,
+    pub(super) is_visible: bool,
+    pub(super) is_focused: bool,
+}
+
+impl Scratch {
+    // n_rows is read from config on startup but then not modified after that
+    fn new(n_rows: usize) -> Self {
+        Self {
+            b: Buffer::new_virtual(SCRATCH_ID, "*scratch*", ""),
+            w: Window::new(n_rows, SCRATCH_ID),
+            is_visible: false,
+            is_focused: false,
+        }
+    }
+
+    /// Toggle the visibility of the scratch buffer and focus it if opening.
+    fn toggle(&mut self) {
+        self.is_visible = !self.is_visible;
+        self.is_focused = self.is_visible;
     }
 }
 
@@ -950,6 +1114,7 @@ mod tests {
         let (tx, _) = channel();
         let mut ws = Layout {
             buffers: Buffers::new_stubbed(&all_ids, tx),
+            scratch: Scratch::new(n_rows),
             screen_rows: n_rows,
             screen_cols: n_cols,
             cols: ZipList::try_from_iter(cols).unwrap(),

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -71,9 +71,17 @@ impl Layout {
             .any(|(_, c)| c.wins.iter().any(|(_, w)| w.view.bufid == id))
     }
 
-    /// The semantics of active_buffer are to always return the active Buffer held within the
-    /// active Window. This means that if currently a tag has input focus then this method
-    /// will return the Buffer the tag is attached to, not the tag itself.
+    /// Returns the active buffer, ignoring whether or not the scratch buffer is focused
+    pub(crate) fn active_buffer_ignoring_scratch(&self) -> &Buffer {
+        self.buffers.active()
+    }
+
+    /// Returns the active buffer, ignoring whether or not the scratch buffer is focused
+    pub(crate) fn active_buffer_mut_ignoring_scratch(&mut self) -> &mut Buffer {
+        self.buffers.active_mut()
+    }
+
+    /// Returns the active buffer or the scratch buffer if it is focused
     pub(crate) fn active_buffer(&self) -> &Buffer {
         if self.scratch.is_focused {
             &self.scratch.b
@@ -82,9 +90,7 @@ impl Layout {
         }
     }
 
-    /// The semantics of active_buffer_mut are to always return the active Buffer held within
-    /// the active Window. This means that if currently a tag has input focus then this method
-    /// will return the Buffer the tag is attached to, not the tag itself.
+    /// Returns the active buffer or the scratch buffer if it is focused
     pub(crate) fn active_buffer_mut(&mut self) -> &mut Buffer {
         if self.scratch.is_focused {
             &mut self.scratch.b

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -4,12 +4,13 @@ use crate::{
     config_handle,
     dot::{Cur, Dot},
     editor::ViewPort,
+    fsys::InputFilter,
     lsp::LspManagerHandle,
     ziplist,
     ziplist::{Position, ZipList},
 };
 use std::{cmp::min, io, mem::swap, path::Path, sync::Arc};
-use tracing::debug;
+use tracing::{debug, warn};
 use unicode_width::UnicodeWidthChar;
 
 const SCRATCH_ID: usize = usize::MAX;
@@ -653,11 +654,6 @@ impl Layout {
         (x + x_offset, y + y_offset)
     }
 
-    // TODO: the scratch buffer needs to be taken into account for mouse interactions:
-    // - Load / Exec is going to need to be behave differently but that is driven by pulling the
-    //   active buffer from Layout so it should be possible without messing with Buffer
-    // - The stub event types for the Tag instead need to be used for the scratch buffer
-
     /// Whether or not the given screen row is within a visible scratch buffer
     fn row_is_scratch(&self, y: usize) -> bool {
         if !self.scratch.is_visible {
@@ -838,10 +834,37 @@ impl Layout {
         });
 
         for (bufid, from, n_rows) in it {
-            // SAFETY: we know this id is valid
-            let b = unsafe { self.buffers.with_id_mut(bufid).unwrap_unchecked() };
+            let b = self.buffers.with_id_mut(bufid).unwrap();
             b.update_ts_state(from, n_rows);
         }
+    }
+
+    /// Returns `true` if the filter was successfully set, false if there was already one in place.
+    pub(crate) fn try_set_input_filter(&mut self, bufid: BufferId, filter: InputFilter) -> bool {
+        let b = match self.buffer_with_id_mut(bufid) {
+            Some(b) => b,
+            None => return false,
+        };
+
+        if b.input_filter.is_some() {
+            warn!("attempt to set an input filter when one is already in place. id={bufid:?}");
+            return false;
+        }
+
+        let scratch_filter = filter.paired_tag_filter();
+        b.input_filter = Some(filter);
+        self.scratch.b.input_filter = Some(scratch_filter);
+
+        true
+    }
+
+    /// Remove the input filter for the given buffer if one exists.
+    pub(crate) fn clear_input_filter(&mut self, bufid: usize) {
+        if let Some(b) = self.buffer_with_id_mut(bufid) {
+            b.input_filter = None;
+        }
+
+        self.scratch.b.input_filter = None;
     }
 }
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,7 +1,7 @@
 //! Layout of UI windows
 use crate::{
     buffer::{Buffer, BufferId, Buffers},
-    config_handle,
+    config_handle, die,
     dot::{Cur, Dot},
     editor::ViewPort,
     fsys::InputFilter,
@@ -131,7 +131,7 @@ impl Layout {
         }
 
         let opt = self.buffers.open_or_focus(path)?;
-        let id = self.active_buffer().id;
+        let id = self.active_buffer_ignoring_scratch().id;
 
         if self.buffer_is_visible(id) {
             self.focus_first_window_with_buffer(id);
@@ -159,9 +159,9 @@ impl Layout {
         if self.buffer_is_visible(id) {
             self.focus_first_window_with_buffer(id);
         } else if new_window {
-            self.show_buffer_in_new_window(self.active_buffer().id);
+            self.show_buffer_in_new_window(id);
         } else {
-            self.show_buffer_in_active_window(self.active_buffer().id);
+            self.show_buffer_in_active_window(id);
         }
     }
 
@@ -184,13 +184,13 @@ impl Layout {
         if self.buffers.len() == 1 {
             // We could have been asked to close a non-existant buffer.
             // If this was the last buffer then Editor::delete_buffer will exit
-            return self.active_buffer().id == id;
+            return self.active_buffer_ignoring_scratch().id == id;
         }
 
         debug_assert!(self.buffers.len() > 1, "we have at least two buffers");
         self.views.retain(|v| v.bufid != id);
         self.buffers.close_buffer(id);
-        let focused_id = self.active_buffer().id;
+        let focused_id = self.active_buffer_ignoring_scratch().id;
         let ix = self.views.iter().position(|v| v.bufid == id);
         let existing_view = ix.map(|ix| self.views.remove(ix));
 
@@ -329,7 +329,7 @@ impl Layout {
     pub(crate) fn jump_forward(&mut self) -> Option<BufferId> {
         let maybe_ids = self.buffers.jump_list_forward();
         if let Some((prev_id, new_id)) = maybe_ids {
-            self.show_buffer_in_active_window(self.active_buffer().id);
+            self.show_buffer_in_active_window(self.active_buffer_ignoring_scratch().id);
             self.set_viewport(ViewPort::Center);
             if new_id != prev_id {
                 return Some(new_id);
@@ -342,7 +342,7 @@ impl Layout {
     pub(crate) fn jump_backward(&mut self) -> Option<BufferId> {
         let maybe_ids = self.buffers.jump_list_backward();
         if let Some((prev_id, new_id)) = maybe_ids {
-            self.show_buffer_in_active_window(self.active_buffer().id);
+            self.show_buffer_in_active_window(self.active_buffer_ignoring_scratch().id);
             self.set_viewport(ViewPort::Center);
             if new_id != prev_id {
                 return Some(new_id);
@@ -814,7 +814,10 @@ impl Layout {
                     continue;
                 }
 
-                let b = self.buffers.with_id_mut(win.view.bufid).unwrap();
+                let b = self
+                    .buffers
+                    .with_id_mut(win.view.bufid)
+                    .unwrap_or_else(|| die!("layout state contains an unknown buffer ID"));
                 apply_scroll(b, win, col.n_cols, focused_col && focused_win, up);
                 return;
             }
@@ -834,7 +837,11 @@ impl Layout {
         });
 
         for (bufid, from, n_rows) in it {
-            let b = self.buffers.with_id_mut(bufid).unwrap();
+            let b = self
+                .buffers
+                .with_id_mut(bufid)
+                .unwrap_or_else(|| die!("layout state contains an unknown buffer ID"));
+
             b.update_ts_state(from, n_rows);
         }
     }
@@ -878,12 +885,9 @@ pub(crate) struct Column {
 
 impl Column {
     pub(crate) fn new(n_rows: usize, n_cols: usize, buf_ids: &[BufferId]) -> Self {
-        if buf_ids.is_empty() {
-            panic!("cant have an empty column");
-        }
         let win_rows = n_rows / buf_ids.len();
-        let mut wins =
-            ZipList::try_from_iter(buf_ids.iter().map(|id| Window::new(win_rows, *id))).unwrap();
+        let mut wins = ZipList::try_from_iter(buf_ids.iter().map(|id| Window::new(win_rows, *id)))
+            .expect("can't have an empty column");
 
         let slop = n_rows - (win_rows * buf_ids.len()) + buf_ids.len() - 1;
         wins.focus.n_rows += slop;

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -13,7 +13,7 @@ use std::{cmp::min, io, mem::swap, path::Path, sync::Arc};
 use tracing::{debug, warn};
 use unicode_width::UnicodeWidthChar;
 
-const SCRATCH_ID: usize = usize::MAX;
+pub(crate) const SCRATCH_ID: usize = usize::MAX;
 
 /// Layout is a screen layout of the windows available for displaying buffer
 /// content to the user. The available screen space is split into a number of
@@ -24,7 +24,7 @@ pub(crate) struct Layout {
     buffers: Buffers,
     /// An anonymous buffer that sits outside of the main buffer state and acts as though it is the
     /// active buffer for the purposes of Load/Execute.
-    pub(super) scratch: Scratch,
+    pub(crate) scratch: Scratch,
     /// Available screen width in terms of characters
     pub(crate) screen_rows: usize,
     /// Available screen height in terms of characters
@@ -918,8 +918,8 @@ impl Column {
 
 /// State for the scratch buffer
 #[derive(Debug)]
-pub(super) struct Scratch {
-    pub(super) b: Buffer,
+pub(crate) struct Scratch {
+    pub(crate) b: Buffer,
     pub(super) w: Window,
     pub(super) is_visible: bool,
     pub(super) is_focused: bool,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc::Sender;
 mod layout;
 mod tui;
 
-pub(crate) use layout::Layout;
+pub(crate) use layout::{Layout, SCRATCH_ID};
 pub use tui::Tui;
 
 pub(crate) trait UserInterface {

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -332,6 +332,12 @@ impl UserInterface for Tui {
             _ => None,
         };
 
+        let (load_exec_range, scratch_load_exec_range) = if layout.scratch.is_focused {
+            (None, load_exec_range)
+        } else {
+            (load_exec_range, None)
+        };
+
         // We need space for each visible line plus the two commands to hide/show the cursor
         let mut lines = Vec::with_capacity(self.screen_rows + 2);
         lines.push(format!("{}{}", Cursor::Hide, Cursor::ToStart));
@@ -350,7 +356,7 @@ impl UserInterface for Tui {
         } else if layout.scratch.is_visible {
             lines.extend(WinIter::new_scratch_iter(
                 &layout.scratch,
-                load_exec_range,
+                scratch_load_exec_range,
                 self.screen_cols,
                 tabstop,
                 cs,

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -356,7 +356,8 @@ impl UserInterface for Tui {
                 cs,
                 self.style_cache.clone(),
             ));
-        } else {
+        }
+        if !w_minibuffer {
             lines.push(self.render_message_bar(cs, pending_keys, status_timeout));
         }
 

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     ts::{LineIter, RangeToken},
     ui::{
-        layout::{Column, Window},
+        layout::{Column, Scratch, Window},
         Layout, StateChange, UserInterface,
     },
     ziplist, ORIGINAL_TERMIOS,
@@ -297,19 +297,33 @@ impl UserInterface for Tui {
     ) {
         self.screen_rows = layout.screen_rows;
         self.screen_cols = layout.screen_cols;
+
+        let conf = config_handle!();
+        let (cs, status_timeout, tabstop, max_mb_lines) = (
+            &conf.colorscheme,
+            conf.status_timeout,
+            conf.tabstop,
+            conf.minibuffer_lines,
+        );
+
+        // If we have a minibuffer open then that takes priority over an open scratch buffer
         let w_minibuffer = mb.is_some();
         let mb = mb.unwrap_or_default();
         let active_buffer = layout.active_buffer();
-        let mb_lines = mb.b.map(|b| b.len_lines()).unwrap_or_default();
-        let mb_offset = if mb_lines > 0 { 1 } else { 0 };
+
+        let mb_has_lines = mb.b.map(|b| !b.is_empty()).unwrap_or_default();
+        let offset = if mb_has_lines {
+            mb.bottom - mb.top + 1
+        } else if !w_minibuffer && layout.scratch.is_visible {
+            max_mb_lines
+        } else {
+            0
+        };
 
         // This is the screen size that we have to work with for the buffer content we currently want to
         // display. If the minibuffer is active then it take priority over anything else and we always
         // show the status bar as the final two lines of the UI.
-        let effective_screen_rows = self.screen_rows - (mb.bottom - mb.top) - mb_offset;
-
-        let conf = config_handle!();
-        let (cs, status_timeout, tabstop) = (&conf.colorscheme, conf.status_timeout, conf.tabstop);
+        let effective_screen_rows = self.screen_rows - offset;
 
         let load_exec_range = match held_click {
             Some(click) if click.btn == MouseButton::Right || click.btn == MouseButton::Middle => {
@@ -333,6 +347,15 @@ impl UserInterface for Tui {
 
         if w_minibuffer {
             lines.append(&mut self.render_minibuffer_state(&mb, tabstop, cs));
+        } else if layout.scratch.is_visible {
+            lines.extend(WinIter::new_scratch_iter(
+                &layout.scratch,
+                load_exec_range,
+                self.screen_cols,
+                tabstop,
+                cs,
+                self.style_cache.clone(),
+            ));
         } else {
             lines.push(self.render_message_bar(cs, pending_keys, status_timeout));
         }
@@ -341,7 +364,7 @@ impl UserInterface for Tui {
         let (x, y) = if w_minibuffer {
             (mb.cx, self.screen_rows + mb.n_visible_lines + 1)
         } else {
-            layout.ui_xy(active_buffer)
+            layout.ui_xy()
         };
         lines.push(format!("{}{}", Cursor::To(x + 1, y + 1), Cursor::Show));
 
@@ -528,6 +551,38 @@ struct WinIter<'a> {
     w: &'a Window,
     cs: &'a ColorScheme,
     style_cache: Rc<RefCell<HashMap<String, String>>>,
+}
+
+impl<'a> WinIter<'a> {
+    fn new_scratch_iter(
+        scratch: &'a Scratch,
+        load_exec_range: Option<(bool, Range)>,
+        n_cols: usize,
+        tabstop: usize,
+        cs: &'a ColorScheme,
+        style_cache: Rc<RefCell<HashMap<String, String>>>,
+    ) -> Self {
+        let b = &scratch.b;
+        let (w_lnum, _) = b.sign_col_dims();
+        let rng = if scratch.is_focused {
+            load_exec_range
+        } else {
+            None
+        };
+        let it = b.iter_tokenized_lines_from(scratch.w.view.row_off, rng);
+
+        WinIter {
+            y: 0,
+            w_lnum,
+            n_cols,
+            tabstop,
+            it,
+            gb: &b.txt,
+            w: &scratch.w,
+            cs,
+            style_cache,
+        }
+    }
 }
 
 impl Iterator for WinIter<'_> {


### PR DESCRIPTION
Instead of the acme style tag approach in #112 this instead adds a single scratch buffer that can be shown and hidden in the same position as the mini-buffer. In acme semantics it acts like a dynamic tag that is always associated with the active window but you can show and hide it on demand rather than it always being part of the UI, so loading and executing from the tag acts as though you had done so from the body of the buffer directly.

Currently `Alt-;` is bound in both normal and insert mode for toggling the visibility of the scratch buffer, with it being auto-focused whenever it is made visible.

### TODO
- [x] copy over input filters as the active buffer changes so that input from the scratch buffer is passed along as with acme tags
- [x] add the scratch buffer as a control file in fsys with semantics similar to buffer body files


https://github.com/user-attachments/assets/9ab21ca8-e143-4683-9bf3-fe3265778ed2


