### PR TITLE
Issue #98 -resizing window and columns

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,9 @@
 :: TODO
 
+-- BUGS --
+
+- [ ] src/ts.rs:638 is getting passed completely invalid indices that result in a crash
+
 -- Misc / Editor features --
 
 - [ ] Add line commenting for known languages

--- a/src/buffer/buffers.rs
+++ b/src/buffer/buffers.rs
@@ -45,6 +45,16 @@ impl Buffers {
     }
 
     #[cfg(test)]
+    pub(crate) fn new_with_raw_sender(tx_req: Sender<Req>) -> Self {
+        Self {
+            next_id: 1,
+            inner: ziplist![Buffer::new_unnamed(0, "")],
+            jump_list: JumpList::default(),
+            lsp_handle: Arc::new(LspManagerHandle::new_stubbed(tx_req)),
+        }
+    }
+
+    #[cfg(test)]
     pub(crate) fn new_stubbed(ids: &[usize], tx_req: Sender<Req>) -> Self {
         Self {
             next_id: ids.last().unwrap() + 1,
@@ -59,7 +69,7 @@ impl Buffers {
     }
 
     /// Returns the id of a newly created buffer, None if the buffer already existed
-    pub fn open_or_focus<P: AsRef<Path>>(&mut self, path: P) -> io::Result<Option<BufferId>> {
+    pub fn open_or_focus<P: AsRef<Path>>(&mut self, path: P, retain_empty_unnamed: bool) -> io::Result<Option<BufferId>> {
         let path = match path.as_ref().canonicalize() {
             Ok(p) => p,
             Err(e) if e.kind() == ErrorKind::NotFound => path.as_ref().to_path_buf(),
@@ -87,8 +97,9 @@ impl Buffers {
         let mut b = Buffer::new_from_canonical_file_path(id, path)?;
         self.lsp_handle.document_opened(&b);
 
-        // Remove an empty scratch buffer if the user has now opened a file
-        if self.is_empty_scratch() {
+        // Remove an empty unnamed buffer if the user has now opened a file and we have not
+        // been told to retain it (typically because we have an open window showing it)
+        if !retain_empty_unnamed && self.is_empty_scratch() {
             mem::swap(&mut self.inner.focus, &mut b);
         } else {
             self.record_jump_position();

--- a/src/buffer/buffers.rs
+++ b/src/buffer/buffers.rs
@@ -69,7 +69,11 @@ impl Buffers {
     }
 
     /// Returns the id of a newly created buffer, None if the buffer already existed
-    pub fn open_or_focus<P: AsRef<Path>>(&mut self, path: P, retain_empty_unnamed: bool) -> io::Result<Option<BufferId>> {
+    pub fn open_or_focus<P: AsRef<Path>>(
+        &mut self,
+        path: P,
+        retain_empty_unnamed: bool,
+    ) -> io::Result<Option<BufferId>> {
         let path = match path.as_ref().canonicalize() {
             Ok(p) => p,
             Err(e) if e.kind() == ErrorKind::NotFound => path.as_ref().to_path_buf(),

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -109,6 +109,8 @@ pub enum Action {
     ReloadBuffer { id: usize },
     ReloadConfig,
     RenameActiveBuffer { name: String },
+    ResizeActiveColumn { delta: i16 },
+    ResizeActiveWindow { delta: i16 },
     RunMode,
     SamMode,
     SaveBuffer { force: bool },

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -47,6 +47,10 @@ pub enum ViewPort {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
     AppendToOutputBuffer { bufid: usize, content: String },
+    BalanceActiveColumn,
+    BalanceAll,
+    BalanceColumns,
+    BalanceWindows,
     ChangeDirectory { path: Option<String> },
     CleanupChild { id: u32 },
     ClearScratch,

--- a/src/editor/built_in_commands.rs
+++ b/src/editor/built_in_commands.rs
@@ -13,6 +13,22 @@ pub fn built_in_commands() -> Vec<(Vec<&'static str>, &'static str)> {
             "switch to the previous available open buffer in the buffer list",
         ),
         (
+            vec!["balance-all"],
+            "force columns to be the same width and all windows to be the same size withing their respective columns"
+        ),
+        (
+            vec!["balance-column"],
+            "force all windows in the current column to be the same size"
+        ),
+        (
+            vec!["balance-columns"],
+            "force all columns to be the same width"
+        ),
+        (
+            vec!["balance-windows"],
+            "force all windows to be the same size within their respective columns"
+        ),
+        (
             vec!["cd", "change-directory"],
             "change ad's working directory ('cd ../src')",
         ),
@@ -110,11 +126,11 @@ pub fn built_in_commands() -> Vec<(Vec<&'static str>, &'static str)> {
             "rename the active buffer so that subsequent file operations will apply to the new path"
         ),
         (
-            vec!["resize-col"],
+            vec!["resize-column"],
             "resize the active layout column by a given delta of characters",
         ),
         (
-            vec!["resize-win"],
+            vec!["resize-window"],
             "resize the active window by a given delta of rows",
         ),
         (

--- a/src/editor/built_in_commands.rs
+++ b/src/editor/built_in_commands.rs
@@ -110,6 +110,14 @@ pub fn built_in_commands() -> Vec<(Vec<&'static str>, &'static str)> {
             "rename the active buffer so that subsequent file operations will apply to the new path"
         ),
         (
+            vec!["resize-col"],
+            "resize the active layout column by a given delta of characters",
+        ),
+        (
+            vec!["resize-win"],
+            "resize the active window by a given delta of rows",
+        ),
+        (
             vec!["set"],
             "set a config property ('set bg-color=#ebdbb2')",
         ),

--- a/src/editor/commands.rs
+++ b/src/editor/commands.rs
@@ -143,6 +143,15 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
             name: args.to_string(),
         })),
 
+        "resize-col" => match args.parse::<i16>() {
+            Ok(delta) => Ok(Single(ResizeActiveColumn { delta })),
+            Err(_) => Err(format!("'{args}' is not a valid delta")),
+        },
+        "resize-win" => match args.parse::<i16>() {
+            Ok(delta) => Ok(Single(ResizeActiveWindow { delta })),
+            Err(_) => Err(format!("'{args}' is not a valid delta")),
+        },
+
         "set" => Ok(Single(UpdateConfig {
             input: input.to_string(),
         })),

--- a/src/editor/commands.rs
+++ b/src/editor/commands.rs
@@ -32,6 +32,11 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
         "prev-column" => Ok(Single(PreviousColumn)),
         "prev-window" => Ok(Single(PreviousWindowInColumn)),
 
+        "balance-all" => Ok(Single(BalanceAll)),
+        "balance-column" => Ok(Single(BalanceActiveColumn)),
+        "balance-columns" => Ok(Single(BalanceColumns)),
+        "balance-windows" => Ok(Single(BalanceWindows)),
+
         "cd" | "change-directory" => {
             if args.is_empty() {
                 Ok(Single(ChangeDirectory { path: None }))
@@ -143,11 +148,11 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
             name: args.to_string(),
         })),
 
-        "resize-col" => match args.parse::<i16>() {
+        "resize-column" => match args.parse::<i16>() {
             Ok(delta) => Ok(Single(ResizeActiveColumn { delta })),
             Err(_) => Err(format!("'{args}' is not a valid delta")),
         },
-        "resize-win" => match args.parse::<i16>() {
+        "resize-window" => match args.parse::<i16>() {
             Ok(delta) => Ok(Single(ResizeActiveWindow { delta })),
             Err(_) => Err(format!("'{args}' is not a valid delta")),
         },

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -530,6 +530,8 @@ where
             ReloadActiveBuffer => self.reload_active_buffer(),
             ReloadBuffer { id } => self.reload_buffer(id),
             ReloadConfig => self.reload_config(),
+            ResizeActiveColumn { delta } => self.layout.resize_active_column(delta),
+            ResizeActiveWindow { delta } => self.layout.resize_active_window(delta),
             RunMode => self.run_mode(),
             SamMode => self.sam_mode(),
             SaveBufferAs { path, force } => self.save_current_buffer(Some(path), force),

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -115,7 +115,7 @@ where
         set_config(cfg);
 
         let lsp_manager = Arc::new(LspManager::spawn(tx_events.clone()));
-        let mut layout = Layout::new(0, 0, lsp_manager.clone());
+        let mut layout = Layout::new(100, 100, lsp_manager.clone());
         if show_splash && layout.is_empty_scratch() {
             layout
                 .active_buffer_mut_ignoring_scratch()
@@ -416,6 +416,10 @@ where
             AppendToOutputBuffer { bufid, content } => self
                 .layout
                 .write_output_for_buffer(bufid, content, &self.cwd),
+            BalanceActiveColumn => self.layout.balance_active_column(),
+            BalanceAll => self.layout.balance_all(),
+            BalanceColumns => self.layout.balance_columns(),
+            BalanceWindows => self.layout.balance_windows(),
             ChangeDirectory { path } => self.change_directory(path),
             CleanupChild { id } => self.system.cleanup_child(id),
             ClearScratch => self.layout.scratch.b.clear(),

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -18,6 +18,34 @@ use unicode_width::UnicodeWidthChar;
 /// doing something _very_ strange...
 pub(crate) const SCRATCH_ID: usize = usize::MAX;
 
+/// Similar to in ../buffer/internal.rs:/assert_line_endings/ this is used to hunt for exactly
+/// _where_ state becomes invalid between the actual buffer state in Buffers and the layout
+/// state referencing what should always be known IDs in Layout. This macro should be called
+/// at all points where the buffers & views are created / destroyed, as well as any time that
+/// views change their IDs. It should always be wrapped with #[cfg(test)] so that it doesn't
+/// affect the performance of the editor when it is actually in use.
+#[cfg(test)]
+macro_rules! assert_buffer_ids {
+    ($self:expr) => {{
+        for (i, (_, col)) in $self.cols.iter().enumerate() {
+            for (j, (_, win)) in col.wins.iter().enumerate() {
+                assert!(
+                    $self.buffers.contains_bufid(win.view.bufid),
+                    "col {i} window {j} held unknown bufid ({})",
+                    win.view.bufid
+                )
+            }
+        }
+        for view in $self.views.iter() {
+            assert!(
+                $self.buffers.contains_bufid(view.bufid),
+                "stored view held unknown bufid ({})",
+                view.bufid
+            )
+        }
+    }};
+}
+
 /// Layout is a screen layout of the windows available for displaying buffer
 /// content to the user. The available screen space is split into a number of
 /// columns each containing a vertical stack of windows.
@@ -47,22 +75,35 @@ impl Layout {
         let buffers = Buffers::new(lsp_handle);
         let id = buffers.active().id;
 
-        Self {
+        let l = Self {
             buffers,
             scratch: Scratch::new(config_handle!().minibuffer_lines),
             screen_rows,
             screen_cols,
             cols: ziplist![Column::new(screen_rows, screen_cols, &[id])],
             views: vec![],
-        }
+        };
+
+        #[cfg(test)]
+        assert_buffer_ids!(l);
+
+        l
     }
 
     pub(crate) fn buffers(&self) -> &Buffers {
         &self.buffers
     }
 
+    /// The number of currently visible windows
+    pub(crate) fn n_open_windows(&self) -> usize {
+        self.cols.iter().map(|(_, c)| c.wins.len()).sum()
+    }
+
     pub(crate) fn ensure_file_is_open(&mut self, path: &str) {
-        self.buffers.ensure_file_is_open(path)
+        self.buffers.ensure_file_is_open(path);
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
     }
 
     pub(crate) fn is_empty_scratch(&self) -> bool {
@@ -133,7 +174,8 @@ impl Layout {
             new_window = false;
         }
 
-        let opt = self.buffers.open_or_focus(path)?;
+        let retain_empty_unnamed = new_window || self.n_open_windows() > 1;
+        let opt = self.buffers.open_or_focus(path, retain_empty_unnamed)?;
         let id = self.active_buffer_ignoring_scratch().id;
 
         if self.buffer_is_visible(id) {
@@ -143,6 +185,9 @@ impl Layout {
         } else {
             self.show_buffer_in_active_window(id);
         }
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
 
         Ok(opt)
     }
@@ -166,6 +211,9 @@ impl Layout {
         } else {
             self.show_buffer_in_active_window(id);
         }
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
     }
 
     /// Returns true if this was the last buffer otherwise false.
@@ -212,20 +260,33 @@ impl Layout {
             if let Some(view) = existing_view {
                 self.cols.focus.wins.focus.view = view;
             }
-            self.update_screen_size(self.screen_rows, self.screen_cols);
+
+            #[cfg(test)]
+            assert_buffer_ids!(self);
+
             return false;
         }
 
         // Remove columns where there are only views of the closing buffer
+        let cols_before = self.cols.len();
         self.cols
             .filter_unchecked(|c| c.wins.iter().any(|(_, w)| w.view.bufid != id));
 
-        // Remove remaining windows which were showing the closing buffer
-        for (_, c) in self.cols.iter_mut() {
-            c.wins.filter_unchecked(|w| w.view.bufid != id)
+        if self.cols.len() < cols_before {
+            self.balance_columns();
         }
 
-        self.update_screen_size(self.screen_rows, self.screen_cols);
+        // Remove remaining windows which were showing the closing buffer
+        for (_, c) in self.cols.iter_mut() {
+            let wins_before = c.wins.len();
+            c.wins.filter_unchecked(|w| w.view.bufid != id);
+            if c.wins.len() < wins_before {
+                c.balance_windows(self.screen_rows);
+            }
+        }
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
 
         false
     }
@@ -285,13 +346,17 @@ impl Layout {
 
         if self.cols.focus.wins.len() == 1 {
             self.cols.remove_focused_unchecked();
+            self.balance_columns();
         } else {
             self.cols.focus.wins.remove_focused_unchecked();
+            self.balance_active_column();
         }
 
         let id = self.cols.focus.wins.focus.view.bufid;
         self.buffers.focus_id(id);
-        self.update_screen_size(self.screen_rows, self.screen_cols);
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
 
         false
     }
@@ -309,10 +374,13 @@ impl Layout {
         }
 
         self.cols.remove_focused_unchecked();
+        self.balance_columns();
 
         let id = self.cols.focus.wins.focus.view.bufid;
         self.buffers.focus_id(id);
-        self.update_screen_size(self.screen_rows, self.screen_cols);
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
 
         false
     }
@@ -360,6 +428,9 @@ impl Layout {
         if !self.buffer_is_visible(id) {
             self.show_buffer_in_new_window(id);
         }
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
     }
 
     /// Move focus to the column to the right of current focus (wrapping)
@@ -419,28 +490,51 @@ impl Layout {
     ///   and the previous column is removed.
     pub(crate) fn drag_left(&mut self) {
         self.scratch.is_focused = false;
-        if self.cols.len() == 1 || self.cols.up.is_empty() {
+
+        // Strictly speaking, self.cols.up.is_empty() == true implies self.cols.len() == 1 but
+        // we keep the explicit check for clarity.
+        if self.cols.up.is_empty() || self.cols.len() == 1 {
+            // Single column or far left column
+
+            // If we only have a single window in this column then we're done...
             if self.cols.focus.wins.len() == 1 {
                 return;
             }
+
+            // Otherwise we need to create a new column containing only this window
             let win = self.cols.focus.wins.remove_focused_unchecked();
+            self.balance_active_column(); // tidy up the column we've just popped from
             let mut col = Column::new(self.screen_rows, self.screen_cols, &[win.view.bufid]);
             col.wins.focus = win;
             self.cols.insert_at(Position::Head, col);
             self.cols.focus_up();
+            self.balance_columns();
         } else if self.cols.focus.wins.len() == 1 {
+            // Column that is not on the far left containing only a single window
+
+            // If this column only has a single window then remove it an place the window in
+            // the column to the left
             let on_left = self.cols.up.is_empty();
             let win = self.cols.remove_focused_unchecked().wins.focus;
+            self.balance_columns();
+            self.balance_active_column();
             if !on_left {
                 self.cols.focus_up();
             }
             self.cols.focus.wins.insert(win);
+            self.balance_active_column();
         } else {
+            // Column that is not on the far left containing more than one window
+
             let win = self.cols.focus.wins.remove_focused_unchecked();
+            self.balance_active_column();
             self.cols.focus_up();
             self.cols.focus.wins.insert(win);
+            self.balance_active_column();
         }
-        self.update_screen_size(self.screen_rows, self.screen_cols);
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
     }
 
     /// Drag the focused window to the column on the right.
@@ -448,24 +542,45 @@ impl Layout {
     /// See [Layout::drag_left] for semantics.
     pub(crate) fn drag_right(&mut self) {
         self.scratch.is_focused = false;
+
+        // Strictly speaking, self.cols.up.is_empty() == true implies self.cols.len() == 1 but
+        // we keep the explicit check for clarity.
         if self.cols.len() == 1 || self.cols.down.is_empty() {
+            // Single column or far right column
+
+            // If we only have a single window in this column then we're done...
             if self.cols.focus.wins.len() == 1 {
                 return;
             }
+
+            // Otherwise we need to create a new column containing only this window
             let win = self.cols.focus.wins.remove_focused_unchecked();
+            self.balance_active_column(); // tidy up the column we've just popped from
+
             let mut col = Column::new(self.screen_rows, self.screen_cols, &[0]);
             col.wins.focus = win;
             self.cols.insert_at(Position::Tail, col);
             self.cols.focus_down();
+            self.balance_columns();
         } else if self.cols.focus.wins.len() == 1 {
+            // Column that is not on the far right containing only a single window
+
             let win = self.cols.remove_focused_unchecked().wins.focus;
             self.cols.focus.wins.insert(win);
+            self.balance_active_column();
+            self.balance_columns();
         } else {
+            // Column that is not on the far right containing more than one window
+
             let win = self.cols.focus.wins.remove_focused_unchecked();
+            self.balance_active_column();
             self.cols.focus_down();
             self.cols.focus.wins.insert(win);
+            self.balance_active_column();
         }
-        self.update_screen_size(self.screen_rows, self.screen_cols);
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
     }
 
     /// Adjust the size of the active [Column] by increasing or decreasing the number of
@@ -493,24 +608,48 @@ impl Layout {
     /// Any existing layout customisation will be preserved as far as possible by converting
     /// dimensions to be relative to the size of the full screen.
     pub(crate) fn update_screen_size(&mut self, rows: usize, cols: usize) {
+        let col_ratio = (cols as f32) / (self.screen_cols as f32);
+        let row_ratio = (rows as f32) / (self.screen_rows as f32);
+
         self.screen_rows = rows;
         self.screen_cols = cols;
 
-        if self.cols.len() == 1 {
-            self.cols.focus.update_size(rows, cols);
-            return;
-        }
-
-        let (w_col, slop) = calculate_dims(cols, self.cols.len());
-        for (i, (_, col)) in self.cols.iter_mut().enumerate() {
-            let mut w = w_col;
-            if i < slop {
-                w += 1;
-            }
-            col.update_size(rows, w);
+        self.cols.scale_sizes(col_ratio, cols);
+        for (_, c) in self.cols.iter_mut() {
+            c.wins.scale_sizes(row_ratio, rows);
         }
 
         self.clamp_scroll();
+    }
+
+    /// Force the columns within the layout to be equally sized.
+    pub(crate) fn balance_columns(&mut self) {
+        let (n_cols, slop) = calculate_dims(self.screen_cols, self.cols.len());
+        for (i, (_, col)) in self.cols.iter_mut().enumerate() {
+            col.n_cols = n_cols;
+            if i < slop {
+                col.n_cols += 1;
+            }
+        }
+    }
+
+    /// Force the windows within the active column to be balanced.
+    pub(crate) fn balance_active_column(&mut self) {
+        self.cols.focus.balance_windows(self.screen_rows);
+    }
+
+    /// Force the all windows within the layout to be equally sized within their respective
+    /// columns.
+    pub(crate) fn balance_windows(&mut self) {
+        for (_, col) in self.cols.iter_mut() {
+            col.balance_windows(self.screen_rows);
+        }
+    }
+
+    /// Force all columns and windows to be equally sized.
+    pub(crate) fn balance_all(&mut self) {
+        self.balance_columns();
+        self.balance_windows();
     }
 
     #[inline]
@@ -544,7 +683,12 @@ impl Layout {
         };
 
         swap(self.focused_view_mut(), &mut view);
-        self.views.push(view);
+        if self.buffers.contains_bufid(view.bufid) {
+            self.views.push(view);
+        }
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
     }
 
     /// Create a new column containing a single window showing the same view found in the
@@ -556,7 +700,10 @@ impl Layout {
         col.wins.last_mut().view = view;
         self.cols.insert_at(Position::Tail, col);
         self.cols.focus_tail();
-        self.update_screen_size(self.screen_rows, self.screen_cols);
+        self.balance_columns();
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
     }
 
     /// Create a new window at the end of the current column showing the same view
@@ -567,7 +714,10 @@ impl Layout {
         let wins = &mut self.cols.focus.wins;
         wins.insert_at(Position::Tail, Window { n_rows: 0, view });
         wins.focus_tail();
-        self.update_screen_size(self.screen_rows, self.screen_cols);
+        self.balance_active_column();
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
     }
 
     /// Set the currently focused window to contain the given buffer
@@ -586,14 +736,18 @@ impl Layout {
             let mut col = Column::new(self.screen_rows, self.screen_cols, &[id]);
             col.wins.last_mut().view = view;
             self.cols.insert_at(Position::Tail, col);
+            self.balance_columns();
         } else {
             let wins = &mut self.cols.last_mut().wins;
             wins.insert_at(Position::Tail, Window { n_rows: 0, view });
             wins.focus_tail();
+            self.balance_active_column();
         }
 
         self.cols.focus_tail();
-        self.update_screen_size(self.screen_rows, self.screen_cols);
+
+        #[cfg(test)]
+        assert_buffer_ids!(self);
     }
 
     pub(crate) fn force_cursor_to_be_in_view(&mut self) {
@@ -841,10 +995,9 @@ impl Layout {
                     continue;
                 }
 
-                let b = self
-                    .buffers
-                    .with_id_mut(win.view.bufid)
-                    .unwrap_or_else(|| die!("layout state contains an unknown buffer ID"));
+                let b = self.buffers.with_id_mut(win.view.bufid).unwrap_or_else(|| {
+                    die!("invalid buffer ID {}", win.view.bufid);
+                });
                 apply_scroll(b, win, col.n_cols, focused_col && focused_win, up);
                 return;
             }
@@ -864,10 +1017,9 @@ impl Layout {
         });
 
         for (bufid, from, n_rows) in it {
-            let b = self
-                .buffers
-                .with_id_mut(bufid)
-                .unwrap_or_else(|| die!("layout state contains an unknown buffer ID"));
+            let b = self.buffers.with_id_mut(bufid).unwrap_or_else(|| {
+                die!("invalid buffer ID {bufid}");
+            });
 
             b.update_ts_state(from, n_rows);
         }
@@ -912,38 +1064,34 @@ pub(crate) struct Column {
 
 impl Column {
     pub(crate) fn new(n_rows: usize, n_cols: usize, buf_ids: &[BufferId]) -> Self {
-        let win_rows = n_rows / buf_ids.len();
+        let (win_rows, slop) = calculate_dims(n_rows, buf_ids.len());
         let mut wins = ZipList::try_from_iter(buf_ids.iter().map(|id| Window::new(win_rows, *id)))
             .expect("can't have an empty column");
 
-        let slop = n_rows - (win_rows * buf_ids.len()) + buf_ids.len() - 1;
-        wins.focus.n_rows += slop;
+        for (i, (_, w)) in wins.iter_mut().enumerate() {
+            if i < slop {
+                w.n_rows += 1;
+            }
+        }
 
         Self { n_cols, wins }
-    }
-
-    fn update_size(&mut self, n_rows: usize, n_cols: usize) {
-        self.n_cols = n_cols;
-
-        if self.wins.len() == 1 {
-            self.wins.focus.n_rows = n_rows;
-            return;
-        }
-
-        let (h_win, slop) = calculate_dims(n_rows, self.wins.len());
-        for (i, (_, win)) in self.wins.iter_mut().enumerate() {
-            let mut h = h_win;
-            if i < slop {
-                h += 1;
-            }
-            win.n_rows = h;
-        }
     }
 
     /// Needed to avoid borrowing all of Layout when calling [Layout::focused_view_mut].
     #[inline]
     fn focused_view_mut(&mut self) -> &mut View {
         &mut self.wins.focus.view
+    }
+
+    /// Force the windows within this column to be balanced regardless of their current sizes
+    fn balance_windows(&mut self, screen_rows: usize) {
+        let (n_rows, slop) = calculate_dims(screen_rows, self.wins.len());
+        for (i, (_, win)) in self.wins.iter_mut().enumerate() {
+            win.n_rows = n_rows;
+            if i < slop {
+                win.n_rows += 1;
+            }
+        }
     }
 }
 
@@ -1125,6 +1273,10 @@ impl<T> ZipList<T>
 where
     T: Growable,
 {
+    /// Attempt to adjust the size of the focused element by a given delta.
+    ///
+    /// Clamp to [MIN_DIM] for both the focused element and the adjacent element
+    /// that is being modified along with it.
     fn grow_focus(&mut self, delta: i16) {
         if self.len() == 1 || delta == 0 {
             return; // nothing to grow
@@ -1142,6 +1294,26 @@ where
         } else {
             let actual = other.clamped_sub(delta as usize, MIN_DIM);
             *self.focus.size() += actual;
+        }
+    }
+
+    /// Attempt to preserve the current relative size of each element when the
+    /// overall available space changes.
+    fn scale_sizes(&mut self, ratio: f32, new_total: usize) {
+        let mut total = 0;
+        for (_, elem) in self.iter_mut() {
+            let new_size = (*elem.size() as f32 * ratio) as usize;
+            *elem.size() = new_size;
+            total += new_size;
+        }
+
+        total += self.len() - 1;
+        let slop = new_total - total;
+
+        for (i, (_, elem)) in self.iter_mut().enumerate() {
+            if i < slop {
+                *elem.size() += 1;
+            }
         }
     }
 }
@@ -1219,11 +1391,13 @@ mod tests {
         let mut cols = Vec::with_capacity(col_wins.len());
         let mut n = 0;
         let mut all_ids = Vec::new();
+        let (col_size, slop) = calculate_dims(n_cols, col_wins.len());
 
-        for m in col_wins.iter() {
+        for (i, m) in col_wins.iter().enumerate() {
             let ids: Vec<usize> = (n..(n + m)).collect();
             n += m;
-            cols.push(Column::new(n_rows, n_cols, &ids));
+            let col_n_cols = if i < slop { col_size + 1 } else { col_size };
+            cols.push(Column::new(n_rows, col_n_cols, &ids));
             all_ids.extend(ids);
         }
 
@@ -1246,6 +1420,28 @@ mod tests {
             .iter()
             .flat_map(|(_, c)| c.wins.iter().map(|(_, w)| w.view.bufid))
             .collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn opening_file_with_unnamed_split_works() {
+        let (tx, _) = channel();
+        let buffers = Buffers::new_with_raw_sender(tx);
+        let id = buffers.active().id;
+        let mut l = Layout {
+            buffers,
+            scratch: Scratch::new(config_handle!().minibuffer_lines),
+            screen_rows: 80,
+            screen_cols: 100,
+            cols: ziplist![Column::new(80, 100, &[id])],
+            views: vec![],
+        };
+
+        l.new_column();
+
+        // This will panic if we've ended removing the original unnamed buffer from
+        // self.buffers as part of opening the virtual buffer as the Layout state
+        // will now contain references to an unknown buffer ID (via assert_buffer_ids)
+        let _ = l.open_or_focus("test-buffer.txt", false);
     }
 
     #[test]
@@ -1524,5 +1720,41 @@ mod tests {
         for (i, (_, w)) in l.cols.focus.wins.iter().enumerate() {
             assert_eq!(w.n_rows, expected_rows[i], "window {i}");
         }
+    }
+
+    #[test_case(100, 120, (73, 46), (100, 63, 36); "increase width and height")]
+    #[test_case(60, 80, (48, 31), (60, 38, 21); "decrease width and height")]
+    #[test]
+    fn update_screen_size_preserves_relative_sizes(
+        w: usize,
+        h: usize,
+        expected_cols: (usize, usize),
+        expected_wins: (usize, usize, usize),
+    ) {
+        let mut l = test_layout(&[1, 2], 80, 100);
+
+        l.cols.focus_head();
+        l.resize_active_column(10);
+        l.cols.focus_down();
+        l.cols.focus.wins.focus_head();
+        l.resize_active_window(10); // now focused on 1st window of 2nd column
+
+        let cols = |l: &Layout| (l.cols.up[0].n_cols, l.cols.focus.n_cols);
+        let wins = |l: &Layout| {
+            (
+                l.cols.up[0].wins.focus.n_rows,
+                l.cols.focus.wins.focus.n_rows,
+                l.cols.focus.wins.down[0].n_rows,
+            )
+        };
+
+        // check that the initial column and window sizes are correct
+        assert_eq!(cols(&l), (60, 39), "initial column widths");
+        assert_eq!(wins(&l), (80, 50, 29), "initial window heights");
+
+        l.update_screen_size(w, h);
+
+        assert_eq!(cols(&l), expected_cols, "updated column widths");
+        assert_eq!(wins(&l), expected_wins, "updated window heights");
     }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -13,6 +13,9 @@ use std::{cmp::min, io, mem::swap, path::Path, sync::Arc};
 use tracing::{debug, warn};
 use unicode_width::UnicodeWidthChar;
 
+/// The reserved ID for the scratch buffer.
+/// If we ever collide with this when creating a normal buffer then the user is
+/// doing something _very_ strange...
 pub(crate) const SCRATCH_ID: usize = usize::MAX;
 
 /// Layout is a screen layout of the windows available for displaying buffer
@@ -465,24 +468,30 @@ impl Layout {
         self.update_screen_size(self.screen_rows, self.screen_cols);
     }
 
-    #[inline]
-    pub(crate) fn focused_view(&self) -> &View {
-        &self.cols.focus.wins.focus.view
+    /// Adjust the size of the active [Column] by increasing or decreasing the number of
+    /// character columns it takes up.
+    ///
+    /// The adjustment is always applied from the left of the Column unless the active column
+    /// is the first in the [Layout], in which case the adjustment is made from the right.
+    pub(crate) fn resize_active_column(&mut self, delta_cols: i16) {
+        self.cols.grow_focus(delta_cols);
     }
 
-    #[inline]
-    pub(crate) fn focused_view_mut(&mut self) -> &mut View {
-        &mut self.cols.focus.wins.focus.view
+    /// Adjust the size of the active [Window] by increasing or decreasing the number of rows
+    /// it takes up.
+    ///
+    /// The adjustment is always applied from the top of the window unless the active window
+    /// is the first window in its [Column], in which case the adjustment is made from the
+    /// bottom of the window instead.
+    pub(crate) fn resize_active_window(&mut self, delta_rows: i16) {
+        self.cols.focus.wins.grow_focus(delta_rows);
     }
 
-    pub(crate) fn active_window_rows(&self) -> usize {
-        if self.scratch.is_focused {
-            self.scratch.w.n_rows
-        } else {
-            self.cols.focus.wins.focus.n_rows
-        }
-    }
-
+    /// Update the current layout state to reflect a new physical screen size given in terms
+    /// of the number of character rows and columns.
+    ///
+    /// Any existing layout customisation will be preserved as far as possible by converting
+    /// dimensions to be relative to the size of the full screen.
     pub(crate) fn update_screen_size(&mut self, rows: usize, cols: usize) {
         self.screen_rows = rows;
         self.screen_cols = cols;
@@ -502,6 +511,24 @@ impl Layout {
         }
 
         self.clamp_scroll();
+    }
+
+    #[inline]
+    pub(crate) fn focused_view(&self) -> &View {
+        &self.cols.focus.wins.focus.view
+    }
+
+    #[inline]
+    pub(crate) fn focused_view_mut(&mut self) -> &mut View {
+        &mut self.cols.focus.wins.focus.view
+    }
+
+    pub(crate) fn active_window_rows(&self) -> usize {
+        if self.scratch.is_focused {
+            self.scratch.w.n_rows
+        } else {
+            self.cols.focus.wins.focus.n_rows
+        }
     }
 
     /// Set the currently focused window to contain the given buffer
@@ -1063,6 +1090,62 @@ impl View {
     }
 }
 
+/// Min window size is 5x5
+const MIN_DIM: usize = 5;
+
+pub trait Growable {
+    fn size(&mut self) -> &mut usize;
+
+    fn clamped_sub(&mut self, delta: usize, min_val: usize) -> usize {
+        let clamped = (*self.size()).saturating_sub(delta);
+        if clamped >= min_val {
+            *self.size() = clamped;
+            delta
+        } else {
+            let actual = *self.size() - min_val;
+            *self.size() = min_val;
+            actual
+        }
+    }
+}
+
+impl Growable for Column {
+    fn size(&mut self) -> &mut usize {
+        &mut self.n_cols
+    }
+}
+
+impl Growable for Window {
+    fn size(&mut self) -> &mut usize {
+        &mut self.n_rows
+    }
+}
+
+impl<T> ZipList<T>
+where
+    T: Growable,
+{
+    fn grow_focus(&mut self, delta: i16) {
+        if self.len() == 1 || delta == 0 {
+            return; // nothing to grow
+        }
+
+        let other = if self.up.is_empty() {
+            &mut self.down[0]
+        } else {
+            &mut self.up[0]
+        };
+
+        if delta < 0 {
+            let actual = self.focus.clamped_sub((-delta) as usize, MIN_DIM);
+            *other.size() += actual;
+        } else {
+            let actual = other.clamped_sub(delta as usize, MIN_DIM);
+            *self.focus.size() += actual;
+        }
+    }
+}
+
 /// Calculate the size (rows/cols) for n blocks within an available space of t
 /// while accounting for "slop" that will be added to some elements to make up
 /// the correct total.
@@ -1132,7 +1215,7 @@ mod tests {
     use simple_test_case::test_case;
     use std::sync::mpsc::channel;
 
-    fn test_windows(col_wins: &[usize], n_rows: usize, n_cols: usize) -> Layout {
+    fn test_layout(col_wins: &[usize], n_rows: usize, n_cols: usize) -> Layout {
         let mut cols = Vec::with_capacity(col_wins.len());
         let mut n = 0;
         let mut all_ids = Vec::new();
@@ -1145,7 +1228,7 @@ mod tests {
         }
 
         let (tx, _) = channel();
-        let mut ws = Layout {
+        let mut l = Layout {
             buffers: Buffers::new_stubbed(&all_ids, tx),
             scratch: Scratch::new(n_rows),
             screen_rows: n_rows,
@@ -1153,13 +1236,13 @@ mod tests {
             cols: ZipList::try_from_iter(cols).unwrap(),
             views: vec![],
         };
-        ws.update_screen_size(n_rows, n_cols);
+        l.update_screen_size(n_rows, n_cols);
 
-        ws
+        l
     }
 
-    fn ordered_window_ids(ws: &Layout) -> Vec<usize> {
-        ws.cols
+    fn ordered_window_ids(l: &Layout) -> Vec<usize> {
+        l.cols
             .iter()
             .flat_map(|(_, c)| c.wins.iter().map(|(_, w)| w.view.bufid))
             .collect::<Vec<_>>()
@@ -1167,20 +1250,20 @@ mod tests {
 
     #[test]
     fn drag_left_works() {
-        let mut ws = test_windows(&[1, 1, 2], 80, 100);
-        ws.next_column();
-        assert_eq!(ws.active_buffer().id, 1);
-        ws.drag_left();
+        let mut l = test_layout(&[1, 1, 2], 80, 100);
+        l.next_column();
+        assert_eq!(l.active_buffer().id, 1);
+        l.drag_left();
 
-        assert_eq!(ws.cols.len(), 2);
-        let first_col: Vec<usize> = ws
+        assert_eq!(l.cols.len(), 2);
+        let first_col: Vec<usize> = l
             .cols
             .head()
             .wins
             .iter()
             .map(|(_, w)| w.view.bufid)
             .collect();
-        let second_col: Vec<usize> = ws
+        let second_col: Vec<usize> = l
             .cols
             .last()
             .wins
@@ -1194,19 +1277,19 @@ mod tests {
 
     #[test]
     fn drag_right_works() {
-        let mut ws = test_windows(&[1, 1, 2], 80, 100);
-        assert_eq!(ws.active_buffer().id, 0);
-        ws.drag_right();
+        let mut l = test_layout(&[1, 1, 2], 80, 100);
+        assert_eq!(l.active_buffer().id, 0);
+        l.drag_right();
 
-        assert_eq!(ws.cols.len(), 2);
-        let first_col: Vec<usize> = ws
+        assert_eq!(l.cols.len(), 2);
+        let first_col: Vec<usize> = l
             .cols
             .head()
             .wins
             .iter()
             .map(|(_, w)| w.view.bufid)
             .collect();
-        let second_col: Vec<usize> = ws
+        let second_col: Vec<usize> = l
             .cols
             .last()
             .wins
@@ -1220,46 +1303,46 @@ mod tests {
 
     #[test]
     fn next_prev_column_methods_work() {
-        let mut ws = test_windows(&[1, 1, 2], 80, 100);
-        assert_eq!(ws.focused_view().bufid, 0);
+        let mut l = test_layout(&[1, 1, 2], 80, 100);
+        assert_eq!(l.focused_view().bufid, 0);
 
         // next wrapping
-        ws.next_column();
-        assert_eq!(ws.focused_view().bufid, 1);
-        ws.next_column();
-        assert_eq!(ws.focused_view().bufid, 2);
-        ws.next_column();
-        assert_eq!(ws.focused_view().bufid, 0);
+        l.next_column();
+        assert_eq!(l.focused_view().bufid, 1);
+        l.next_column();
+        assert_eq!(l.focused_view().bufid, 2);
+        l.next_column();
+        assert_eq!(l.focused_view().bufid, 0);
 
         // prev wrapping
-        ws.prev_column();
-        assert_eq!(ws.focused_view().bufid, 2);
-        ws.prev_column();
-        assert_eq!(ws.focused_view().bufid, 1);
-        ws.prev_column();
-        assert_eq!(ws.focused_view().bufid, 0);
+        l.prev_column();
+        assert_eq!(l.focused_view().bufid, 2);
+        l.prev_column();
+        assert_eq!(l.focused_view().bufid, 1);
+        l.prev_column();
+        assert_eq!(l.focused_view().bufid, 0);
     }
 
     #[test]
     fn next_prev_window_methods_work() {
-        let mut ws = test_windows(&[3, 1], 80, 100);
-        assert_eq!(ws.focused_view().bufid, 0);
+        let mut l = test_layout(&[3, 1], 80, 100);
+        assert_eq!(l.focused_view().bufid, 0);
 
         // next wrapping
-        ws.next_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 1);
-        ws.next_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 2);
-        ws.next_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 0);
+        l.next_window_in_column();
+        assert_eq!(l.focused_view().bufid, 1);
+        l.next_window_in_column();
+        assert_eq!(l.focused_view().bufid, 2);
+        l.next_window_in_column();
+        assert_eq!(l.focused_view().bufid, 0);
 
         // prev wrapping
-        ws.prev_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 2);
-        ws.prev_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 1);
-        ws.prev_window_in_column();
-        assert_eq!(ws.focused_view().bufid, 0);
+        l.prev_window_in_column();
+        assert_eq!(l.focused_view().bufid, 2);
+        l.prev_window_in_column();
+        assert_eq!(l.focused_view().bufid, 1);
+        l.prev_window_in_column();
+        assert_eq!(l.focused_view().bufid, 0);
     }
 
     #[test_case(&[1], 30, 40, 0; "one col one win")]
@@ -1273,25 +1356,24 @@ mod tests {
     #[test_case(&[1, 4], 60, 70, 4; "two cols second with four click in fourth window")]
     #[test]
     fn buffer_for_screen_coords_works(col_wins: &[usize], x: usize, y: usize, expected: BufferId) {
-        let mut ws = test_windows(col_wins, 80, 100);
-        println!("{ws:#?}");
+        let mut l = test_layout(col_wins, 80, 100);
 
         assert_eq!(
-            ws.buffer_for_screen_coords(x, y),
+            l.buffer_for_screen_coords(x, y),
             expected,
             "bufid without mutation"
         );
         assert_eq!(
-            ws.cols.focus.wins.focus.view.bufid, 0,
+            l.cols.focus.wins.focus.view.bufid, 0,
             "focused id before mutation"
         );
         assert_eq!(
-            ws.focus_buffer_for_screen_coords(x, y),
+            l.focus_buffer_for_screen_coords(x, y),
             expected,
             "bufid with mutation"
         );
         assert_eq!(
-            ws.cols.focus.wins.focus.view.bufid, expected,
+            l.cols.focus.wins.focus.view.bufid, expected,
             "focused id after mutation"
         );
     }
@@ -1303,24 +1385,21 @@ mod tests {
     #[test_case(4, &[0, 1, 2, 3]; "4")]
     #[test]
     fn close_buffer_works(id: usize, expected: &[usize]) {
-        let mut ws = test_windows(&[1, 4], 80, 100);
-        assert_eq!(&ordered_window_ids(&ws), &[0, 1, 2, 3, 4], "initial ids");
+        let mut l = test_layout(&[1, 4], 80, 100);
+        assert_eq!(&ordered_window_ids(&l), &[0, 1, 2, 3, 4], "initial ids");
 
-        ws.close_buffer(id);
-        assert!(
-            !ws.buffers.contains_bufid(id),
-            "buffer id should be removed"
-        );
+        l.close_buffer(id);
+        assert!(!l.buffers.contains_bufid(id), "buffer id should be removed");
 
         for bufid in expected.iter() {
             assert!(
-                ws.buffers.contains_bufid(*bufid),
+                l.buffers.contains_bufid(*bufid),
                 "other buffers should still be there"
             );
         }
 
         assert_eq!(
-            &ordered_window_ids(&ws),
+            &ordered_window_ids(&l),
             expected,
             "ids for each window should be correct"
         );
@@ -1330,34 +1409,34 @@ mod tests {
     fn focus_buffer_for_screen_coords_doesnt_reorder_windows() {
         let (x, y) = (60, 70);
         let expected = 4;
-        let mut ws = test_windows(&[1, 4], 80, 100);
+        let mut l = test_layout(&[1, 4], 80, 100);
 
         assert_eq!(
-            &ordered_window_ids(&ws),
+            &ordered_window_ids(&l),
             &[0, 1, 2, 3, 4],
             "before first click"
         );
 
         assert_eq!(
-            ws.focus_buffer_for_screen_coords(x, y),
+            l.focus_buffer_for_screen_coords(x, y),
             expected,
             "bufid with mutation"
         );
 
         assert_eq!(
-            &ordered_window_ids(&ws),
+            &ordered_window_ids(&l),
             &[0, 1, 2, 3, 4],
             "after first click"
         );
 
         assert_eq!(
-            ws.focus_buffer_for_screen_coords(x, y),
+            l.focus_buffer_for_screen_coords(x, y),
             expected,
             "bufid with mutation"
         );
 
         assert_eq!(
-            &ordered_window_ids(&ws),
+            &ordered_window_ids(&l),
             &[0, 1, 2, 3, 4],
             "after second click"
         );
@@ -1390,6 +1469,60 @@ mod tests {
             b.set_dot(TextObject::Arr(Arrow::Right), 1);
             view.clamp_scroll(&mut b, 80, 80);
             offset += widths[idx];
+        }
+    }
+
+    #[test_case(1, 0, 10, &[100]; "one col inc")]
+    #[test_case(1, 0, -10, &[100]; "one col dec")]
+    #[test_case(2, 0, 10, &[60, 39]; "two cols inc one")]
+    #[test_case(2, 0, -10, &[40, 59]; "two cols dec one")]
+    #[test_case(2, 1, 10, &[40, 59]; "two cols inc two")]
+    #[test_case(2, 1, -10, &[60, 39]; "two cols dec two")]
+    #[test_case(3, 1, 10, &[23, 43, 32]; "three cols inc two")]
+    #[test_case(3, 1, -10, &[43, 23, 32]; "three cols dec two")]
+    #[test_case(2, 0, -200, &[MIN_DIM, 100 - MIN_DIM - 1]; "two cols dec one clamping")]
+    #[test_case(2, 0, 200, &[100 - MIN_DIM - 1, MIN_DIM]; "two cols inc one clamping")]
+    #[test]
+    fn resize_active_column_works(n_cols: usize, ix: usize, delta: i16, expected_cols: &[usize]) {
+        assert_eq!(expected_cols.len(), n_cols, "malformed test case");
+        let mut l = test_layout(&vec![1; n_cols], 80, 100);
+        // set focus to the target column
+        l.cols.focus_head();
+        for _ in 0..ix {
+            l.cols.focus_down();
+        }
+
+        l.resize_active_column(delta);
+
+        for (i, (_, c)) in l.cols.iter().enumerate() {
+            assert_eq!(c.n_cols, expected_cols[i], "column {i}");
+        }
+    }
+
+    #[test_case(1, 0, 10, &[80]; "one win inc")]
+    #[test_case(1, 0, -10, &[80]; "one win dec")]
+    #[test_case(2, 0, 10, &[50, 29]; "two wins inc one")]
+    #[test_case(2, 0, -10, &[30, 49]; "two wins dec one")]
+    #[test_case(2, 1, 10, &[30, 49]; "two wins inc two")]
+    #[test_case(2, 1, -10, &[50, 29]; "two wins dec two")]
+    #[test_case(3, 1, 10, &[16, 36, 26]; "three wins inc two")]
+    #[test_case(3, 1, -10, &[36, 16, 26]; "three wins dec two")]
+    #[test_case(2, 0, -200, &[MIN_DIM, 80 - MIN_DIM - 1]; "two wins dec one clamping")]
+    #[test_case(2, 0, 200, &[80 - MIN_DIM - 1, MIN_DIM]; "two wins inc one clamping")]
+    #[test]
+    fn resize_active_window_works(n_wins: usize, ix: usize, delta: i16, expected_rows: &[usize]) {
+        assert_eq!(expected_rows.len(), n_wins, "malformed test case");
+        let mut l = test_layout(&[n_wins], 80, 100);
+        // set focus to the target window
+        l.cols.focus.wins.focus_head();
+        for _ in 0..ix {
+            l.cols.focus.wins.focus_down();
+        }
+
+        l.resize_active_window(delta);
+
+        for (i, (_, w)) in l.cols.focus.wins.iter().enumerate() {
+            assert_eq!(w.n_rows, expected_rows[i], "window {i}");
         }
     }
 }


### PR DESCRIPTION
So far this adds two new commands "resize-col" and "resize-win" that both take a single argument of a signed integer and resize the active column or window respectively by that delta (in terms of character cells). Resizing clamps so that the column/window being shrunk is at least 5 cells wide/tall but currently any call to update_size will result in the user customised layout being trashed. Fixing that is up next.

![2025-05-04_12-10](https://github.com/user-attachments/assets/05256192-83aa-4de2-998a-714ad000b28f)
