### PR TITLE
Fix panic when terminal width shrinks too much

### DIFF
--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -132,7 +132,7 @@ impl Tui {
             },
             b.dot.addr(b)
         );
-        let width = self.screen_cols - lstatus.len();
+        let width = self.screen_cols.saturating_sub(lstatus.len());
 
         format!(
             "{}{}{lstatus}{rstatus:>width$}{}\r\n",
@@ -166,7 +166,7 @@ impl Tui {
                 Style::Bg(cs.bg)
             ));
         } else {
-            let width = self.screen_cols - 10;
+            let width = self.screen_cols.saturating_sub(10);
             buf.push_str(&format!(
                 "{}{}{pending:>width$}          ",
                 Style::Fg(cs.fg),


### PR DESCRIPTION
Before:
![2025-05-24T20:34:33 066+02:00](https://github.com/user-attachments/assets/36c4b42e-a233-4176-80cc-6b473903720b)
After:
![2025-05-24T20:35:12 960+02:00](https://github.com/user-attachments/assets/7507715b-02a3-4e06-b233-e8d4235d773f)

Rationale:

Currently, ad panics when you resize the terminal such the the number of columns gets too small (smaller than `lstatus.len()`, or smaller than 10) . I don't know how often this happens, but my guess is that panicking is never desired.

I've replaced the plain subtraction operation with `saturating_sub()` to prevent integer underflow that was causing the panic.

Additionally, even though all current tests still pass, there are none that test for this kind of thing, so I suspect there are other places (likely in src/ui/tui.rs) where this needs to be 'fixed'.