### PR TITLE
feat: Fast Scrolling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "ad-editor"
 version = "0.3.2"
 dependencies = [
  "ad_event",
+ "criterion",
  "libc",
  "libloading",
  "lsp-types",
@@ -82,6 +83,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,10 +128,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -128,6 +159,128 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -149,6 +302,16 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -178,10 +341,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -280,6 +462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +502,34 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -322,6 +547,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -366,10 +611,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -518,6 +778,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -704,10 +974,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -724,6 +1072,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,19 @@ doc = false
 name = "ad"
 path = "src/main.rs"
 
+[[bench]]
+name = "bench_main"
+harness = false
+
 [profile.release]
 strip = true
+lto = true
+codegen-units = 1
+
+# Used with https://github.com/flamegraph-rs/flamegraph
+[profile.flamegraph]
+debug=true
+strip = false
 lto = true
 codegen-units = 1
 
@@ -54,6 +65,7 @@ tree-sitter = "0.25.8"
 unicode-width = "0.2.1"
 
 [dev-dependencies]
+criterion = { version = "0.7.0", features = ["html_reports"] }
 simple_test_case = "1"
 simple_txtar = "1"
 tree-sitter-python = "0.23.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,9 @@ codegen-units = 1
 
 # Used with https://github.com/flamegraph-rs/flamegraph
 [profile.flamegraph]
+inherits = "release"
 debug=true
 strip = false
-lto = true
-codegen-units = 1
 
 # For a release optimised build that is quicker to run while iterating locally
 [profile.release-test]

--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -1,0 +1,9 @@
+use criterion::criterion_main;
+
+mod benchmarks;
+
+criterion_main! {
+    benchmarks::rsc_pathological_regex::benches,
+    benchmarks::burntsushi_torture_regex::benches,
+    benchmarks::tui_render::benches,
+}

--- a/benches/benchmarks/burntsushi_torture_regex.rs
+++ b/benches/benchmarks/burntsushi_torture_regex.rs
@@ -1,0 +1,50 @@
+// This is a variation on the torture test used by Burntsushi in their repo looking at
+// how to translate rsc's C code implementing the Thompson NFA algorithm into Rust.
+//
+// For now I'm using a much smaller input than the one Burntsushi uses (475 alternations
+// of in the regex itself and a haystack of 43,000 repetitions of 'abc' before the final
+// Z) because my VM is clearly far to slow at the moment and a single match takes multiple
+// seconds.
+//
+// As I get the performance improved I'll take a look at ramping up the torture.
+//
+//  https://github.com/BurntSushi/rsc-regexp/blob/master/torture-test
+
+use ad_editor::regex::Regex;
+use criterion::{Criterion, criterion_group};
+use std::hint::black_box;
+
+fn burntsushi_inputs(n_alts: usize, n_reps: usize) -> (String, Regex) {
+    let mut re = "(abc)*d|".repeat(n_alts);
+    re.push_str("(abc)*Z");
+    let mut s = "abc".repeat(n_reps);
+    s.push('Z');
+    let r = Regex::compile(&re).unwrap();
+
+    (s, r)
+}
+
+fn burntsushi_pathological_case(n_alts: usize, n_reps: usize) {
+    let (s, mut r) = burntsushi_inputs(n_alts, n_reps);
+    assert!(r.matches_str(&s));
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // > The full torture test Burntsushi used would be 475, 43000
+    let n_alts = 50;
+    let n_reps = 1000;
+
+    let mut group = c.benchmark_group(format!("burntsushi {n_alts} alts, {n_reps} reps"));
+    group.bench_function("with compile", |b| {
+        b.iter(|| burntsushi_pathological_case(black_box(n_alts), black_box(n_reps)))
+    });
+
+    let (s, mut r) = burntsushi_inputs(n_alts, n_reps);
+    group.bench_function("without compile", |b| {
+        b.iter(|| assert!(r.matches_str(black_box(&s))))
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);

--- a/benches/benchmarks/mod.rs
+++ b/benches/benchmarks/mod.rs
@@ -1,0 +1,3 @@
+pub mod burntsushi_torture_regex;
+pub mod rsc_pathological_regex;
+pub mod tui_render;

--- a/benches/benchmarks/rsc_pathological_regex.rs
+++ b/benches/benchmarks/rsc_pathological_regex.rs
@@ -1,0 +1,40 @@
+// This is the pathological case that Russ Cox covers in his article which leads
+// to exponential behaviour in backtracking based implementations.
+//
+// The graph from the article can be found here:
+//   https://swtch.com/~rsc/regexp/grep1p.png
+
+use ad_editor::regex::Regex;
+use criterion::{Criterion, criterion_group};
+use std::hint::black_box;
+
+fn rsc_inputs(n: usize) -> (String, Regex) {
+    let s = "a".repeat(n);
+    let mut re = "a?".repeat(n);
+    re.push_str(&s);
+    let r = Regex::compile(&re).unwrap();
+
+    (s, r)
+}
+
+fn rsc_pathological_case(n: usize) {
+    let (s, mut r) = rsc_inputs(n);
+    assert!(r.matches_str(&s));
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rsc 100");
+
+    group.bench_function("with compile", |b| {
+        b.iter(|| rsc_pathological_case(black_box(100)))
+    });
+
+    let (s, mut r) = rsc_inputs(100);
+    group.bench_function("without compile", |b| {
+        b.iter(|| assert!(r.matches_str(black_box(&s))))
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);

--- a/benches/benchmarks/tui_render.rs
+++ b/benches/benchmarks/tui_render.rs
@@ -5,13 +5,43 @@ use ad_editor::{
     system::DefaultSystem,
     ui::{GenericTui, Layout, UserInterface},
 };
-use criterion::{Criterion, criterion_group};
+use criterion::{BenchmarkGroup, Criterion, criterion_group, measurement::WallTime};
 use std::{
     env::current_dir,
     hint::black_box,
     io::{self, Write},
     sync::{Arc, Mutex},
 };
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("TUI render");
+
+    fixed_view(&mut group, "single window", &["src/util.rs"]);
+    fixed_view(&mut group, "two windows", &["src/util.rs", "src/term.rs"]);
+
+    single_window_editor_scroll_inputs(
+        &mut group,
+        "single window editor scroll inputs stdout",
+        EditorMode::Terminal,
+    );
+
+    let config = Config::try_load().unwrap();
+    let mut tui = GenericTui::new_with_stdout_handle(
+        Arc::new(Mutex::new(config.clone())),
+        StdoutSink(Vec::with_capacity(512 * 1024)),
+    );
+    tui.set_size(80, 160);
+
+    single_window_editor_scroll_inputs(
+        &mut group,
+        "single window editor scroll inputs sink",
+        EditorMode::Boxed(Box::new(tui)),
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
 
 struct StdoutSink(Vec<u8>);
 
@@ -51,11 +81,9 @@ fn tui_and_layout(files: &[&str]) -> (GenericTui<StdoutSink>, Layout) {
     (tui, layout)
 }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("TUI render");
-
-    let (mut tui, layout) = tui_and_layout(&["src/util.rs"]);
-    group.bench_function("single window", |b| {
+fn fixed_view(group: &mut BenchmarkGroup<'_, WallTime>, title: &str, files: &[&str]) {
+    let (mut tui, layout) = tui_and_layout(files);
+    group.bench_function(title, |b| {
         b.iter(|| {
             tui.refresh(
                 black_box("NORMAL"),
@@ -67,80 +95,17 @@ fn criterion_benchmark(c: &mut Criterion) {
             );
         })
     });
+}
 
-    let (mut tui, layout) = tui_and_layout(&["src/util.rs", "src/term.rs"]);
-    group.bench_function("two windows", |b| {
-        b.iter(|| {
-            tui.refresh(
-                black_box("NORMAL"),
-                black_box(&layout),
-                black_box(0),
-                black_box(&[]),
-                black_box(None),
-                black_box(None),
-            );
-        })
-    });
-
-    let (mut tui, mut layout) = tui_and_layout(&["src/ui/tui.rs"]);
-    let mut n = 0;
-    let mut up = false;
-
-    group.bench_function("single window scroll active", |b| {
-        b.iter(|| {
-            tui.refresh(
-                black_box("NORMAL"),
-                black_box(&layout),
-                black_box(0),
-                black_box(&[]),
-                black_box(None),
-                black_box(None),
-            );
-
-            n += 1;
-            if n == 500 {
-                n = 0;
-                up = !up;
-            }
-            layout.scroll_active(up);
-        })
-    });
-
-    let (mut tui, mut layout) = tui_and_layout(&["src/ui/tui.rs"]);
-    let mut n = 0;
-    let mut up = false;
-
-    group.bench_function("single window scroll view", |b| {
-        b.iter(|| {
-            tui.refresh(
-                black_box("NORMAL"),
-                black_box(&layout),
-                black_box(0),
-                black_box(&[]),
-                black_box(None),
-                black_box(None),
-            );
-
-            n += 1;
-            if n == 500 {
-                n = 0;
-                up = !up;
-            }
-            layout.scroll_view(20, 20, up);
-        })
-    });
-
-    let config = Config::try_load().unwrap();
-    let mut tui = GenericTui::new_with_stdout_handle(
-        Arc::new(Mutex::new(config.clone())),
-        StdoutSink(Vec::with_capacity(512 * 1024)),
-    );
-    tui.set_size(80, 160);
-
+fn single_window_editor_scroll_inputs(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    title: &str,
+    editor_mode: EditorMode,
+) {
     let mut e = Editor::new_with_system_and_initial_files(
         Config::try_load(),
         PlumbingRules::try_load(),
-        EditorMode::Boxed(Box::new(tui)),
+        editor_mode,
         LogBuffer::default(),
         DefaultSystem::without_clipboard_provider(),
         &["src/ui/tui.rs"],
@@ -149,7 +114,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut n = 0;
     let mut btn = MouseButton::WheelDown;
 
-    group.bench_function("single window editor scroll inputs", |b| {
+    group.bench_function(title, |b| {
         b.iter(|| {
             n += 1;
             if n == 500 {
@@ -161,6 +126,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 };
             }
 
+            e.refresh_screen_w_minibuffer(None);
             e.handle_input(Input::Mouse(MouseEvent {
                 k: MouseEventKind::Press,
                 m: MouseMod::NoMod,
@@ -168,11 +134,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                 x: 20,
                 y: 20,
             }));
-            e.refresh_screen_w_minibuffer(None);
         })
     });
-
-    group.finish();
 }
-
-criterion_group!(benches, criterion_benchmark);

--- a/benches/benchmarks/tui_render.rs
+++ b/benches/benchmarks/tui_render.rs
@@ -1,0 +1,178 @@
+// Render times for the TUI ui implementation.
+use ad_editor::{
+    Config, Editor, EditorMode, LogBuffer, PlumbingRules,
+    key::{Input, MouseButton, MouseEvent, MouseEventKind, MouseMod},
+    system::DefaultSystem,
+    ui::{GenericTui, Layout, UserInterface},
+};
+use criterion::{Criterion, criterion_group};
+use std::{
+    env::current_dir,
+    hint::black_box,
+    io::{self, Write},
+    sync::{Arc, Mutex},
+};
+
+struct StdoutSink(Vec<u8>);
+
+impl Write for StdoutSink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let res = self.0.flush();
+        self.0.clear();
+
+        res
+    }
+}
+
+fn tui_and_layout(files: &[&str]) -> (GenericTui<StdoutSink>, Layout) {
+    // This will need to point to the TS config for rust
+    let config = Arc::new(Mutex::new(Config::try_load().unwrap()));
+    let mut tui = GenericTui::new_with_stdout_handle(
+        config.clone(),
+        StdoutSink(Vec::with_capacity(512 * 1024)),
+    );
+    tui.set_size(80, 160);
+    let mut layout = Layout::new_with_stub_lsp_handle(80, 160, config);
+
+    let repo_root = current_dir().unwrap();
+
+    for file in files {
+        layout.open_or_focus(repo_root.join(file), false).unwrap();
+    }
+
+    (tui, layout)
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("TUI render");
+
+    let (mut tui, layout) = tui_and_layout(&["src/util.rs"]);
+    group.bench_function("single window", |b| {
+        b.iter(|| {
+            tui.refresh(
+                black_box("NORMAL"),
+                black_box(&layout),
+                black_box(0),
+                black_box(&[]),
+                black_box(None),
+                black_box(None),
+            );
+        })
+    });
+
+    let (mut tui, layout) = tui_and_layout(&["src/util.rs", "src/term.rs"]);
+    group.bench_function("two windows", |b| {
+        b.iter(|| {
+            tui.refresh(
+                black_box("NORMAL"),
+                black_box(&layout),
+                black_box(0),
+                black_box(&[]),
+                black_box(None),
+                black_box(None),
+            );
+        })
+    });
+
+    let (mut tui, mut layout) = tui_and_layout(&["src/ui/tui.rs"]);
+    let mut n = 0;
+    let mut up = false;
+
+    group.bench_function("single window scroll active", |b| {
+        b.iter(|| {
+            tui.refresh(
+                black_box("NORMAL"),
+                black_box(&layout),
+                black_box(0),
+                black_box(&[]),
+                black_box(None),
+                black_box(None),
+            );
+
+            n += 1;
+            if n == 500 {
+                n = 0;
+                up = !up;
+            }
+            layout.scroll_active(up);
+        })
+    });
+
+    let (mut tui, mut layout) = tui_and_layout(&["src/ui/tui.rs"]);
+    let mut n = 0;
+    let mut up = false;
+
+    group.bench_function("single window scroll view", |b| {
+        b.iter(|| {
+            tui.refresh(
+                black_box("NORMAL"),
+                black_box(&layout),
+                black_box(0),
+                black_box(&[]),
+                black_box(None),
+                black_box(None),
+            );
+
+            n += 1;
+            if n == 500 {
+                n = 0;
+                up = !up;
+            }
+            layout.scroll_view(20, 20, up);
+        })
+    });
+
+    let config = Config::try_load().unwrap();
+    let mut tui = GenericTui::new_with_stdout_handle(
+        Arc::new(Mutex::new(config.clone())),
+        StdoutSink(Vec::with_capacity(512 * 1024)),
+    );
+    tui.set_size(80, 160);
+
+    let mut e = Editor::new_with_system_and_initial_files(
+        Config::try_load(),
+        PlumbingRules::try_load(),
+        EditorMode::Boxed(Box::new(tui)),
+        LogBuffer::default(),
+        DefaultSystem::without_clipboard_provider(),
+        &["src/ui/tui.rs"],
+    );
+
+    let mut n = 0;
+    let mut btn = MouseButton::WheelDown;
+
+    group.bench_function("single window editor scroll inputs", |b| {
+        b.iter(|| {
+            n += 1;
+            if n == 500 {
+                n = 0;
+                btn = if btn == MouseButton::WheelUp {
+                    MouseButton::WheelDown
+                } else {
+                    MouseButton::WheelUp
+                };
+            }
+
+            e.handle_input(Input::Mouse(MouseEvent {
+                k: MouseEventKind::Press,
+                m: MouseMod::NoMod,
+                b: btn,
+                x: 20,
+                y: 20,
+            }));
+            e.refresh_screen_w_minibuffer(None);
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);

--- a/justfile
+++ b/justfile
@@ -11,8 +11,13 @@ todo:
 	rg 'TODO|FIXME|todo!' src crates
 
 # Run workspace tests using nextest
-test FILTER="":
+test FILTER=".*":
 	cargo nextest run --workspace {{FILTER}}
+
+# Run criterion benchmarks and open the report in firefox
+bench FILTER="":
+	cargo bench -- {{FILTER}}
+	firefox --new-tab target/criterion/report/index.html
 
 # Use entr to run tests every time git tracked files are modified
 watch-tests FILTER="":

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -341,7 +341,7 @@ where
         }
     }
 
-    pub(super) fn refresh_screen_w_minibuffer(&mut self, mb: Option<MiniBufferState<'_>>) {
+    pub fn refresh_screen_w_minibuffer(&mut self, mb: Option<MiniBufferState<'_>>) {
         self.layout.clamp_scroll();
         self.layout.update_visible_ts_state();
         self.ui.refresh(
@@ -506,7 +506,7 @@ where
         }
     }
 
-    fn handle_input(&mut self, input: Input) {
+    pub fn handle_input(&mut self, input: Input) {
         self.pending_keys.push(input);
         let maybe_actions =
             self.modes[0].handle_keys(&mut self.pending_keys, &*config_handle!(self));

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -11,6 +11,11 @@ use crate::{
 use ad_event::Source;
 use std::time::Instant;
 
+/// Number of milliseconds between successive mouse inputs under which we enable fast scrolling.
+const FAST_SCROLL_MS: u128 = 5;
+/// Number of rows to scroll per mouse wheel event when fast scrolling is enabled.
+const FAST_SCROLL_ROWS: usize = 5;
+
 /// Transient state that we hold to track the last mouse click we saw while
 /// we wait for it to be released or if the buffer changes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,6 +52,25 @@ impl<S> Editor<S>
 where
     S: System,
 {
+    /// When scrolling with the mouse wheel we support two scroll rates based on the interval
+    /// between successive mouse clicks. If the delta between clicks is under [FAST_SCROLL_MS] we
+    /// move into fast scrolling and advance by [FAST_SCROLL_ROWS] per mouse wheel event rather
+    /// than individual rows.
+    ///
+    /// We _could_ be tracking whether or not the last click received was the same mouse wheel
+    /// event in order to avoid false positives when the user is clicking and scrolling at the same
+    /// time but in practice this doesn't seem to be required due to the short interval we are
+    /// using for detecting fast scrolling.
+    fn scroll_rows(&self, last_click_time: Instant) -> usize {
+        let delta = (self.last_click_time - last_click_time).as_millis();
+        if delta < FAST_SCROLL_MS {
+            tracing::warn!("fast scrolling");
+            FAST_SCROLL_ROWS
+        } else {
+            1
+        }
+    }
+
     /// The outcome of a mouse event depends on any prior mouse state that is being held:
     ///   - Left   (click+release):      set Cur Dot at the location of the click
     ///   - Left   (click+hold+release): set Range Dot from click->release with click active
@@ -123,12 +147,14 @@ where
 
             (Press, _, WheelUp) => {
                 self.last_click_was_left = false;
-                self.layout.scroll_view(x, y, true);
+                self.layout
+                    .scroll_view(x, y, true, self.scroll_rows(last_click_time));
             }
 
             (Press, _, WheelDown) => {
                 self.last_click_was_left = false;
-                self.layout.scroll_view(x, y, false);
+                self.layout
+                    .scroll_view(x, y, false, self.scroll_rows(last_click_time));
             }
 
             (Release, m, b) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 #![allow(text_direction_codepoint_in_literal)]
 
 use libc::termios as Termios;
-use std::{io::Stdout, process, sync::OnceLock};
+use std::{io::Write, process, sync::OnceLock};
 
 pub mod buffer;
 pub mod cli;
@@ -89,7 +89,7 @@ macro_rules! die {
 }
 
 /// Restore the terminal state to what we had originally before starting our UI.
-pub(crate) fn restore_terminal_state(so: &mut Stdout) {
+pub(crate) fn restore_terminal_state(so: &mut impl Write) {
     disable_alternate_screen(so);
     disable_mouse_support(so);
     let t = match ORIGINAL_TERMIOS.get() {

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -73,7 +73,6 @@ pub struct LspManagerHandle {
 }
 
 impl LspManagerHandle {
-    #[cfg(test)]
     pub(crate) fn new_stubbed(tx_req: Sender<Req>) -> Self {
         Self {
             tx_req,

--- a/src/term.rs
+++ b/src/term.rs
@@ -8,7 +8,7 @@ use libc::{
 use serde::Deserialize;
 use std::{
     fmt,
-    io::{self, Stdout, Write},
+    io::{self, Write},
     mem, ptr,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -242,7 +242,7 @@ pub(crate) fn get_termsize() -> (usize, usize) {
     (ts.r as usize, ts.c as usize)
 }
 
-pub(crate) fn clear_screen(stdout: &mut Stdout) {
+pub(crate) fn clear_screen(stdout: &mut impl Write) {
     if let Err(e) = stdout.write_all(format!("{CLEAR_SCREEN}{}", Cursor::ToStart).as_bytes()) {
         panic!("unable to clear screen: {e}");
     }
@@ -251,7 +251,7 @@ pub(crate) fn clear_screen(stdout: &mut Stdout) {
     }
 }
 
-pub(crate) fn enable_mouse_support(stdout: &mut Stdout) {
+pub(crate) fn enable_mouse_support(stdout: &mut impl Write) {
     if let Err(e) = stdout.write_all(ENABLE_MOUSE_SUPPORT.as_bytes()) {
         panic!("unable to enable mouse support: {e}");
     }
@@ -260,7 +260,7 @@ pub(crate) fn enable_mouse_support(stdout: &mut Stdout) {
     }
 }
 
-pub(crate) fn disable_mouse_support(stdout: &mut Stdout) {
+pub(crate) fn disable_mouse_support(stdout: &mut impl Write) {
     if let Err(e) = stdout.write_all(DISABLE_MOUSE_SUPPORT.as_bytes()) {
         panic!("unable to disable mouse support: {e}");
     }
@@ -269,7 +269,7 @@ pub(crate) fn disable_mouse_support(stdout: &mut Stdout) {
     }
 }
 
-pub(crate) fn enable_alternate_screen(stdout: &mut Stdout) {
+pub(crate) fn enable_alternate_screen(stdout: &mut impl Write) {
     if let Err(e) = stdout.write_all(ENABLE_ALTERNATE_SCREEN.as_bytes()) {
         panic!("unable to enable alternate screen: {e}");
     }
@@ -278,7 +278,7 @@ pub(crate) fn enable_alternate_screen(stdout: &mut Stdout) {
     }
 }
 
-pub(crate) fn disable_alternate_screen(stdout: &mut Stdout) {
+pub(crate) fn disable_alternate_screen(stdout: &mut impl Write) {
     if let Err(e) = stdout.write_all(DISABLE_ALTERNATE_SCREEN.as_bytes()) {
         panic!("unable to disable alternate screen: {e}");
     }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1055,7 +1055,7 @@ impl Layout {
         bufid == current_bufid
     }
 
-    /// Scroll the [View] under the given cursor coordinates up or down by `scroll_rows`
+    /// Scroll the `View` under the given cursor coordinates up or down by `scroll_rows`
     pub fn scroll_view(&mut self, x: usize, y: usize, up: bool, scroll_rows: usize) {
         let tabstop = config_handle!(self).tabstop;
         let mut x_offset = 0;
@@ -1464,7 +1464,7 @@ fn apply_scroll(
     tabstop: usize,
     focused: bool,
     up: bool,
-    scoll_rows: usize,
+    scroll_rows: usize,
 ) {
     let n_rows = win.n_rows;
     let view = &mut win.view;
@@ -1478,9 +1478,9 @@ fn apply_scroll(
     let mut need_clamp = false;
 
     if up && view.row_off > 0 && y == view.row_off + n_rows - 1 {
-        cur = Cur::from_yx(y.saturating_sub(scoll_rows), x, b);
+        cur = Cur::from_yx(y.saturating_sub(scroll_rows), x, b);
     } else if !up && y == view.row_off && view.row_off < y_max {
-        cur = Cur::from_yx(min(y + scoll_rows, y_max), x, b);
+        cur = Cur::from_yx(min(y + scroll_rows, y_max), x, b);
         need_clamp = true;
     };
 
@@ -1495,9 +1495,9 @@ fn apply_scroll(
     }
 
     view.row_off = if up {
-        view.row_off.saturating_sub(scoll_rows)
+        view.row_off.saturating_sub(scroll_rows)
     } else {
-        view.row_off + scoll_rows
+        view.row_off + scroll_rows
     };
 
     if focused {

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -15,7 +15,7 @@ use std::{
     io,
     mem::swap,
     path::Path,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, mpsc::channel},
 };
 use tracing::{debug, warn};
 use unicode_width::UnicodeWidthChar;
@@ -91,6 +91,17 @@ pub struct Layout {
 }
 
 impl Layout {
+    pub fn new_with_stub_lsp_handle(
+        screen_rows: usize,
+        screen_cols: usize,
+        config: Arc<Mutex<Config>>,
+    ) -> Self {
+        let (tx, _rx) = channel();
+        let lsp_handle = LspManagerHandle::new_stubbed(tx);
+
+        Self::new(screen_rows, screen_cols, Arc::new(lsp_handle), config)
+    }
+
     pub(crate) fn new(
         screen_rows: usize,
         screen_cols: usize,
@@ -161,7 +172,7 @@ impl Layout {
     }
 
     /// Returns the active buffer or the scratch buffer if it is focused
-    pub(crate) fn active_buffer(&self) -> &Buffer {
+    pub fn active_buffer(&self) -> &Buffer {
         if self.scratch.is_focused {
             &self.scratch.b
         } else {
@@ -196,7 +207,7 @@ impl Layout {
         self.scratch.toggle();
     }
 
-    pub(crate) fn open_or_focus<P: AsRef<Path>>(
+    pub fn open_or_focus<P: AsRef<Path>>(
         &mut self,
         path: P,
         mut new_window: bool,
@@ -1045,7 +1056,7 @@ impl Layout {
     }
 
     /// Scroll the [View] under the given cursor coordinates up or down by a single line
-    pub(crate) fn scroll_view(&mut self, x: usize, y: usize, up: bool) {
+    pub fn scroll_view(&mut self, x: usize, y: usize, up: bool) {
         let tabstop = config_handle!(self).tabstop;
         let mut x_offset = 0;
         let mut y_offset = 0;
@@ -1089,6 +1100,18 @@ impl Layout {
             }
         }
 
+        // Default to scrolling the active window
+        let n_cols = self.cols.focus.n_cols;
+        let win = &mut self.cols.focus.wins.focus;
+        let b = self.buffers.with_id_mut(win.view.bufid).unwrap();
+        apply_scroll(b, win, n_cols, tabstop, true, up);
+
+        #[cfg(test)]
+        assert_invariants!(self);
+    }
+
+    pub fn scroll_active(&mut self, up: bool) {
+        let tabstop = config_handle!(self).tabstop;
         let n_cols = self.cols.focus.n_cols;
         let win = &mut self.cols.focus.wins.focus;
         let b = self.buffers.with_id_mut(win.view.bufid).unwrap();

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1055,8 +1055,8 @@ impl Layout {
         bufid == current_bufid
     }
 
-    /// Scroll the [View] under the given cursor coordinates up or down by a single line
-    pub fn scroll_view(&mut self, x: usize, y: usize, up: bool) {
+    /// Scroll the [View] under the given cursor coordinates up or down by `scroll_rows`
+    pub fn scroll_view(&mut self, x: usize, y: usize, up: bool, scroll_rows: usize) {
         let tabstop = config_handle!(self).tabstop;
         let mut x_offset = 0;
         let mut y_offset = 0;
@@ -1069,6 +1069,7 @@ impl Layout {
                 tabstop,
                 self.scratch.is_focused,
                 up,
+                scroll_rows,
             );
 
             #[cfg(test)]
@@ -1091,7 +1092,8 @@ impl Layout {
                 let b = self.buffers.with_id_mut(win.view.bufid).unwrap_or_else(|| {
                     die!("invalid buffer ID {}", win.view.bufid);
                 });
-                apply_scroll(b, win, col.n_cols, tabstop, focused_col && focused_win, up);
+                let focused = focused_col && focused_win;
+                apply_scroll(b, win, col.n_cols, tabstop, focused, up, scroll_rows);
 
                 #[cfg(test)]
                 assert_invariants!(self);
@@ -1104,18 +1106,7 @@ impl Layout {
         let n_cols = self.cols.focus.n_cols;
         let win = &mut self.cols.focus.wins.focus;
         let b = self.buffers.with_id_mut(win.view.bufid).unwrap();
-        apply_scroll(b, win, n_cols, tabstop, true, up);
-
-        #[cfg(test)]
-        assert_invariants!(self);
-    }
-
-    pub fn scroll_active(&mut self, up: bool) {
-        let tabstop = config_handle!(self).tabstop;
-        let n_cols = self.cols.focus.n_cols;
-        let win = &mut self.cols.focus.wins.focus;
-        let b = self.buffers.with_id_mut(win.view.bufid).unwrap();
-        apply_scroll(b, win, n_cols, tabstop, true, up);
+        apply_scroll(b, win, n_cols, tabstop, true, up, scroll_rows);
 
         #[cfg(test)]
         assert_invariants!(self);
@@ -1473,6 +1464,7 @@ fn apply_scroll(
     tabstop: usize,
     focused: bool,
     up: bool,
+    scoll_rows: usize,
 ) {
     let n_rows = win.n_rows;
     let view = &mut win.view;
@@ -1482,12 +1474,13 @@ fn apply_scroll(
         view.cur
     };
     let (y, x) = cur.as_yx(b);
+    let y_max = b.txt.len_lines() - 1;
     let mut need_clamp = false;
 
     if up && view.row_off > 0 && y == view.row_off + n_rows - 1 {
-        cur = Cur::from_yx(y - 1, x, b);
-    } else if !up && y == view.row_off && view.row_off < b.txt.len_lines() - 1 {
-        cur = Cur::from_yx(y + 1, x, b);
+        cur = Cur::from_yx(y.saturating_sub(scoll_rows), x, b);
+    } else if !up && y == view.row_off && view.row_off < y_max {
+        cur = Cur::from_yx(min(y + scoll_rows, y_max), x, b);
         need_clamp = true;
     };
 
@@ -1502,9 +1495,9 @@ fn apply_scroll(
     }
 
     view.row_off = if up {
-        view.row_off.saturating_sub(1)
+        view.row_off.saturating_sub(scoll_rows)
     } else {
-        view.row_off + 1
+        view.row_off + scoll_rows
     };
 
     if focused {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,7 +15,7 @@ mod layout;
 mod tui;
 
 pub use layout::{Layout, SCRATCH_ID};
-pub use tui::Tui;
+pub use tui::{GenericTui, Tui};
 
 /// Something that can be used as a user interface
 pub trait UserInterface {

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -26,7 +26,7 @@ use std::{
     char,
     cmp::Ordering,
     collections::HashMap,
-    io::{Read, Stdout, Write, stdin, stdout},
+    io::{Read, StdoutLock, Write, stdin, stdout},
     iter::{Peekable, repeat_n},
     panic,
     rc::Rc,
@@ -50,9 +50,11 @@ fn box_draw_str(s: &str, cs: &ColorScheme) -> String {
     format!("{}{}{s}", Style::Fg(cs.minibuffer_hl), Style::Bg(cs.bg))
 }
 
+pub type Tui = GenericTui<StdoutLock<'static>>;
+
 #[derive(Debug)]
-pub struct Tui {
-    stdout: Stdout,
+pub struct GenericTui<W: Write> {
+    stdout: W,
     config: Arc<Mutex<Config>>,
     screen_rows: usize,
     screen_cols: usize,
@@ -75,7 +77,7 @@ impl Default for Tui {
     }
 }
 
-impl Drop for Tui {
+impl<W: Write> Drop for GenericTui<W> {
     fn drop(&mut self) {
         restore_terminal_state(&mut self.stdout);
     }
@@ -83,8 +85,14 @@ impl Drop for Tui {
 
 impl Tui {
     pub fn new(config: Arc<Mutex<Config>>) -> Self {
+        Self::new_with_stdout_handle(config, stdout().lock())
+    }
+}
+
+impl<W: Write> GenericTui<W> {
+    pub fn new_with_stdout_handle(config: Arc<Mutex<Config>>, stdout: W) -> Self {
         let mut tui = Self {
-            stdout: stdout(),
+            stdout,
             config,
             screen_rows: 0,
             screen_cols: 0,
@@ -240,58 +248,13 @@ impl Tui {
 
         lines
     }
-}
 
-impl UserInterface for Tui {
-    fn init(&mut self, tx: Sender<Event>) -> (usize, usize) {
-        let original_termios = get_termios();
-        enable_raw_mode(original_termios);
-        _ = ORIGINAL_TERMIOS.set(original_termios);
-
-        panic::set_hook(Box::new(|panic_info| {
-            let mut stdout = stdout();
-            restore_terminal_state(&mut stdout);
-            _ = stdout.flush();
-
-            // Restoring the terminal state to move us off of the alternate screen
-            // can race with our attempt to print the panic info so given that we
-            // are already in a fatal situation, sleeping briefly to ensure that
-            // the cause of the panic is visible before we exit isn't _too_ bad.
-            std::thread::sleep(std::time::Duration::from_millis(300));
-            eprintln!("Fatal error:\n{panic_info}");
-            _ = std::fs::write("/tmp/ad.panic", format!("{panic_info}"));
-        }));
-
-        enable_mouse_support(&mut self.stdout);
-        enable_alternate_screen(&mut self.stdout);
-
-        // SAFETY: we only register our signal handler once
-        unsafe { register_signal_handler() };
-
-        let (screen_rows, screen_cols) = get_termsize();
-        self.screen_rows = screen_rows;
-        self.screen_cols = screen_cols;
-
-        spawn_input_thread(tx);
-
-        (screen_rows, screen_cols)
+    pub fn set_size(&mut self, rows: usize, cols: usize) {
+        self.screen_rows = rows;
+        self.screen_cols = cols;
     }
 
-    fn shutdown(&mut self) {
-        clear_screen(&mut self.stdout);
-    }
-
-    fn state_change(&mut self, change: StateChange) {
-        match change {
-            StateChange::ConfigUpdated => self.update_cached_elements(),
-            StateChange::StatusMessage { msg } => {
-                self.status_message = msg;
-                self.last_status = Instant::now();
-            }
-        }
-    }
-
-    fn refresh(
+    pub fn render_lines(
         &mut self,
         mode_name: &str,
         layout: &Layout,
@@ -299,14 +262,7 @@ impl UserInterface for Tui {
         pending_keys: &[Input],
         held_click: Option<&Click>,
         mb: Option<MiniBufferState<'_>>,
-    ) {
-        self.screen_rows = layout.screen_rows;
-        self.screen_cols = layout.screen_cols;
-
-        if self.screen_cols < MIN_COLS || self.screen_rows < MIN_ROWS {
-            return;
-        }
-
+    ) -> Vec<String> {
         let conf = config_handle!(self);
         let (cs, status_timeout, tabstop, max_mb_lines) = (
             &conf.colorscheme,
@@ -384,6 +340,77 @@ impl UserInterface for Tui {
         };
         lines.push(format!("{}{}", Cursor::To(x + 1, y + 1), Cursor::Show));
 
+        lines
+    }
+}
+
+impl<W: Write> UserInterface for GenericTui<W> {
+    fn init(&mut self, tx: Sender<Event>) -> (usize, usize) {
+        let original_termios = get_termios();
+        enable_raw_mode(original_termios);
+        _ = ORIGINAL_TERMIOS.set(original_termios);
+
+        panic::set_hook(Box::new(|panic_info| {
+            let mut stdout = stdout();
+            restore_terminal_state(&mut stdout);
+            _ = stdout.flush();
+
+            // Restoring the terminal state to move us off of the alternate screen
+            // can race with our attempt to print the panic info so given that we
+            // are already in a fatal situation, sleeping briefly to ensure that
+            // the cause of the panic is visible before we exit isn't _too_ bad.
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            eprintln!("Fatal error:\n{panic_info}");
+            _ = std::fs::write("/tmp/ad.panic", format!("{panic_info}"));
+        }));
+
+        enable_mouse_support(&mut self.stdout);
+        enable_alternate_screen(&mut self.stdout);
+
+        // SAFETY: we only register our signal handler once
+        unsafe { register_signal_handler() };
+
+        let (screen_rows, screen_cols) = get_termsize();
+        self.screen_rows = screen_rows;
+        self.screen_cols = screen_cols;
+
+        spawn_input_thread(tx);
+
+        (screen_rows, screen_cols)
+    }
+
+    fn shutdown(&mut self) {
+        clear_screen(&mut self.stdout);
+    }
+
+    fn state_change(&mut self, change: StateChange) {
+        match change {
+            StateChange::ConfigUpdated => self.update_cached_elements(),
+            StateChange::StatusMessage { msg } => {
+                self.status_message = msg;
+                self.last_status = Instant::now();
+            }
+        }
+    }
+
+    fn refresh(
+        &mut self,
+        mode_name: &str,
+        layout: &Layout,
+        n_running: usize,
+        pending_keys: &[Input],
+        held_click: Option<&Click>,
+        mb: Option<MiniBufferState<'_>>,
+    ) {
+        self.screen_rows = layout.screen_rows;
+        self.screen_cols = layout.screen_cols;
+
+        if self.screen_cols < MIN_COLS || self.screen_rows < MIN_ROWS {
+            return;
+        }
+
+        let lines = self.render_lines(mode_name, layout, n_running, pending_keys, held_click, mb);
+
         if let Err(e) = self.stdout.write_all(lines.join("").as_bytes()) {
             die!("Unable to refresh screen: {e}");
         }
@@ -413,12 +440,12 @@ struct WinsIter<'a> {
 }
 
 impl<'a> WinsIter<'a> {
-    fn new(
+    fn new<W: Write>(
         layout: &'a Layout,
         load_exec_range: Option<(bool, Range)>,
         screen_rows: usize,
         tabstop: usize,
-        tui: &'a Tui,
+        tui: &'a GenericTui<W>,
         cs: &'a ColorScheme,
     ) -> Self {
         let col_iters: Vec<_> = layout
@@ -833,9 +860,9 @@ fn render_line<'a>(
 /// Spawn a thread to read from stdin and process user input to send Events to
 /// the main editor event loop.
 fn spawn_input_thread(tx: Sender<Event>) -> JoinHandle<()> {
-    let mut stdin = stdin();
-
     spawn(move || {
+        let mut stdin = stdin().lock();
+
         loop {
             if let Some(key) = try_read_input(&mut stdin) {
                 _ = tx.send(Event::Input(key));

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -26,7 +26,7 @@ use std::{
     char,
     cmp::Ordering,
     collections::HashMap,
-    io::{Read, StdoutLock, Write, stdin, stdout},
+    io::{BufWriter, Read, StdoutLock, Write, stdin, stdout},
     iter::{Peekable, repeat_n},
     panic,
     rc::Rc,
@@ -54,7 +54,7 @@ pub type Tui = GenericTui<StdoutLock<'static>>;
 
 #[derive(Debug)]
 pub struct GenericTui<W: Write> {
-    stdout: W,
+    stdout: BufWriter<W>,
     config: Arc<Mutex<Config>>,
     screen_rows: usize,
     screen_cols: usize,
@@ -92,7 +92,7 @@ impl Tui {
 impl<W: Write> GenericTui<W> {
     pub fn new_with_stdout_handle(config: Arc<Mutex<Config>>, stdout: W) -> Self {
         let mut tui = Self {
-            stdout,
+            stdout: BufWriter::new(stdout),
             config,
             screen_rows: 0,
             screen_cols: 0,


### PR DESCRIPTION
Closes #101 (see for original motivation)

The main user facing change coming from this PR is a new feature of "fast scrolling" that kicks in when `ad` detects that repeated mouse wheel events are being received, causing the editor to scroll 5 lines per event rather than the default 1 line per event.

This has come about from me attempting to benchmark the TUI rendering performance and trying to work out why neovim scrolling to the bottom of a 1000 line file was roughly four times faster than ad. After writing some benchmarks and playing around with getting [flamegraphs](https://github.com/flamegraph-rs/flamegraph) to work I've worked out that under my personal setup where my terminal is a build of `st`, I'm getting around 300FPS with the existing rendering logic, which then tracks that it takes a little over 3 seconds to scroll to the bottom of the file. Realising that this probably _isn't_ the performance bottleneck, I then felt pretty daft for not detecting that the mouse wheel is being spun and speeding up scrolling accordingly...

With this in place I can match the observed performance of neovim.

In addition to the main feature, the following supporting changes are also part of this PR:
- Re-add criterion benchmarks
- Use a generic writer rather than Stdout for terminal state functions
- Support using an arbitrary writer in the TUI ui
- Buffer writes to TUI stdout
- Add a build profile to support generating flamegraphs

<img width="1001" height="630" alt="2025-08-31_11-11" src="https://github.com/user-attachments/assets/d39e393a-54a3-468d-8450-be90ea307c89" />

![flamegraph](https://github.com/user-attachments/assets/2f0e8917-6827-4665-8758-5926142cda65)

