### PR TITLE
Rename environment variables for spawned commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "ad_client"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "ad_event",
  "ninep",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "ad_event"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "ad_repl"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ad_client",
  "subprocess",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "ad_watch"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ad_client",
  "subprocess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ lto = false
 codegen-units = 16
 
 [dependencies]
-ad_event = { version = "0.3", path = "crates/ad_event" }
+ad_event = { version = "0.4", path = "crates/ad_event" }
 libc = "0.2.175"
 libloading = "0.8.8"
 lsp-types = "0.97.0"

--- a/crates/ad_client/Cargo.toml
+++ b/crates/ad_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ad_client"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 authors = ["sminez <innes.andersonmorrison@gmail.com>"]
 license = "MIT"
@@ -18,5 +18,5 @@ categories = [ "development-tools", "text-editors", "command-line-utilities" ]
 
 
 [dependencies]
-ad_event = { version = "0.3", path = "../ad_event" }
+ad_event = { version = "0.4", path = "../ad_event" }
 ninep = { version = "0.4", path = "../ninep" }

--- a/crates/ad_client/examples/list_sessions.rs
+++ b/crates/ad_client/examples/list_sessions.rs
@@ -1,0 +1,10 @@
+//! A simple demo of the client behaviour
+use ad_client::list_open_sessions;
+
+fn main() -> std::io::Result<()> {
+    for session in list_open_sessions()?.into_iter() {
+        println!("{session:#?}");
+    }
+
+    Ok(())
+}

--- a/crates/ad_client/src/lib.rs
+++ b/crates/ad_client/src/lib.rs
@@ -10,8 +10,11 @@
     rustdoc::all,
     clippy::undocumented_unsafe_blocks
 )]
-use ninep::sync::client::{ReadLineIter, UnixClient};
-use std::{io, io::Write, os::unix::net::UnixStream, str::FromStr};
+use ninep::{
+    sansio::server::socket_dir,
+    sync::client::{ReadLineIter, UnixClient},
+};
+use std::{env, fs, io, io::Write, os::unix::net::UnixStream, str::FromStr};
 
 mod event;
 
@@ -264,4 +267,110 @@ impl FromStr for LogEvent {
 
         Ok(evt)
     }
+}
+
+fn open_9p_sockets() -> io::Result<Vec<String>> {
+    let mut ad_sockets = Vec::new();
+    for entry in fs::read_dir(socket_dir())? {
+        let entry = entry?;
+        let fname = entry.file_name();
+        if let Some(s) = fname.to_str()
+            && s.starts_with("ad-")
+        {
+            ad_sockets.push(s.to_string());
+        }
+    }
+
+    Ok(ad_sockets)
+}
+
+/// Metadata for an ad editor session.
+#[derive(Debug)]
+pub struct SessionMeta {
+    /// The socket name within [socket_dir] for this session.
+    pub socket_name: String,
+    /// Whether or not the session is currently unresponsive.
+    ///
+    /// A session can become unresponsive when it crashes before successfully
+    /// removing it's filesystem socket.
+    pub is_unresponsive: bool,
+    /// The id of the currently active buffer.
+    pub active_buffer_id: String,
+    /// Metadata for the buffers open in this session.
+    pub buffers: Vec<BufferMeta>,
+}
+
+impl SessionMeta {
+    /// Create a new [Client] for this session.
+    pub fn client_for_session(&self) -> io::Result<Client> {
+        Ok(Client {
+            inner: UnixClient::new_unix(&self.socket_name, "")?,
+        })
+    }
+
+    /// Remove this session's filesystem socket.
+    pub fn remove_socket(&self) -> io::Result<()> {
+        fs::remove_file(socket_dir().join(&self.socket_name))
+    }
+}
+
+/// Metadata for an open buffer within an ad editor session.
+#[derive(Debug)]
+pub struct BufferMeta {
+    /// The id of the buffer.
+    pub id: String,
+    /// The full filename of the buffer.
+    pub filename: String,
+}
+
+/// Call [SessionMeta::remove_socket] for all currently unresponsive editor sessions.
+pub fn remove_unresponsive_sessions() -> io::Result<()> {
+    for session in list_open_sessions()?.into_iter() {
+        if session.is_unresponsive {
+            session.remove_socket()?;
+        }
+    }
+
+    Ok(())
+}
+
+/// List open `ad` editor sessions and their current state.
+pub fn list_open_sessions() -> io::Result<Vec<SessionMeta>> {
+    let mut sessions = Vec::new();
+
+    for ns in open_9p_sockets()?.into_iter() {
+        let mut client = match UnixClient::new_unix(&ns, "") {
+            Ok(client) => client,
+            Err(_) => {
+                sessions.push(SessionMeta {
+                    socket_name: ns,
+                    is_unresponsive: true,
+                    active_buffer_id: String::new(),
+                    buffers: Vec::new(),
+                });
+                continue;
+            }
+        };
+        let active_buffer_id = client.read_str("buffers/current")?;
+        let buffers = client
+            .read_str("buffers/index")?
+            .lines()
+            .map(|line| {
+                let mut it = line.split_whitespace();
+                let id = it.next().map(String::from).unwrap_or_default();
+                let filename = it.next().map(String::from).unwrap_or_default();
+
+                BufferMeta { id, filename }
+            })
+            .collect();
+
+        sessions.push(SessionMeta {
+            socket_name: ns,
+            is_unresponsive: false,
+            active_buffer_id,
+            buffers,
+        });
+    }
+
+    Ok(sessions)
 }

--- a/crates/ad_client/src/lib.rs
+++ b/crates/ad_client/src/lib.rs
@@ -25,10 +25,26 @@ pub struct Client {
 }
 
 impl Client {
-    /// Create a new client connected to `ad` over its 9p unix socket
+    /// Create a new client connected to `ad` over it's 9p unix socket
     pub fn new() -> io::Result<Self> {
+        let ns = match env::var("AD_PID") {
+            Ok(pid) => format!("ad-{pid}"),
+            Err(_) => "ad".to_string(),
+        };
+
         Ok(Self {
-            inner: UnixClient::new_unix("ad", "")?,
+            inner: UnixClient::new_unix(ns, "")?,
+        })
+    }
+
+    /// Create a new client connected to the `ad` session with the given pid
+    /// over it's 9p unix socket.
+    ///
+    /// When running under ad, the [Client::new] method will automatically find
+    /// and connect to it's parent session.
+    pub fn new_for_pid(pid: &str) -> io::Result<Self> {
+        Ok(Self {
+            inner: UnixClient::new_unix(format!("ad-{pid}"), "")?,
         })
     }
 

--- a/crates/ad_event/Cargo.toml
+++ b/crates/ad_event/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ad_event"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["sminez <innes.andersonmorrison@gmail.com>"]
 license = "MIT"

--- a/crates/ad_repl/Cargo.toml
+++ b/crates/ad_repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ad_repl"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["sminez <innes.andersonmorrison@gmail.com>"]
 license = "MIT"
@@ -17,5 +17,5 @@ keywords = [ "terminal", "editor", "text-editor", ]
 categories = [ "development-tools", "text-editors", "command-line-utilities" ]
 
 [dependencies]
-ad_client = { version = "0.3", path = "../ad_client" }
+ad_client = { version = "0.4", path = "../ad_client" }
 subprocess = "0.2.9"

--- a/crates/ad_watch/Cargo.toml
+++ b/crates/ad_watch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ad_watch"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [[bin]]
@@ -9,5 +9,5 @@ name = "watch-ad"
 path = "src/main.rs"
 
 [dependencies]
-ad_client = { version = "0.3", path = "../ad_client" }
+ad_client = { version = "0.4", path = "../ad_client" }
 subprocess = "0.2.9"

--- a/data/bin/G
+++ b/data/bin/G
@@ -9,12 +9,12 @@ requireAd
 pat="$*"
 if [[ -z "$*" ]]; then
   adCtl "expand-dot"
-  pat="$(bufRead "$bufid" dot)"
+  pat="$(bufRead "$AD_BUFID" dot)"
 fi
 
 dirname="$(git rev-parse --show-toplevel)"
 if [[ ! -d "$dirname" ]]; then
-  fname="$(bufRead "$bufid" filename)"
+  fname="$(bufRead "$AD_BUFID" filename)"
   if [[ -d "$fname" ]]; then
     dirname="$fname"
   else

--- a/data/bin/Slide
+++ b/data/bin/Slide
@@ -22,7 +22,7 @@
 
 requireAd
 
-fname="$(bufRead "$bufid" filename)"
+fname="$(bufRead "$AD_BUFID" filename)"
 f="$(basename "$fname")"
 d="$(dirname "$fname")"
 
@@ -45,8 +45,8 @@ case "$1" in
     ;;
 esac
 
-echo "$d/$toLoad" | bufWrite "$bufid" filename
+echo "$d/$toLoad" | bufWrite "$AD_BUFID" filename
 adCtl "Get"
 adEdit "0 i/[PrevSlide] [NextSlide]\n\n/"
-curToBof "$bufid"
-markClean "$bufid"
+curToBof "$AD_BUFID"
+markClean "$AD_BUFID"

--- a/data/bin/fmt
+++ b/data/bin/fmt
@@ -3,20 +3,20 @@
 source "$HOME/.ad/lib/ad.sh"
 
 requireAd
-fname=$(bufRead "$bufid" filename)
-addr=$(bufRead "$bufid" addr)
+fname=$(bufRead "$AD_BUFID" filename)
+addr=$(bufRead "$AD_BUFID" addr)
 maybext="${fname##*.}"
 
 case $maybext in
-  dart) formatted=$(bufRead "$bufid" body | dart format) ;;
-  json) formatted=$(bufRead "$bufid" body | jq) ;;
-  rs) formatted=$(bufRead "$bufid" body | rustfmt --edition 2021) ;;
+  dart) formatted=$(bufRead "$AD_BUFID" body | dart format) ;;
+  json) formatted=$(bufRead "$AD_BUFID" body | jq) ;;
+  rs) formatted=$(bufRead "$AD_BUFID" body | rustfmt --edition 2021) ;;
   *) adError "no format rules found for '$maybext'" ;;
 esac
 
 if [[ -n "$formatted" ]]; then
-  echo -n "," | bufWrite "$bufid" xaddr
-  echo -n "$formatted" | bufWrite "$bufid" xdot
-  echo -n "$addr" | bufWrite "$bufid" addr
+  echo -n "," | bufWrite "$AD_BUFID" xaddr
+  echo -n "$formatted" | bufWrite "$AD_BUFID" xdot
+  echo -n "$addr" | bufWrite "$AD_BUFID" addr
   adCtl "viewport-center"
 fi

--- a/data/bin/indent
+++ b/data/bin/indent
@@ -2,7 +2,6 @@
 source "$HOME/.ad/lib/ad.sh"
 
 requireAd
-id="$(currentBufferId)"
-addr="$(bufRead "$id" addr | sed -E 's/(.+):.+,(.+):.+/\1,\2/')"
+addr="$(bufRead "$AD_BUFID" addr | sed -E 's/(.+):.+,(.+):.+/\1,\2/')"
 adEdit '. x/.+/ s/^/    /'
-echo "$addr" | bufWrite "$id" addr
+echo "$addr" | bufWrite "$AD_BUFID" addr

--- a/data/bin/lint
+++ b/data/bin/lint
@@ -18,7 +18,7 @@ if [ -e "$root/Cargo.toml" ]; then
   lnum="$(echo "$line" | cut -d':' -f2)"
   col="$(echo "$line" | cut -d':' -f3)"
   adCtl "open $root/$fname"
-  bufid=$(currentBufferId)
+  bufid="$(currentBufferId)"
   echo -n "$lnum:$col" | bufWrite "$bufid" "addr"
   adCtl "viewport-center"
 else

--- a/data/bin/toggle-comment
+++ b/data/bin/toggle-comment
@@ -15,9 +15,8 @@ source "$HOME/.ad/lib/ad.sh"
 FTYPE_COMMENT_STRS="$HOME/.ad/lib/ftype-comment-chars.txt"
 
 requireAd
-id="$(currentBufferId)"
-addr="$(bufRead "$id" addr | sed -E 's/(.+):.+,(.+):.+/\1,\2/')"
-ftype="$(bufRead "$id" filetype)"
+addr="$(bufRead "$AD_BUFID" addr | sed -E 's/(.+):.+,(.+):.+/\1,\2/')"
+ftype="$(bufRead "$AD_BUFID" filetype)"
 comment_str="$(grep "$ftype" "$FTYPE_COMMENT_STRS" | cut -d' ' -f2)"
 
 if [ -z "$comment_str" ]; then
@@ -25,12 +24,12 @@ if [ -z "$comment_str" ]; then
   exit 1
 fi
 
-echo '-,/\n/' | bufWrite "$id" xaddr # expand xdot to full lines
+echo '-,/\n/' | bufWrite "$AD_BUFID" xaddr # expand xdot to full lines
 
 # If every line starts with the comment string then we're uncommenting otherwise
 # we're commenting out everything, even lines that already start with the comment
 # string
-xdot="$(bufRead "$id" xdot)"
+xdot="$(bufRead "$AD_BUFID" xdot)"
 n_lines="$(echo "$xdot" | wc -l)"
 n_comment_lines="$(echo "$xdot" | grep "^\\s*$comment_str" | wc -l)"
 
@@ -42,4 +41,4 @@ else
   adEdit "-,/\\n/ x/.+\\n/ s:^(\\s*?)$comment_str ?:\$1:"
 fi
 
-echo "$addr" | bufWrite "$id" addr
+echo "$addr" | bufWrite "$AD_BUFID" addr

--- a/data/bin/unindent
+++ b/data/bin/unindent
@@ -2,7 +2,6 @@
 source "$HOME/.ad/lib/ad.sh"
 
 requireAd
-id="$(currentBufferId)"
-addr="$(bufRead "$id" addr | sed -E 's/(.+):.+,(.+):.+/\1,\2/')"
+addr="$(bufRead "$AD_BUFID" addr | sed -E 's/(.+):.+,(.+):.+/\1,\2/')"
 adEdit '. x/.+/ s/^    //'
-echo "$addr" | bufWrite "$id" addr
+echo "$addr" | bufWrite "$AD_BUFID" addr

--- a/data/contrib/sh/sendtoRepl
+++ b/data/contrib/sh/sendtoRepl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This script can be used to send code from an ad buffer to the ad_repl (+win) buffer 
 # and executed. 
@@ -16,7 +16,7 @@ requireAd
 replbuf=$(9p read ad/buffers/index | grep win | cut -c 1)
 
 # read in selected lines and get length 
-varin=$(bufRead "$bufid" dot)
+varin=$(bufRead "$AD_BUFID" dot)
 nlines=$(echo "$varin" | wc -l)
 
 # send to ad_repl buffer

--- a/data/lib/ad.sh
+++ b/data/lib/ad.sh
@@ -21,7 +21,7 @@ adError() {
 
 # Exit with an error message if this script was not launched from ad itself
 requireAd() {
-  [[ -z "$bufid" ]] && adError "need to be run from inside of ad"
+  [[ -z "$AD_PID" ]] && adError "need to be run from inside of ad"
 }
 
 # Read the contents of an fsys file for the specified buffer

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -275,7 +275,6 @@ where
             "git rev-parse --show-toplevel",
             &d,
             self.active_buffer_id(),
-            self.active_buffer_name(),
         ) {
             Ok(s) => s,
             Err(e) => {
@@ -833,9 +832,7 @@ where
         };
 
         let id = self.active_buffer_id();
-        let res =
-            self.system
-                .pipe_through_command(raw_cmd_str, &s, d, id, self.active_buffer_name());
+        let res = self.system.pipe_through_command(raw_cmd_str, &s, d, id);
 
         match res {
             Ok(s) => self.forward_action_to_active_buffer_ignoring_scratch(
@@ -850,9 +847,7 @@ where
         let b = self.layout.active_buffer_ignoring_scratch();
         let d = b.dir().unwrap_or(&self.cwd);
         let id = b.id;
-        let res = self
-            .system
-            .run_command_blocking(raw_cmd_str, d, id, b.full_name());
+        let res = self.system.run_command_blocking(raw_cmd_str, d, id);
 
         match res {
             Ok(s) => self.handle_action(Action::InsertString { s }, Source::Fsys),
@@ -864,9 +859,9 @@ where
         let b = self.layout.active_buffer_ignoring_scratch();
         let d = b.dir().unwrap_or(&self.cwd);
         let id = b.id;
-        let res =
-            self.system
-                .run_command(raw_cmd_str, d, id, b.full_name(), self.tx_events.clone());
+        let res = self
+            .system
+            .run_command(raw_cmd_str, d, id, self.tx_events.clone());
 
         if let Err(e) = res {
             self.set_status_message(format!("Error running external command: {e}"));

--- a/src/editor/minibuffer.rs
+++ b/src/editor/minibuffer.rs
@@ -317,18 +317,17 @@ where
         cmd: &str,
         dir: &Path,
     ) -> MiniBufferSelection {
-        let initial_lines = match self.system.run_command_blocking(
-            cmd,
-            dir,
-            self.active_buffer_id(),
-            self.active_buffer_name(),
-        ) {
-            Ok(s) => s.lines().map(String::from).collect(),
-            Err(e) => {
-                self.set_status_message(format!("unable to get minibuffer input: {e}"));
-                return MiniBufferSelection::Cancelled;
-            }
-        };
+        let initial_lines =
+            match self
+                .system
+                .run_command_blocking(cmd, dir, self.active_buffer_id())
+            {
+                Ok(s) => s.lines().map(String::from).collect(),
+                Err(e) => {
+                    self.set_status_message(format!("unable to get minibuffer input: {e}"));
+                    return MiniBufferSelection::Cancelled;
+                }
+            };
 
         self.prompt_w_callback(prompt, initial_lines, None, |_| None)
     }

--- a/src/fsys/buffer.rs
+++ b/src/fsys/buffer.rs
@@ -205,7 +205,8 @@ impl BufferNodes {
                 .expect("FILENAME to be valid");
             let id = &b.str_id;
 
-            entries.push(format!("{id}\t{filename}\n"));
+            // filename already contains a trailing newline
+            entries.push(format!("{id}\t{filename}"));
         }
 
         entries.join("")

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn run_9p_oneshot(args: Vec<String>) {
     }
 }
 
-/// Depending on the requested namespace and the presence or absence of an "ad-pid" env var we may
+/// Depending on the requested namespace and the presence or absence of an "AD_PID" env var we may
 /// need to adjust the ns to include an ad PID
 fn client_for_ns(ns: &str, aname: String) -> io::Result<UnixClient> {
     if ns != "ad" {
@@ -151,7 +151,7 @@ fn client_for_ns(ns: &str, aname: String) -> io::Result<UnixClient> {
     }
 
     let mut ns = ns.to_string();
-    if let Ok(pid) = env::var("ad-pid") {
+    if let Ok(pid) = env::var("AD_PID") {
         ns.push('-');
         ns.push_str(&pid);
     } else {

--- a/src/system.rs
+++ b/src/system.rs
@@ -37,14 +37,8 @@ pub trait System: fmt::Debug {
     fn kill_child(&mut self, idx: usize);
 
     /// Run an external command and collect its output.
-    fn run_command_blocking(
-        &self,
-        cmd: &str,
-        cwd: &Path,
-        bufid: usize,
-        bufname: &str,
-    ) -> io::Result<String> {
-        run_command_blocking(cmd, cwd, bufid, bufname)
+    fn run_command_blocking(&self, cmd: &str, cwd: &Path, bufid: usize) -> io::Result<String> {
+        run_command_blocking(cmd, cwd, bufid)
     }
 
     /// Run an external command and append its output to the output buffer for `bufid` from a
@@ -55,10 +49,9 @@ pub trait System: fmt::Debug {
         cmd: &str,
         cwd: &Path,
         bufid: usize,
-        bufname: &str,
         tx: Sender<Event>,
     ) -> io::Result<()> {
-        let child = run_command(cmd, cwd, bufid, bufname, tx)?;
+        let child = run_command(cmd, cwd, bufid, tx)?;
         self.store_child_handle(cmd, child);
 
         Ok(())
@@ -71,9 +64,8 @@ pub trait System: fmt::Debug {
         input: &str,
         cwd: &Path,
         bufid: usize,
-        bufname: &str,
     ) -> io::Result<String> {
-        pipe_through_command(cmd, input, cwd, bufid, bufname)
+        pipe_through_command(cmd, input, cwd, bufid)
     }
 }
 
@@ -212,7 +204,7 @@ impl System for DefaultSystem {
     }
 }
 
-fn prepare_command(cmd: &str, cwd: &Path, bufid: usize, bufname: &str) -> Command {
+fn prepare_command(cmd: &str, cwd: &Path, bufid: usize) -> Command {
     let mut args: Vec<&str> = cmd.split_whitespace().collect();
     if args.is_empty() {
         return Command::new("");
@@ -224,17 +216,16 @@ fn prepare_command(cmd: &str, cwd: &Path, bufid: usize, bufname: &str) -> Comman
     let mut command = Command::new(cmd);
     command
         .env("PATH", format!("{home}/.ad/bin:{path}"))
-        .env("ad-pid", crate::pid().to_string())
-        .env("bufid", bufid.to_string())
-        .env("bufname", bufname)
+        .env("AD_PID", crate::pid().to_string())
+        .env("AD_BUFID", bufid.to_string())
         .current_dir(cwd)
         .args(args);
 
     command
 }
 
-fn run_command_blocking(cmd: &str, cwd: &Path, bufid: usize, bufname: &str) -> io::Result<String> {
-    let output = prepare_command(cmd, cwd, bufid, bufname).output()?;
+fn run_command_blocking(cmd: &str, cwd: &Path, bufid: usize) -> io::Result<String> {
+    let output = prepare_command(cmd, cwd, bufid).output()?;
     let mut stdout = String::from_utf8(output.stdout).unwrap_or_default();
     let stderr = String::from_utf8(output.stderr).unwrap_or_default();
     stdout.push_str(&stderr);
@@ -242,14 +233,8 @@ fn run_command_blocking(cmd: &str, cwd: &Path, bufid: usize, bufname: &str) -> i
     Ok(normalize_line_endings(stdout))
 }
 
-fn run_command(
-    cmd: &str,
-    cwd: &Path,
-    bufid: usize,
-    bufname: &str,
-    tx: Sender<Event>,
-) -> io::Result<Child> {
-    let mut child = prepare_command(cmd, cwd, bufid, bufname)
+fn run_command(cmd: &str, cwd: &Path, bufid: usize, tx: Sender<Event>) -> io::Result<Child> {
+    let mut child = prepare_command(cmd, cwd, bufid)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
@@ -289,9 +274,8 @@ pub fn pipe_through_command(
     input: &str,
     cwd: &Path,
     bufid: usize,
-    bufname: &str,
 ) -> io::Result<String> {
-    let mut child = prepare_command(cmd, cwd, bufid, bufname)
+    let mut child = prepare_command(cmd, cwd, bufid)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
Closes #147

### Environment variable changes
- `AD_PID` replaces `ad-pid`
- `AD_BUFID` replaces `bufid`
- `bufname` has been removed as this can be obtained from fsys already

### New `ad_client` functionality
- Auto-check for `AD_PID` when creating new clients
- Support attaching to a specified ad socket
- Support listing open session metadata
- Create a client from session metadata
- Support removing unresponsive sessions (same semantics as `ad --rm-sockets`)
