### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
       run: cargo nextest run --workspace --no-fail-fast
 
   reference_tests:
-    name: Run refrence editing tests on stable
+    name: Run reference editing tests on stable
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/data/help-template.txt
+++ b/data/help-template.txt
@@ -470,7 +470,7 @@ Example directory structure and contents:
 For additional information on how to write tree-sitter queries see the official documentation here:
   https://tree-sitter.github.io/tree-sitter/syntax-highlighting#queries
 
-For a quick way of re-using parsers and queries from neovim, see the following from the nvim-treesitter
+For a quick way of reusing parsers and queries from neovim, see the following from the nvim-treesitter
 project:
   https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/parsers.lua
   https://github.com/nvim-treesitter/nvim-treesitter/tree/master/queries

--- a/src/buffer/internal.rs
+++ b/src/buffer/internal.rs
@@ -641,7 +641,7 @@ impl GapBuffer {
         self.raw_byte_to_byte(raw)
     }
 
-    /// Insert a single character at the specifified character index.
+    /// Insert a single character at the specified character index.
     ///
     /// This is O(1) if idx is at the current gap start and the gap is large enough to accommodate
     /// the new text, otherwise data will need to be copied in order to relocate the gap.
@@ -675,7 +675,7 @@ impl GapBuffer {
         assert_line_endings!(self);
     }
 
-    /// Insert a string at the specifified character index.
+    /// Insert a string at the specified character index.
     ///
     /// This is O(1) if idx is at the current gap start and the gap is large enough to accommodate
     /// the new text, otherwise data will need to be copied in order to relocate the gap.

--- a/src/dot/mod.rs
+++ b/src/dot/mod.rs
@@ -66,7 +66,7 @@ impl Dot {
         }
     }
 
-    /// Convert a [Dot] into character offsets within the buffer idendifying its start and end
+    /// Convert a [Dot] into character offsets within the buffer identifying its start and end
     /// positions.
     ///
     /// For a [Cur] dot the start and end are equal

--- a/src/lsp/messages/request/mod.rs
+++ b/src/lsp/messages/request/mod.rs
@@ -132,7 +132,7 @@ pub(crate) trait LspRequest:
         man: &mut LspManager,
     ) -> Option<Actions>;
 
-    /// Map an error response from the server into editor [Actions] for processin in the main event
+    /// Map an error response from the server into editor [Actions] for processing in the main event
     /// loop. By default this method will error log the raw response before dropping it and taking
     /// no further action.
     #[allow(unused_variables)]

--- a/src/regex/vm.rs
+++ b/src/regex/vm.rs
@@ -612,7 +612,7 @@ mod tests {
     #[test_case("(?<xy>X|Y)", "xy", "X"; "named match on its own")]
     #[test_case("(?<xy>X|Y)(a|b)", "xy", "X"; "named match before unnamed")]
     #[test_case("(e| )(?<xy>X|Y)", "xy", "X"; "named match after unnamed")]
-    #[test_case("(e| )(?<xy>X|Y)(a|b)", "xy", "X"; "named match inbetween unnamed")]
+    #[test_case("(e| )(?<xy>X|Y)(a|b)", "xy", "X"; "named match in between unnamed")]
     #[test]
     fn named_submatch_works(re: &str, name: &str, expected: &str) {
         let mut r = Regex::compile(re).unwrap();

--- a/src/syntax/ts.rs
+++ b/src/syntax/ts.rs
@@ -122,7 +122,7 @@ impl TsState {
 
         if let Some((a, b)) = self.t.missing_region(raw_from, raw_to) {
             // To avoid spinning on calling back to the tree-sitter API for individual lines, we
-            // pre-emptively grab a larger block of tokens from the region ahead or behind of the
+            // preemptively grab a larger block of tokens from the region ahead or behind of the
             // requested one if we have missing tokens in that direction.
             const PADDING: usize = 512;
             let byte_from = if b < raw_to {

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -69,7 +69,7 @@ where
         })
     }
 
-    // TODO: re-use this when dynamic config updates are supported
+    // TODO: reuse this when dynamic config updates are supported
     // pub(crate) fn extend_from_pairs(
     //     &mut self,
     //     pairs: Vec<(Vec<K>, V)>,


### PR DESCRIPTION
Found via `codespell -S target -L tread,fo,worl,lits` and `typos --hidden --format brief`