### PR TITLE
Reduce allocations in the TUI renderer

### DIFF
--- a/benches/benchmarks/tui_render.rs
+++ b/benches/benchmarks/tui_render.rs
@@ -82,12 +82,12 @@ fn tui_and_layout(files: &[&str]) -> (GenericTui<StdoutSink>, Layout) {
 }
 
 fn fixed_view(group: &mut BenchmarkGroup<'_, WallTime>, title: &str, files: &[&str]) {
-    let (mut tui, layout) = tui_and_layout(files);
+    let (mut tui, mut layout) = tui_and_layout(files);
     group.bench_function(title, |b| {
         b.iter(|| {
             tui.refresh(
                 black_box("NORMAL"),
-                black_box(&layout),
+                black_box(&mut layout),
                 black_box(0),
                 black_box(&[]),
                 black_box(None),

--- a/src/buffer/buffers.rs
+++ b/src/buffer/buffers.rs
@@ -173,6 +173,10 @@ impl Buffers {
         self.inner.iter().map(|(_, b)| b)
     }
 
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Buffer> {
+        self.inner.iter_mut().map(|(_, b)| b)
+    }
+
     pub fn close_buffer(&mut self, id: BufferId) {
         let removed = self.inner.remove_where_with_default(
             |b| b.id == id,

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -176,6 +176,7 @@ pub struct Buffer {
     pub(crate) cached_rx: usize,
     pub(crate) last_save: SystemTime,
     pub(crate) dirty: bool,
+    pub(crate) changed_since_last_render: bool,
     pub(crate) input_filter: Option<InputFilter>,
     pub(crate) syntax_state: Option<SyntaxState>,
     config: Arc<Mutex<Config>>,
@@ -200,6 +201,7 @@ impl Buffer {
             cached_rx: 0,
             last_save: SystemTime::now(),
             dirty: false,
+            changed_since_last_render: false,
             input_filter: None,
             syntax_state: None,
             config,
@@ -223,6 +225,7 @@ impl Buffer {
             cached_rx: 0,
             last_save: SystemTime::now(),
             dirty: false,
+            changed_since_last_render: false,
             input_filter: None,
             syntax_state: None,
             config,
@@ -255,6 +258,7 @@ impl Buffer {
             cached_rx: 0,
             last_save: SystemTime::now(),
             dirty: false,
+            changed_since_last_render: false,
             input_filter: None,
             syntax_state: None,
             config,
@@ -280,6 +284,7 @@ impl Buffer {
             cached_rx: 0,
             last_save: SystemTime::now(),
             dirty: false,
+            changed_since_last_render: false,
             input_filter: None,
             syntax_state: None,
             config,
@@ -344,6 +349,7 @@ impl Buffer {
 
         self.kind = kind;
         self.try_set_ts_state();
+        self.changed_since_last_render = true;
 
         None
     }
@@ -397,6 +403,7 @@ impl Buffer {
         self.xdot.clamp_idx(n_chars);
         self.edit_log.clear();
         self.dirty = false;
+        self.changed_since_last_render = true;
         self.last_save = SystemTime::now();
 
         let n_lines = self.txt.len_lines();
@@ -421,6 +428,7 @@ impl Buffer {
             cached_rx: 0,
             last_save: SystemTime::now(),
             dirty: false,
+            changed_since_last_render: false,
             input_filter: None,
             syntax_state: None,
             config,
@@ -675,6 +683,7 @@ impl Buffer {
         };
 
         self.set_dot(TextObject::Delimited(l, r), 1);
+        self.changed_since_last_render = true;
     }
 
     /// If the current dot is a cursor rather than a range, expand it to a sensible range.
@@ -686,6 +695,7 @@ impl Buffer {
             Dot::Cur { c: Cur { idx } } => idx,
             Dot::Range { .. } => return,
         };
+        self.changed_since_last_render = true;
 
         if let Some(dot) = self.try_expand_known(current_index) {
             self.dot = dot;
@@ -820,6 +830,7 @@ impl Buffer {
         self.dot = dot;
         self.dot.clamp_idx(self.txt.len_chars());
         self.xdot.clamp_idx(self.txt.len_chars());
+        self.changed_since_last_render = true;
     }
 
     /// The error result of this function is an error string that should be displayed to the user
@@ -916,9 +927,10 @@ impl Buffer {
 
             Input::Arrow(arr) => self.set_dot(TextObject::Arr(arr), 1),
 
-            _ => (),
+            _ => return None,
         }
 
+        self.changed_since_last_render = true;
         None
     }
 
@@ -929,12 +941,14 @@ impl Buffer {
         }
         self.dot.clamp_idx(self.txt.len_chars());
         self.xdot.clamp_idx(self.txt.len_chars());
+        self.changed_since_last_render = true;
     }
 
     /// Set this Buffer's dot to an explicit cursor position, clamping to EOB.
     pub fn set_dot_from_cursor(&mut self, idx: usize) {
         self.dot = Cur::new(idx).into();
         self.dot.clamp_idx(self.txt.len_chars());
+        self.changed_since_last_render = true;
     }
 
     /// Set this Buffer's dot to an explicit [Range], clamping to EOB.
@@ -942,6 +956,7 @@ impl Buffer {
         self.dot = Dot::from(Range::from_cursors(Cur::new(from), Cur::new(to), false))
             .collapse_null_range();
         self.dot.clamp_idx(self.txt.len_chars());
+        self.changed_since_last_render = true;
     }
 
     fn set_dot_from_coords(&mut self, coords: Coords) {
@@ -949,6 +964,7 @@ impl Buffer {
         self.dot = self.map_addr(&mut addr);
         self.dot.clamp_idx(self.txt.len_chars());
         self.xdot.clamp_idx(self.txt.len_chars());
+        self.changed_since_last_render = true;
     }
 
     fn set_xdot_from_coords(&mut self, coords: Coords) {
@@ -964,6 +980,7 @@ impl Buffer {
         }
         self.dot.clamp_idx(self.txt.len_chars());
         self.xdot.clamp_idx(self.txt.len_chars());
+        self.changed_since_last_render = true;
     }
 
     /// Extend dot backward and clamp to ensure it is within bounds
@@ -973,6 +990,7 @@ impl Buffer {
         }
         self.dot.clamp_idx(self.txt.len_chars());
         self.xdot.clamp_idx(self.txt.len_chars());
+        self.changed_since_last_render = true;
     }
 
     pub(crate) fn new_edit_log_transaction(&mut self) {
@@ -988,6 +1006,7 @@ impl Buffer {
                 }
                 self.edit_log.paused = false;
                 self.dirty = !self.edit_log.is_empty();
+                self.changed_since_last_render = true;
                 None
             }
             None => Some(ActionOutcome::SetStatusMessage(
@@ -1004,6 +1023,8 @@ impl Buffer {
                     self.apply_edit(edit);
                 }
                 self.edit_log.paused = false;
+                self.dirty = true;
+                self.changed_since_last_render = true;
                 None
             }
             None => Some(ActionOutcome::SetStatusMessage(
@@ -1097,6 +1118,7 @@ impl Buffer {
         }
 
         self.mark_dirty();
+        self.changed_since_last_render = true;
 
         (Cur { idx: idx + 1 }, deleted)
     }
@@ -1143,6 +1165,7 @@ impl Buffer {
         }
 
         self.mark_dirty();
+        self.changed_since_last_render = true;
 
         (cur, deleted)
     }
@@ -1174,6 +1197,7 @@ impl Buffer {
 
             self.edit_log.delete_char(cur, ch);
             self.mark_dirty();
+            self.changed_since_last_render = true;
         }
 
         cur
@@ -1195,6 +1219,7 @@ impl Buffer {
 
         self.edit_log.delete_string(r.start, s.clone());
         self.mark_dirty();
+        self.changed_since_last_render = true;
 
         (r.start, Some(s))
     }
@@ -1202,6 +1227,7 @@ impl Buffer {
     pub(crate) fn find_forward(&mut self, s: &str) {
         if let Some(dot) = find_forward_wrapping(&s, self) {
             self.dot = dot;
+            self.changed_since_last_render = true;
         }
     }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -347,10 +347,9 @@ where
 
     pub fn refresh_screen_w_minibuffer(&mut self, mb: Option<MiniBufferState<'_>>) {
         self.layout.clamp_scroll();
-        self.layout.update_visible_ts_state();
         self.ui.refresh(
             &self.modes[0].name,
-            &self.layout,
+            &mut self.layout,
             self.system.n_running_children(),
             &self.pending_keys,
             self.held_click.as_ref(),

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -88,6 +88,10 @@ pub struct Layout {
     pub(super) cols: ZipList<Column>,
     /// Known Buffer views that are not currently active
     pub(super) views: Vec<View>,
+    /// Whether or not the on-screen state changed since the last render of the UI.
+    /// Per-buffer state changes are tracked on each [Buffer], this flag is only for
+    /// changes to the UI layout itself.
+    changed_since_last_render: bool,
 }
 
 impl Layout {
@@ -120,12 +124,28 @@ impl Layout {
             screen_cols,
             cols: ziplist![Column::new(screen_rows, screen_cols, &[id])],
             views: vec![],
+            changed_since_last_render: false,
         };
 
         #[cfg(test)]
         assert_invariants!(l);
 
         l
+    }
+
+    /// Check to see if any actions taken since the last time this method was called resulted
+    /// in changes to the visible UI state.
+    ///
+    /// Calling this method will reset the internal flags used for checking these state changes.
+    pub(crate) fn changed_since_last_render(&mut self) -> bool {
+        let had_change = self.changed_since_last_render
+            || self.buffers.iter().any(|b| b.changed_since_last_render);
+        self.changed_since_last_render = false;
+        self.buffers
+            .iter_mut()
+            .for_each(|b| b.changed_since_last_render = false);
+
+        had_change
     }
 
     pub(crate) fn buffers(&self) -> &Buffers {
@@ -205,6 +225,7 @@ impl Layout {
 
     pub(crate) fn toggle_scratch(&mut self) {
         self.scratch.toggle();
+        self.changed_since_last_render = true;
     }
 
     pub fn open_or_focus<P: AsRef<Path>>(
@@ -213,6 +234,8 @@ impl Layout {
         mut new_window: bool,
     ) -> io::Result<Option<BufferId>> {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         if self.buffers.is_empty_squirrel() {
             // in the case where we only have an empty squirrel buffer present, we always replace
             // the current buffer with the one that is newly opened.
@@ -247,6 +270,8 @@ impl Layout {
         new_window: bool,
     ) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         let id = self.buffers.open_virtual(name.into(), content.into());
 
         if self.buffer_is_visible(id) {
@@ -271,6 +296,8 @@ impl Layout {
         name: impl Into<String>,
         content: impl Into<String>,
     ) {
+        self.changed_since_last_render = true;
+
         self.scratch
             .set_transient(name.into(), content.into(), self.config.clone());
     }
@@ -286,6 +313,8 @@ impl Layout {
     ///     first column
     pub(crate) fn close_buffer(&mut self, id: BufferId) -> bool {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         if id == self.scratch.b.buffer().id {
             self.scratch.is_visible = false;
             return false;
@@ -358,6 +387,7 @@ impl Layout {
         }
 
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
 
         if let Some(id) = self.buffers.focus_id(id) {
             if !force_active && self.buffer_is_visible(id) {
@@ -375,6 +405,8 @@ impl Layout {
 
     pub(crate) fn focus_next_buffer(&mut self) -> BufferId {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         self.buffers.next();
         let id = self.active_buffer().id;
         self.show_buffer_in_active_window(id);
@@ -384,6 +416,8 @@ impl Layout {
 
     pub(crate) fn focus_previous_buffer(&mut self) -> BufferId {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         self.buffers.previous();
         let id = self.active_buffer().id;
         self.show_buffer_in_active_window(id);
@@ -394,6 +428,8 @@ impl Layout {
     /// Close the active window, if this was the last remaining window then
     /// Editor::delete_active_window will exit.
     pub(crate) fn close_active_window(&mut self) -> bool {
+        self.changed_since_last_render = true;
+
         if self.scratch.is_focused {
             self.scratch.toggle();
             return false;
@@ -423,6 +459,8 @@ impl Layout {
     /// Close the active column, if this was the last remaining column then
     /// Editor::delete_active_column will exit.
     pub(crate) fn close_active_column(&mut self) -> bool {
+        self.changed_since_last_render = true;
+
         if self.scratch.is_focused {
             self.scratch.toggle();
             return false;
@@ -495,6 +533,8 @@ impl Layout {
     /// Move focus to the column to the right of current focus (wrapping)
     pub(crate) fn next_column(&mut self) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         self.cols.focus_down();
         self.buffers.focus_id(self.focused_view().bufid);
         self.force_cursor_to_be_in_view();
@@ -506,6 +546,8 @@ impl Layout {
     /// Move focus to the column to the left of current focus (wrapping)
     pub(crate) fn prev_column(&mut self) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         self.cols.focus_up();
         self.buffers.focus_id(self.focused_view().bufid);
         self.force_cursor_to_be_in_view();
@@ -517,6 +559,8 @@ impl Layout {
     /// Move focus to the window below in the current column (wrapping)
     pub(crate) fn next_window_in_column(&mut self) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         self.cols.focus.wins.focus_down();
         self.buffers.focus_id(self.focused_view().bufid);
         self.force_cursor_to_be_in_view();
@@ -528,6 +572,8 @@ impl Layout {
     /// Move focus to the window above in the current column (wrapping)
     pub(crate) fn prev_window_in_column(&mut self) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         self.cols.focus.wins.focus_up();
         self.buffers.focus_id(self.focused_view().bufid);
         self.force_cursor_to_be_in_view();
@@ -539,6 +585,8 @@ impl Layout {
     /// Drag the focused window up through the column containing it (wrapping)
     pub(crate) fn drag_up(&mut self) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         self.cols.focus.wins.swap_up();
 
         #[cfg(test)]
@@ -548,6 +596,8 @@ impl Layout {
     /// Drag the focused window down through the column containing it (wrapping)
     pub(crate) fn drag_down(&mut self) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         self.cols.focus.wins.swap_down();
 
         #[cfg(test)]
@@ -567,6 +617,7 @@ impl Layout {
     ///   and the previous column is removed.
     pub(crate) fn drag_left(&mut self) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
 
         // Strictly speaking, self.cols.up.is_empty() == true implies self.cols.len() == 1 but
         // we keep the explicit check for clarity.
@@ -619,6 +670,7 @@ impl Layout {
     /// See [Layout::drag_left] for semantics.
     pub(crate) fn drag_right(&mut self) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
 
         // Strictly speaking, self.cols.up.is_empty() == true implies self.cols.len() == 1 but
         // we keep the explicit check for clarity.
@@ -666,6 +718,7 @@ impl Layout {
     /// The adjustment is always applied from the left of the Column unless the active column
     /// is the first in the [Layout], in which case the adjustment is made from the right.
     pub(crate) fn resize_active_column(&mut self, delta_cols: i16) {
+        self.changed_since_last_render = true;
         self.cols.grow_focus(delta_cols);
     }
 
@@ -676,6 +729,7 @@ impl Layout {
     /// is the first window in its [Column], in which case the adjustment is made from the
     /// bottom of the window instead.
     pub(crate) fn resize_active_window(&mut self, delta_rows: i16) {
+        self.changed_since_last_render = true;
         self.cols.focus.wins.grow_focus(delta_rows);
     }
 
@@ -685,6 +739,8 @@ impl Layout {
     /// Any existing layout customisation will be preserved as far as possible by converting
     /// dimensions to be relative to the size of the full screen.
     pub(crate) fn update_screen_size(&mut self, rows: usize, cols: usize) {
+        self.changed_since_last_render = true;
+
         let col_ratio = (cols as f32) / (self.screen_cols as f32);
         let row_ratio = (rows as f32) / (self.screen_rows as f32);
 
@@ -701,6 +757,8 @@ impl Layout {
 
     /// Force the columns within the layout to be equally sized.
     pub(crate) fn balance_columns(&mut self) {
+        self.changed_since_last_render = true;
+
         let (n_cols, slop) = calculate_dims(self.screen_cols, self.cols.len());
         for (i, (_, col)) in self.cols.iter_mut().enumerate() {
             col.n_cols = n_cols;
@@ -712,12 +770,14 @@ impl Layout {
 
     /// Force the windows within the active column to be balanced.
     pub(crate) fn balance_active_column(&mut self) {
+        self.changed_since_last_render = true;
         self.cols.focus.balance_windows(self.screen_rows);
     }
 
     /// Force the all windows within the layout to be equally sized within their respective
     /// columns.
     pub(crate) fn balance_windows(&mut self) {
+        self.changed_since_last_render = true;
         for (_, col) in self.cols.iter_mut() {
             col.balance_windows(self.screen_rows);
         }
@@ -750,6 +810,8 @@ impl Layout {
     /// Set the currently focused window to contain the given buffer
     pub(crate) fn show_buffer_in_active_window(&mut self, id: BufferId) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         if self.focused_view().bufid == id {
             return;
         }
@@ -772,6 +834,8 @@ impl Layout {
     /// current active window.
     pub(crate) fn new_column(&mut self) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         let view = self.focused_view().clone();
         let mut col = Column::new(self.screen_rows, self.screen_cols, &[view.bufid]);
         col.wins.last_mut().view = view;
@@ -787,6 +851,8 @@ impl Layout {
     /// found in the current active window.
     pub(crate) fn new_window(&mut self) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         let view = self.focused_view().clone();
         let wins = &mut self.cols.focus.wins;
         wins.insert_at(Position::Tail, Window { n_rows: 0, view });
@@ -800,6 +866,8 @@ impl Layout {
     /// Set the currently focused window to contain the given buffer
     pub(crate) fn show_buffer_in_new_window(&mut self, id: BufferId) {
         self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
         let view = if self.focused_view().bufid == id {
             self.focused_view().clone()
         } else {
@@ -830,6 +898,7 @@ impl Layout {
     }
 
     pub(crate) fn force_cursor_to_be_in_view(&mut self) {
+        self.changed_since_last_render = true;
         let tabstop = config_handle!(self).tabstop;
 
         if self.scratch.is_focused {
@@ -855,6 +924,7 @@ impl Layout {
     }
 
     pub(crate) fn clamp_scroll(&mut self) {
+        self.changed_since_last_render = true;
         let tabstop = config_handle!(self).tabstop;
 
         if self.scratch.is_focused {
@@ -880,6 +950,7 @@ impl Layout {
     }
 
     pub(crate) fn set_viewport(&mut self, vp: ViewPort) {
+        self.changed_since_last_render = true;
         let tabstop = config_handle!(self).tabstop;
 
         if self.scratch.is_focused {
@@ -970,6 +1041,7 @@ impl Layout {
     }
 
     fn focus_buffer_for_screen_coords(&mut self, x: usize, y: usize) -> BufferId {
+        self.changed_since_last_render = true;
         let mut x_offset = 0;
         let mut y_offset = 0;
 
@@ -1058,6 +1130,7 @@ impl Layout {
     /// Returns true if the click was in the currently active buffer and false if this click has
     /// changed the active buffer.
     pub(crate) fn set_dot_from_screen_coords(&mut self, x: usize, y: usize) -> bool {
+        self.changed_since_last_render = true;
         let current_bufid = self.active_buffer().id;
         let bufid = self.focus_buffer_for_screen_coords(x, y);
         let c = self.cur_from_screen_coords(x, y);
@@ -1071,6 +1144,7 @@ impl Layout {
 
     /// Scroll the `View` under the given cursor coordinates up or down by `scroll_rows`
     pub fn scroll_view(&mut self, x: usize, y: usize, up: bool, scroll_rows: usize) {
+        self.changed_since_last_render = true;
         let tabstop = config_handle!(self).tabstop;
         let mut x_offset = 0;
         let mut y_offset = 0;
@@ -1594,6 +1668,7 @@ mod tests {
             screen_cols: n_cols,
             cols: ZipList::try_from_iter(cols).unwrap(),
             views: vec![],
+            changed_since_last_render: false,
         };
         l.update_screen_size(n_rows, n_cols);
 
@@ -1624,6 +1699,7 @@ mod tests {
             screen_cols: 100,
             cols: ziplist![Column::new(80, 100, &[id])],
             views: vec![],
+            changed_since_last_render: false,
         };
 
         l.new_column();

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -924,7 +924,6 @@ impl Layout {
     }
 
     pub(crate) fn clamp_scroll(&mut self) {
-        self.changed_since_last_render = true;
         let tabstop = config_handle!(self).tabstop;
 
         if self.scratch.is_focused {

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -139,11 +139,13 @@ impl Layout {
     /// Calling this method will reset the internal flags used for checking these state changes.
     pub(crate) fn changed_since_last_render(&mut self) -> bool {
         let had_change = self.changed_since_last_render
-            || self.buffers.iter().any(|b| b.changed_since_last_render);
+            || self.buffers.iter().any(|b| b.changed_since_last_render)
+            || self.scratch.b.buffer().changed_since_last_render;
         self.changed_since_last_render = false;
         self.buffers
             .iter_mut()
             .for_each(|b| b.changed_since_last_render = false);
+        self.scratch.b.buffer_mut().changed_since_last_render = false;
 
         had_change
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -34,7 +34,7 @@ pub trait UserInterface {
     fn refresh(
         &mut self,
         mode_name: &str,
-        layout: &Layout,
+        layout: &mut Layout,
         n_running: usize,
         pending_keys: &[Input],
         held_click: Option<&Click>,
@@ -128,7 +128,7 @@ impl UserInterface for Ui {
     fn refresh(
         &mut self,
         mode_name: &str,
-        layout: &Layout,
+        layout: &mut Layout,
         n_running: usize,
         pending_keys: &[Input],
         held_click: Option<&Click>,

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -40,11 +40,11 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 const MIN_COLS: usize = 20;
 const MIN_ROWS: usize = 5;
 
-const HLINE: &str = "─";
-const VLINE: &str = "│";
-const RTSTR: &str = "├";
-const LTSTR: &str = "┤";
-const XSTR: &str = "┼";
+const H_STR: &str = "─";
+const V_STR: &str = "│";
+const TR_STR: &str = "├";
+const TL_STR: &str = "┤";
+const X_STR: &str = "┼";
 
 pub type Tui = GenericTui<StdoutLock<'static>>;
 
@@ -642,8 +642,8 @@ impl<'a> ColRenderer<'a> {
         } else {
             self.current = None;
             let left_edge = match prev_col {
-                Some(PrevCol::Buffer) => RTSTR,
-                Some(PrevCol::Hline) => XSTR,
+                Some(PrevCol::Buffer) => TR_STR,
+                Some(PrevCol::Hline) => X_STR,
                 None => "",
             };
 
@@ -652,7 +652,7 @@ impl<'a> ColRenderer<'a> {
                 "{}{}{left_edge}{}",
                 Style::Fg(self.cs.minibuffer_hl),
                 Style::Bg(self.cs.bg),
-                HLINE.repeat(self.n_cols)
+                H_STR.repeat(self.n_cols)
             );
             Some(PrevCol::Hline)
         };
@@ -688,8 +688,8 @@ impl<'a> WinRenderer<'a> {
 
         if let Some(pc) = prev_col {
             let left_edge = match pc {
-                PrevCol::Buffer => VLINE,
-                PrevCol::Hline => LTSTR,
+                PrevCol::Buffer => V_STR,
+                PrevCol::Hline => TL_STR,
             };
 
             _ = write!(
@@ -704,7 +704,7 @@ impl<'a> WinRenderer<'a> {
             None => {
                 _ = write!(
                     buf,
-                    "{}{}~ {VLINE:>width$}{}",
+                    "{}{}~ {V_STR:>width$}{}",
                     Style::Fg(self.cs.signcol_fg),
                     Style::Bg(self.cs.bg),
                     Style::Fg(self.cs.fg),
@@ -720,7 +720,7 @@ impl<'a> WinRenderer<'a> {
 
                 _ = write!(
                     buf,
-                    "{}{} {:>width$}{VLINE}",
+                    "{}{} {:>width$}{V_STR}",
                     Style::Fg(self.cs.signcol_fg),
                     Style::Bg(self.cs.bg),
                     file_row + 1,

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -55,8 +55,6 @@ pub type Tui = GenericTui<StdoutLock<'static>>;
 pub struct GenericTui<W: Write> {
     stdout: BufWriter<W>,
     config: Arc<Mutex<Config>>,
-    screen_rows: usize,
-    screen_cols: usize,
     status_message: String,
     last_status: Instant,
     mb_last_frame: bool,
@@ -87,8 +85,6 @@ impl<W: Write> GenericTui<W> {
         Self {
             stdout: BufWriter::new(stdout),
             config,
-            screen_rows: 0,
-            screen_cols: 0,
             status_message: String::new(),
             last_status: Instant::now(),
             mb_last_frame: false,
@@ -97,8 +93,8 @@ impl<W: Write> GenericTui<W> {
     }
 
     pub fn set_size(&mut self, rows: usize, cols: usize) {
-        self.screen_rows = rows;
-        self.screen_cols = cols;
+        self.frame.screen_rows = rows;
+        self.frame.screen_cols = cols;
     }
 
     fn render(
@@ -135,7 +131,7 @@ impl<W: Write> GenericTui<W> {
         // This is the screen size that we have to work with for the buffer content we currently want to
         // display. If the minibuffer is active then it take priority over anything else and we always
         // show the status bar as the final two lines of the UI.
-        let effective_screen_rows = self.screen_rows.saturating_sub(offset);
+        let effective_screen_rows = self.frame.screen_rows.saturating_sub(offset);
 
         let load_exec_range = match held_click {
             Some(click) if click.btn == MouseButton::Right || click.btn == MouseButton::Middle => {
@@ -153,22 +149,16 @@ impl<W: Write> GenericTui<W> {
         self.frame
             .render_windows(layout, load_exec_range, effective_screen_rows, tabstop, cs);
         self.frame
-            .render_status_bar(cs, mode_name, n_running, active_buffer, self.screen_cols);
+            .render_status_bar(cs, mode_name, n_running, active_buffer);
 
         self.frame.show_mb = w_minibuffer || layout.scratch.is_visible;
         self.frame.show_msg_bar = !w_minibuffer;
 
         if w_minibuffer {
-            self.frame
-                .render_minibuffer_state(&mb, tabstop, cs, self.screen_cols);
+            self.frame.render_minibuffer_state(&mb, tabstop, cs);
         } else if layout.scratch.is_visible {
-            self.frame.render_scratch(
-                &layout.scratch,
-                scratch_load_exec_range,
-                self.screen_cols,
-                tabstop,
-                cs,
-            );
+            self.frame
+                .render_scratch(&layout.scratch, scratch_load_exec_range, tabstop, cs);
         };
 
         if self.frame.show_msg_bar {
@@ -178,12 +168,11 @@ impl<W: Write> GenericTui<W> {
                 status_timeout,
                 self.status_message.clone(),
                 self.last_status,
-                self.screen_cols,
             );
         };
 
         let (cur_x, cur_y) = if w_minibuffer {
-            (mb.cx, self.screen_rows + mb.n_visible_lines + 1)
+            (mb.cx, self.frame.screen_rows + mb.n_visible_lines + 1)
         } else {
             layout.ui_xy()
         };
@@ -221,8 +210,8 @@ impl<W: Write> UserInterface for GenericTui<W> {
         unsafe { register_signal_handler() };
 
         let (screen_rows, screen_cols) = get_termsize();
-        self.screen_rows = screen_rows;
-        self.screen_cols = screen_cols;
+        self.frame.screen_rows = screen_rows;
+        self.frame.screen_cols = screen_cols;
 
         spawn_input_thread(tx);
 
@@ -252,12 +241,12 @@ impl<W: Write> UserInterface for GenericTui<W> {
         held_click: Option<&Click>,
         mb: Option<MiniBufferState<'_>>,
     ) {
-        self.screen_rows = layout.screen_rows;
-        self.screen_cols = layout.screen_cols;
+        self.frame.screen_rows = layout.screen_rows;
+        self.frame.screen_cols = layout.screen_cols;
         self.frame.show_msg_bar = mb.is_none();
         let mb_this_frame = mb.is_some();
 
-        if self.screen_cols < MIN_COLS || self.screen_rows < MIN_ROWS {
+        if self.frame.screen_cols < MIN_COLS || self.frame.screen_rows < MIN_ROWS {
             return;
         }
 
@@ -281,9 +270,8 @@ impl<W: Write> UserInterface for GenericTui<W> {
                 status_timeout,
                 self.status_message.clone(),
                 self.last_status,
-                self.screen_cols,
             );
-            if let Err(e) = self.frame.write_msg_bar(&mut self.stdout, self.screen_rows) {
+            if let Err(e) = self.frame.write_msg_bar(&mut self.stdout) {
                 die!("Unable to refresh screen: {e}");
             }
         }
@@ -313,6 +301,8 @@ pub struct Frame {
     show_mb: bool,
     msg_bar: String,
     show_msg_bar: bool,
+    screen_rows: usize,
+    screen_cols: usize,
     cur_x: usize,
     cur_y: usize,
     // Box elements for rendering window borders
@@ -375,8 +365,8 @@ impl Frame {
         )
     }
 
-    fn write_msg_bar(&self, w: &mut impl Write, screen_rows: usize) -> io::Result<()> {
-        write!(w, "{}{}", Cursor::Hide, Cursor::To(1, screen_rows + 2))?;
+    fn write_msg_bar(&self, w: &mut impl Write) -> io::Result<()> {
+        write!(w, "{}{}", Cursor::Hide, Cursor::To(1, self.screen_rows + 2))?;
         w.write_all(self.msg_bar.as_bytes())?;
         write!(
             w,
@@ -432,7 +422,6 @@ impl Frame {
         mode_name: &str,
         n_running: usize,
         b: &Buffer,
-        screen_cols: usize,
     ) {
         self.status_bar.clear();
 
@@ -452,7 +441,9 @@ impl Frame {
             },
             b.dot.addr(b)
         );
-        let width = screen_cols.saturating_sub(UnicodeWidthStr::width(lstatus.as_str()));
+        let width = self
+            .screen_cols
+            .saturating_sub(UnicodeWidthStr::width(lstatus.as_str()));
 
         _ = write!(
             &mut self.status_bar,
@@ -471,17 +462,19 @@ impl Frame {
         status_timeout: u64,
         mut msg: String,
         last_status: Instant,
-        screen_cols: usize,
     ) {
         self.msg_bar.clear();
         self.msg_bar.push_str(&Cursor::ClearRight.to_string());
-        msg.truncate(screen_cols.saturating_sub(10));
+        msg.truncate(self.screen_cols.saturating_sub(10));
 
         let pending = render_pending(pending_keys);
         let delta = (Instant::now() - last_status).as_secs();
 
         if !msg.is_empty() && delta < status_timeout {
-            let width = screen_cols.saturating_sub(msg.len()).saturating_sub(10);
+            let width = self
+                .screen_cols
+                .saturating_sub(msg.len())
+                .saturating_sub(10);
             _ = write!(
                 &mut self.msg_bar,
                 "{}{}{msg}{pending:>width$}          ",
@@ -489,7 +482,7 @@ impl Frame {
                 Style::Bg(cs.bg)
             );
         } else {
-            let width = screen_cols.saturating_sub(10);
+            let width = self.screen_cols.saturating_sub(10);
             _ = write!(
                 &mut self.msg_bar,
                 "{}{}{pending:>width$}          ",
@@ -504,7 +497,6 @@ impl Frame {
         mb: &MiniBufferState<'_>,
         tabstop: usize,
         cs: &ColorScheme,
-        screen_cols: usize,
     ) {
         self.mb_lines.clear();
 
@@ -532,17 +524,17 @@ impl Frame {
                 render_chars(
                     &mut chars,
                     None,
-                    screen_cols,
+                    self.screen_cols,
                     tabstop,
                     &mut cols,
                     &mut self.mb_lines,
                 );
 
-                if cols < screen_cols {
+                if cols < self.screen_cols {
                     self.mb_lines.push_str(&Style::Bg(bg).to_string());
                 }
 
-                let width = screen_cols;
+                let width = self.screen_cols;
                 _ = write!(&mut self.mb_lines, "{:>width$}\r\n", Cursor::ClearRight);
             }
         }
@@ -562,7 +554,6 @@ impl Frame {
         &mut self,
         scratch: &Scratch,
         load_exec_range: Option<(bool, Range)>,
-        n_cols: usize,
         tabstop: usize,
         cs: &ColorScheme,
     ) {
@@ -578,7 +569,7 @@ impl Frame {
         let mut wr = WinRenderer {
             y: 0,
             w_lnum,
-            n_cols,
+            n_cols: self.screen_cols,
             tabstop,
             it: b.iter_tokenized_lines_from(scratch.w.view.row_off, rng),
             gb: &b.txt,
@@ -1204,14 +1195,13 @@ mod tests {
             bottom: 0,
         };
 
-        let mut tui = Tui::new(Default::default());
-        tui.screen_cols = 91;
+        let mut frame = Frame::new(Default::default());
+        frame.screen_cols = 91;
 
         // In 137 this was panicking due to indexing into the rendered line using self.screen_cols
         // as a raw byte offset. The fix is simply not to truncate in that way as render_chars is
         // already ensuring that the buffer it is building up is staying within the available
         // screen space.
-        tui.frame
-            .render_minibuffer_state(&mb, 4, &Default::default(), tui.screen_cols);
+        frame.render_minibuffer_state(&mb, 4, &Default::default());
     }
 }

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -265,7 +265,10 @@ impl<W: Write> UserInterface for GenericTui<W> {
         if layout.changed_since_last_render() {
             layout.update_visible_ts_state();
             self.render(mode_name, layout, n_running, pending_keys, held_click, mb);
-        } else if mb.is_none() {
+            if let Err(e) = self.frame.write(&mut self.stdout) {
+                die!("Unable to refresh screen: {e}");
+            }
+        } else if self.frame.show_msg_bar {
             // match self.render in not showing the message bar if the minibuffer is open
             let conf = config_handle!(self);
             let (cs, status_timeout) = (&conf.colorscheme, conf.status_timeout);
@@ -277,10 +280,9 @@ impl<W: Write> UserInterface for GenericTui<W> {
                 self.last_status,
                 self.screen_cols,
             );
-        }
-
-        if let Err(e) = self.frame.write(&mut self.stdout) {
-            die!("Unable to refresh screen: {e}");
+            if let Err(e) = self.frame.write_msg_bar(&mut self.stdout, self.screen_rows) {
+                die!("Unable to refresh screen: {e}");
+            }
         }
 
         if let Err(e) = self.stdout.flush() {
@@ -360,6 +362,17 @@ impl Frame {
             w.write_all(self.msg_bar.as_bytes())?;
         }
 
+        write!(
+            w,
+            "{}{}",
+            Cursor::To(self.cur_x + 1, self.cur_y + 1),
+            Cursor::Show
+        )
+    }
+
+    fn write_msg_bar(&self, w: &mut impl Write, screen_rows: usize) -> io::Result<()> {
+        write!(w, "{}{}", Cursor::Hide, Cursor::To(1, screen_rows + 2))?;
+        w.write_all(self.msg_bar.as_bytes())?;
         write!(
             w,
             "{}{}",

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -42,7 +42,8 @@ const MIN_ROWS: usize = 5;
 
 const HLINE: &str = "─";
 const VLINE: &str = "│";
-const TSTR: &str = "├";
+const RTSTR: &str = "├";
+const LTSTR: &str = "┤";
 const XSTR: &str = "┼";
 
 fn box_draw_str(s: &str, cs: &ColorScheme) -> String {
@@ -338,7 +339,7 @@ impl Frame {
         let cs = &config_handle!(self).colorscheme;
         let vstr = box_draw_str(VLINE, cs);
         let hstr = box_draw_str(HLINE, cs);
-        self.tstr = box_draw_str(TSTR, cs);
+        self.tstr = box_draw_str(RTSTR, cs);
         self.xstr = box_draw_str(XSTR, cs);
         self.hvh = format!("{hstr}{vstr}{hstr}");
         self.vh = format!("{vstr}{hstr}");
@@ -397,21 +398,18 @@ impl Frame {
 
         let n_cols = col_renderers.len();
         'outer: loop {
+            let mut remaining;
+            let mut prev_col = None;
+
             for (i, cr) in col_renderers.iter_mut().enumerate() {
-                let remaining = cr.render_next_line(&mut self.win_lines, &mut self.style_cache);
-                if i < n_cols - 1 {
-                    self.win_lines.push_str(&self.vstr);
-                }
+                (remaining, prev_col) =
+                    cr.render_next_line(&mut self.win_lines, prev_col, &mut self.style_cache);
                 if i == n_cols - 1 && !remaining {
                     _ = write!(&mut self.win_lines, "{}\r\n", Cursor::ClearRight);
                     break 'outer;
                 }
             }
 
-            // col_buf = col_buf
-            //     .replace(&self.hvh, &self.xstr)
-            //     .replace(&self.vh, &self.tstr);
-            // self.win_lines.push_str(&col_buf);
             _ = write!(&mut self.win_lines, "{}\r\n", Cursor::ClearRight);
         }
     }
@@ -577,8 +575,14 @@ impl Frame {
             cs,
         };
 
-        while wr.render_next_line(&mut self.mb_lines, &mut self.style_cache) {}
+        while wr.render_next_line(&mut self.mb_lines, None, &mut self.style_cache) {}
     }
+}
+
+#[derive(Clone, Copy)]
+enum PrevCol {
+    Buffer,
+    Hline,
 }
 
 struct ColRenderer<'a> {
@@ -644,34 +648,44 @@ impl<'a> ColRenderer<'a> {
     fn render_next_line(
         &mut self,
         buf: &mut String,
+        prev_col: Option<PrevCol>,
         style_cache: &mut HashMap<String, String>,
-    ) -> bool {
+    ) -> (bool, Option<PrevCol>) {
         if self.current.is_none() {
             self.current = match self.next_window() {
                 Some(w) => Some(w),
-                None => return false,
+                None => return (false, None),
             }
         }
 
-        let lines_remaining = self
-            .current
-            .as_mut()
-            .unwrap()
-            .render_next_line(buf, style_cache);
+        let lines_remaining =
+            self.current
+                .as_mut()
+                .unwrap()
+                .render_next_line(buf, prev_col, style_cache);
         self.row += 1;
 
-        if !lines_remaining {
+        let this_col = if lines_remaining {
+            Some(PrevCol::Buffer)
+        } else {
             self.current = None;
+            let left_edge = match prev_col {
+                Some(PrevCol::Buffer) => RTSTR,
+                Some(PrevCol::Hline) => XSTR,
+                None => "",
+            };
+
             _ = write!(
                 buf,
-                "{}{}{}",
+                "{}{}{left_edge}{}",
                 Style::Fg(self.cs.minibuffer_hl),
                 Style::Bg(self.cs.bg),
                 HLINE.repeat(self.n_cols)
             );
-        }
+            Some(PrevCol::Hline)
+        };
 
-        self.row < self.screen_rows
+        (self.row < self.screen_rows, this_col)
     }
 }
 
@@ -690,6 +704,7 @@ impl<'a> WinRenderer<'a> {
     fn render_next_line(
         &mut self,
         buf: &mut String,
+        prev_col: Option<PrevCol>,
         style_cache: &mut HashMap<String, String>,
     ) -> bool {
         if self.y >= self.w.n_rows {
@@ -698,6 +713,20 @@ impl<'a> WinRenderer<'a> {
 
         let file_row = self.y + self.w.view.row_off;
         self.y += 1;
+
+        if let Some(pc) = prev_col {
+            let left_edge = match pc {
+                PrevCol::Buffer => VLINE,
+                PrevCol::Hline => LTSTR,
+            };
+
+            _ = write!(
+                buf,
+                "{}{}{left_edge}",
+                Style::Fg(self.cs.minibuffer_hl),
+                Style::Bg(self.cs.bg)
+            );
+        }
 
         match self.it.next() {
             None => {

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -46,10 +46,6 @@ const RTSTR: &str = "├";
 const LTSTR: &str = "┤";
 const XSTR: &str = "┼";
 
-fn box_draw_str(s: &str, cs: &ColorScheme) -> String {
-    format!("{}{}{s}", Style::Fg(cs.minibuffer_hl), Style::Bg(cs.bg))
-}
-
 pub type Tui = GenericTui<StdoutLock<'static>>;
 
 #[derive(Debug)]
@@ -82,14 +78,13 @@ impl Tui {
 
 impl<W: Write> GenericTui<W> {
     pub fn new_with_stdout_handle(config: Arc<Mutex<Config>>, stdout: W) -> Self {
-        let frame = Frame::new(config.clone());
         Self {
             stdout: BufWriter::new(stdout),
             config,
             status_message: String::new(),
             last_status: Instant::now(),
             mb_last_frame: false,
-            frame,
+            frame: Frame::new(),
         }
     }
 
@@ -225,7 +220,7 @@ impl<W: Write> UserInterface for GenericTui<W> {
 
     fn state_change(&mut self, change: StateChange) {
         match change {
-            StateChange::ConfigUpdated => self.frame.update_cached_elements(),
+            StateChange::ConfigUpdated => self.frame.style_cache.clear(),
             StateChange::StatusMessage { msg } => {
                 self.status_message = msg;
                 self.last_status = Instant::now();
@@ -295,7 +290,6 @@ impl<W: Write> UserInterface for GenericTui<W> {
 
 #[derive(Debug, Default)]
 pub struct Frame {
-    config: Arc<Mutex<Config>>,
     win_lines: String,
     status_bar: String,
     mb_lines: String,
@@ -306,45 +300,23 @@ pub struct Frame {
     screen_cols: usize,
     cur_x: usize,
     cur_y: usize,
-    // Box elements for rendering window borders
-    vstr: String,
-    xstr: String,
-    tstr: String,
-    hvh: String,
-    vh: String,
     // Cache of the ANSI escape code strings required for each fully qualified tree-sitter
     // highlighting tag. See render_line for details on how the cache is used.
     style_cache: HashMap<String, String>,
 }
 
 impl Frame {
-    fn new(config: Arc<Mutex<Config>>) -> Self {
+    fn new() -> Self {
         let win_lines_cap = 128 * 1024;
         let bar_cap = 8 * 1024;
 
-        let mut frame = Self {
-            config,
+        Self {
             win_lines: String::with_capacity(win_lines_cap),
             mb_lines: String::with_capacity(bar_cap),
             status_bar: String::with_capacity(bar_cap),
             msg_bar: String::with_capacity(bar_cap),
             ..Default::default()
-        };
-        frame.update_cached_elements();
-
-        frame
-    }
-
-    fn update_cached_elements(&mut self) {
-        let cs = &config_handle!(self).colorscheme;
-        let vstr = box_draw_str(VLINE, cs);
-        let hstr = box_draw_str(HLINE, cs);
-        self.tstr = box_draw_str(RTSTR, cs);
-        self.xstr = box_draw_str(XSTR, cs);
-        self.hvh = format!("{hstr}{vstr}{hstr}");
-        self.vh = format!("{vstr}{hstr}");
-        self.vstr = vstr;
-        self.style_cache.clear();
+        }
     }
 
     fn write(&self, w: &mut impl Write) -> io::Result<()> {
@@ -1224,7 +1196,7 @@ mod tests {
             bottom: 0,
         };
 
-        let mut frame = Frame::new(Default::default());
+        let mut frame = Frame::new();
         frame.screen_cols = 91;
 
         // In 137 this was panicking due to indexing into the rendered line using self.screen_cols

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -59,6 +59,7 @@ pub struct GenericTui<W: Write> {
     screen_cols: usize,
     status_message: String,
     last_status: Instant,
+    mb_last_frame: bool,
     frame: Frame,
 }
 
@@ -90,6 +91,7 @@ impl<W: Write> GenericTui<W> {
             screen_cols: 0,
             status_message: String::new(),
             last_status: Instant::now(),
+            mb_last_frame: false,
             frame,
         }
     }
@@ -150,29 +152,26 @@ impl<W: Write> GenericTui<W> {
 
         self.frame
             .render_windows(layout, load_exec_range, effective_screen_rows, tabstop, cs);
-
         self.frame
             .render_status_bar(cs, mode_name, n_running, active_buffer, self.screen_cols);
+
         self.frame.show_mb = w_minibuffer || layout.scratch.is_visible;
+        self.frame.show_msg_bar = !w_minibuffer;
 
         if w_minibuffer {
             self.frame
                 .render_minibuffer_state(&mb, tabstop, cs, self.screen_cols);
         } else if layout.scratch.is_visible {
-            self.frame.mb_lines.clear();
-            WinRenderer::render_scratch(
+            self.frame.render_scratch(
                 &layout.scratch,
                 scratch_load_exec_range,
                 self.screen_cols,
                 tabstop,
                 cs,
-                &mut self.frame.mb_lines,
-                &mut self.frame.style_cache,
             );
         };
 
-        if !w_minibuffer {
-            self.frame.show_msg_bar = true;
+        if self.frame.show_msg_bar {
             self.frame.render_message_bar(
                 cs,
                 pending_keys,
@@ -181,9 +180,8 @@ impl<W: Write> GenericTui<W> {
                 self.last_status,
                 self.screen_cols,
             );
-        } else {
-            self.frame.show_msg_bar = false;
         };
+
         let (cur_x, cur_y) = if w_minibuffer {
             (mb.cx, self.screen_rows + mb.n_visible_lines + 1)
         } else {
@@ -257,12 +255,17 @@ impl<W: Write> UserInterface for GenericTui<W> {
         self.screen_rows = layout.screen_rows;
         self.screen_cols = layout.screen_cols;
         self.frame.show_msg_bar = mb.is_none();
+        let mb_this_frame = mb.is_some();
 
         if self.screen_cols < MIN_COLS || self.screen_rows < MIN_ROWS {
             return;
         }
 
-        if layout.changed_since_last_render() {
+        // If the UI changed or we have an active minibuffer then we need to rerender the UI.
+        // We also need to re-render on the frame after a minibuffer is closed in order to
+        // get rid of it, as none of the other buffers in the layout will be marked as changed
+        // since the last render.
+        if layout.changed_since_last_render() || mb_this_frame || self.mb_last_frame {
             layout.update_visible_ts_state();
             self.render(mode_name, layout, n_running, pending_keys, held_click, mb);
             if let Err(e) = self.frame.write(&mut self.stdout) {
@@ -288,6 +291,8 @@ impl<W: Write> UserInterface for GenericTui<W> {
         if let Err(e) = self.stdout.flush() {
             die!("Unable to refresh screen: {e}");
         }
+
+        self.mb_last_frame = mb_this_frame;
     }
 
     fn set_cursor_shape(&mut self, cur_shape: CurShape) {
@@ -552,6 +557,37 @@ impl Frame {
             Cursor::ClearRight
         );
     }
+
+    fn render_scratch(
+        &mut self,
+        scratch: &Scratch,
+        load_exec_range: Option<(bool, Range)>,
+        n_cols: usize,
+        tabstop: usize,
+        cs: &ColorScheme,
+    ) {
+        self.mb_lines.clear();
+        let b = scratch.b.buffer();
+        let (w_lnum, _) = b.sign_col_dims();
+        let rng = if scratch.is_focused {
+            load_exec_range
+        } else {
+            None
+        };
+
+        let mut wr = WinRenderer {
+            y: 0,
+            w_lnum,
+            n_cols,
+            tabstop,
+            it: b.iter_tokenized_lines_from(scratch.w.view.row_off, rng),
+            gb: &b.txt,
+            w: &scratch.w,
+            cs,
+        };
+
+        while wr.render_next_line(&mut self.mb_lines, &mut self.style_cache) {}
+    }
 }
 
 struct ColRenderer<'a> {
@@ -660,38 +696,6 @@ struct WinRenderer<'a> {
 }
 
 impl<'a> WinRenderer<'a> {
-    fn render_scratch(
-        scratch: &'a Scratch,
-        load_exec_range: Option<(bool, Range)>,
-        n_cols: usize,
-        tabstop: usize,
-        cs: &'a ColorScheme,
-        buf: &mut String,
-        style_cache: &mut HashMap<String, String>,
-    ) {
-        let b = scratch.b.buffer();
-        let (w_lnum, _) = b.sign_col_dims();
-        let rng = if scratch.is_focused {
-            load_exec_range
-        } else {
-            None
-        };
-        let it = b.iter_tokenized_lines_from(scratch.w.view.row_off, rng);
-
-        let mut wr = WinRenderer {
-            y: 0,
-            w_lnum,
-            n_cols,
-            tabstop,
-            it,
-            gb: &b.txt,
-            w: &scratch.w,
-            cs,
-        };
-
-        while wr.render_next_line(buf, style_cache) {}
-    }
-
     fn render_next_line(
         &mut self,
         buf: &mut String,

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -22,27 +22,25 @@ use crate::{
     ziplist,
 };
 use std::{
-    cell::RefCell,
     char,
     cmp::Ordering,
     collections::HashMap,
-    io::{BufWriter, Read, StdoutLock, Write, stdin, stdout},
+    fmt::Write as _,
+    io::{self, BufWriter, Read, StdoutLock, Write, stdin, stdout},
     iter::{Peekable, repeat_n},
     panic,
-    rc::Rc,
     sync::{Arc, Mutex, mpsc::Sender},
     thread::{JoinHandle, spawn},
     time::Instant,
 };
 use tracing::debug;
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 // If the screen dimensions drop below these values then we disable rendering
 const MIN_COLS: usize = 20;
 const MIN_ROWS: usize = 5;
 
-// const HLINE: &str = "—"; // em dash
-const HLINE: &str = "-";
+const HLINE: &str = "─";
 const VLINE: &str = "│";
 const TSTR: &str = "├";
 const XSTR: &str = "┼";
@@ -61,15 +59,7 @@ pub struct GenericTui<W: Write> {
     screen_cols: usize,
     status_message: String,
     last_status: Instant,
-    // Box elements for rendering window borders
-    vstr: String,
-    xstr: String,
-    tstr: String,
-    hvh: String,
-    vh: String,
-    // Cache of the ANSI escape code strings required for each fully qualified tree-sitter
-    // highlighting tag. See render_line for details on how the cache is used.
-    style_cache: Rc<RefCell<HashMap<String, String>>>,
+    frame: Frame,
 }
 
 impl Default for Tui {
@@ -92,162 +82,16 @@ impl Tui {
 
 impl<W: Write> GenericTui<W> {
     pub fn new_with_stdout_handle(config: Arc<Mutex<Config>>, stdout: W) -> Self {
-        let mut tui = Self {
+        let frame = Frame::new(config.clone());
+        Self {
             stdout: BufWriter::new(stdout),
             config,
             screen_rows: 0,
             screen_cols: 0,
             status_message: String::new(),
             last_status: Instant::now(),
-            vstr: String::new(),
-            tstr: String::new(),
-            xstr: String::new(),
-            hvh: String::new(),
-            vh: String::new(),
-            style_cache: Default::default(),
-        };
-        tui.update_cached_elements();
-
-        tui
-    }
-
-    fn update_cached_elements(&mut self) {
-        let cs = &config_handle!(self).colorscheme;
-        let vstr = box_draw_str(VLINE, cs);
-        let hstr = box_draw_str(HLINE, cs);
-        self.tstr = box_draw_str(TSTR, cs);
-        self.xstr = box_draw_str(XSTR, cs);
-        self.hvh = format!("{hstr}{vstr}{hstr}");
-        self.vh = format!("{vstr}{hstr}");
-        self.vstr = vstr;
-        self.style_cache.borrow_mut().clear();
-    }
-
-    fn render_status_bar(
-        &self,
-        cs: &ColorScheme,
-        mode_name: &str,
-        n_running: usize,
-        b: &Buffer,
-    ) -> String {
-        let lstatus = format!(
-            "{} {} - {} lines {}",
-            mode_name,
-            b.display_name(),
-            b.len_lines(),
-            if b.dirty { "[+]" } else { "" }
-        );
-        let rstatus = format!(
-            "{}{}",
-            if n_running == 0 {
-                String::new()
-            } else {
-                format!("[{n_running} running] ")
-            },
-            b.dot.addr(b)
-        );
-        let width = self.screen_cols.saturating_sub(lstatus.len());
-
-        format!(
-            "{}{}{lstatus}{rstatus:>width$}{}\r\n",
-            Style::Bg(cs.bar_bg),
-            Style::Fg(cs.fg),
-            Style::Reset
-        )
-    }
-
-    // current prompt and pending chars
-    fn render_message_bar(
-        &self,
-        cs: &ColorScheme,
-        pending_keys: &[Input],
-        status_timeout: u64,
-    ) -> String {
-        let mut buf = String::new();
-        buf.push_str(&Cursor::ClearRight.to_string());
-
-        let mut msg = self.status_message.clone();
-        msg.truncate(self.screen_cols.saturating_sub(10));
-
-        let pending = render_pending(pending_keys);
-        let delta = (Instant::now() - self.last_status).as_secs();
-
-        if !msg.is_empty() && delta < status_timeout {
-            let width = self
-                .screen_cols
-                .saturating_sub(msg.len())
-                .saturating_sub(10);
-            buf.push_str(&format!(
-                "{}{}{msg}{pending:>width$}          ",
-                Style::Fg(cs.fg),
-                Style::Bg(cs.bg)
-            ));
-        } else {
-            let width = self.screen_cols.saturating_sub(10);
-            buf.push_str(&format!(
-                "{}{}{pending:>width$}          ",
-                Style::Fg(cs.fg),
-                Style::Bg(cs.bg)
-            ));
+            frame,
         }
-
-        buf
-    }
-
-    fn render_minibuffer_state(
-        &self,
-        mb: &MiniBufferState<'_>,
-        tabstop: usize,
-        cs: &ColorScheme,
-    ) -> Vec<String> {
-        let mut lines = Vec::new();
-
-        if let Some(b) = mb.b {
-            for i in mb.top..=mb.bottom {
-                let slice = b.line(i).unwrap();
-                let bg = if i == mb.selected_line_idx {
-                    cs.minibuffer_hl
-                } else {
-                    cs.bg
-                };
-
-                let mut cols = 0;
-                let mut chars = slice.chars().peekable();
-                let mut rline = Styles {
-                    fg: Some(cs.fg),
-                    bg: Some(bg),
-                    ..Default::default()
-                }
-                .to_string();
-
-                render_chars(
-                    &mut chars,
-                    None,
-                    self.screen_cols,
-                    tabstop,
-                    &mut cols,
-                    &mut rline,
-                );
-
-                if cols < self.screen_cols {
-                    rline.push_str(&Style::Bg(bg).to_string());
-                }
-
-                let width = self.screen_cols;
-                lines.push(format!("{rline:<width$}{}\r\n", Cursor::ClearRight));
-            }
-        }
-
-        lines.push(format!(
-            "{}{}{}{}{}",
-            Style::Fg(cs.fg),
-            Style::Bg(cs.bg),
-            mb.prompt,
-            mb.input,
-            Cursor::ClearRight
-        ));
-
-        lines
     }
 
     pub fn set_size(&mut self, rows: usize, cols: usize) {
@@ -255,7 +99,7 @@ impl<W: Write> GenericTui<W> {
         self.screen_cols = cols;
     }
 
-    pub fn render_lines(
+    fn render(
         &mut self,
         mode_name: &str,
         layout: &Layout,
@@ -263,7 +107,7 @@ impl<W: Write> GenericTui<W> {
         pending_keys: &[Input],
         held_click: Option<&Click>,
         mb: Option<MiniBufferState<'_>>,
-    ) -> Vec<String> {
+    ) {
         let conf = config_handle!(self);
         let (cs, status_timeout, tabstop, max_mb_lines) = (
             &conf.colorscheme,
@@ -304,44 +148,50 @@ impl<W: Write> GenericTui<W> {
             (load_exec_range, None)
         };
 
-        // We need space for each visible line plus the two commands to hide/show the cursor
-        let mut lines = Vec::with_capacity(self.screen_rows + 2);
-        lines.push(format!("{}{}", Cursor::Hide, Cursor::ToStart));
-        lines.extend(WinsIter::new(
-            layout,
-            load_exec_range,
-            effective_screen_rows,
-            tabstop,
-            self,
-            cs,
-        ));
-        lines.push(self.render_status_bar(cs, mode_name, n_running, active_buffer));
+        self.frame
+            .render_windows(layout, load_exec_range, effective_screen_rows, tabstop, cs);
+
+        self.frame
+            .render_status_bar(cs, mode_name, n_running, active_buffer, self.screen_cols);
+        self.frame.show_mb = w_minibuffer || layout.scratch.is_visible;
 
         if w_minibuffer {
-            lines.append(&mut self.render_minibuffer_state(&mb, tabstop, cs));
+            self.frame
+                .render_minibuffer_state(&mb, tabstop, cs, self.screen_cols);
         } else if layout.scratch.is_visible {
-            lines.extend(WinIter::new_scratch_iter(
+            self.frame.mb_lines.clear();
+            WinRenderer::render_scratch(
                 &layout.scratch,
                 scratch_load_exec_range,
                 self.screen_cols,
                 tabstop,
                 cs,
-                self.style_cache.clone(),
-            ));
-        }
-        if !w_minibuffer {
-            lines.push(self.render_message_bar(cs, pending_keys, status_timeout));
-        }
+                &mut self.frame.mb_lines,
+                &mut self.frame.style_cache,
+            );
+        };
 
-        // Position the cursor
-        let (x, y) = if w_minibuffer {
+        if !w_minibuffer {
+            self.frame.show_msg_bar = true;
+            self.frame.render_message_bar(
+                cs,
+                pending_keys,
+                status_timeout,
+                self.status_message.clone(),
+                self.last_status,
+                self.screen_cols,
+            );
+        } else {
+            self.frame.show_msg_bar = false;
+        };
+        let (cur_x, cur_y) = if w_minibuffer {
             (mb.cx, self.screen_rows + mb.n_visible_lines + 1)
         } else {
             layout.ui_xy()
         };
-        lines.push(format!("{}{}", Cursor::To(x + 1, y + 1), Cursor::Show));
 
-        lines
+        self.frame.cur_x = cur_x;
+        self.frame.cur_y = cur_y;
     }
 }
 
@@ -387,7 +237,7 @@ impl<W: Write> UserInterface for GenericTui<W> {
 
     fn state_change(&mut self, change: StateChange) {
         match change {
-            StateChange::ConfigUpdated => self.update_cached_elements(),
+            StateChange::ConfigUpdated => self.frame.update_cached_elements(),
             StateChange::StatusMessage { msg } => {
                 self.status_message = msg;
                 self.last_status = Instant::now();
@@ -398,7 +248,7 @@ impl<W: Write> UserInterface for GenericTui<W> {
     fn refresh(
         &mut self,
         mode_name: &str,
-        layout: &Layout,
+        layout: &mut Layout,
         n_running: usize,
         pending_keys: &[Input],
         held_click: Option<&Click>,
@@ -406,14 +256,30 @@ impl<W: Write> UserInterface for GenericTui<W> {
     ) {
         self.screen_rows = layout.screen_rows;
         self.screen_cols = layout.screen_cols;
+        self.frame.show_msg_bar = mb.is_none();
 
         if self.screen_cols < MIN_COLS || self.screen_rows < MIN_ROWS {
             return;
         }
 
-        let lines = self.render_lines(mode_name, layout, n_running, pending_keys, held_click, mb);
+        if layout.changed_since_last_render() {
+            layout.update_visible_ts_state();
+            self.render(mode_name, layout, n_running, pending_keys, held_click, mb);
+        } else if mb.is_none() {
+            // match self.render in not showing the message bar if the minibuffer is open
+            let conf = config_handle!(self);
+            let (cs, status_timeout) = (&conf.colorscheme, conf.status_timeout);
+            self.frame.render_message_bar(
+                cs,
+                pending_keys,
+                status_timeout,
+                self.status_message.clone(),
+                self.last_status,
+                self.screen_cols,
+            );
+        }
 
-        if let Err(e) = self.stdout.write_all(lines.join("").as_bytes()) {
+        if let Err(e) = self.frame.write(&mut self.stdout) {
             die!("Unable to refresh screen: {e}");
         }
 
@@ -431,87 +297,263 @@ impl<W: Write> UserInterface for GenericTui<W> {
     }
 }
 
-struct WinsIter<'a> {
-    col_iters: Vec<ColIter<'a>>,
-    buf: Vec<String>,
-    vstr: &'a str,
-    xstr: &'a str,
-    tstr: &'a str,
-    hvh: &'a str,
-    vh: &'a str,
+#[derive(Debug, Default)]
+pub struct Frame {
+    config: Arc<Mutex<Config>>,
+    win_lines: String,
+    status_bar: String,
+    mb_lines: String,
+    show_mb: bool,
+    msg_bar: String,
+    show_msg_bar: bool,
+    cur_x: usize,
+    cur_y: usize,
+    // Box elements for rendering window borders
+    vstr: String,
+    xstr: String,
+    tstr: String,
+    hvh: String,
+    vh: String,
+    // Cache of the ANSI escape code strings required for each fully qualified tree-sitter
+    // highlighting tag. See render_line for details on how the cache is used.
+    style_cache: HashMap<String, String>,
 }
 
-impl<'a> WinsIter<'a> {
-    fn new<W: Write>(
-        layout: &'a Layout,
+impl Frame {
+    fn new(config: Arc<Mutex<Config>>) -> Self {
+        let win_lines_cap = 128 * 1024;
+        let bar_cap = 8 * 1024;
+
+        let mut frame = Self {
+            config,
+            win_lines: String::with_capacity(win_lines_cap),
+            mb_lines: String::with_capacity(bar_cap),
+            status_bar: String::with_capacity(bar_cap),
+            msg_bar: String::with_capacity(bar_cap),
+            ..Default::default()
+        };
+        frame.update_cached_elements();
+
+        frame
+    }
+
+    fn update_cached_elements(&mut self) {
+        let cs = &config_handle!(self).colorscheme;
+        let vstr = box_draw_str(VLINE, cs);
+        let hstr = box_draw_str(HLINE, cs);
+        self.tstr = box_draw_str(TSTR, cs);
+        self.xstr = box_draw_str(XSTR, cs);
+        self.hvh = format!("{hstr}{vstr}{hstr}");
+        self.vh = format!("{vstr}{hstr}");
+        self.vstr = vstr;
+        self.style_cache.clear();
+    }
+
+    fn write(&self, w: &mut impl Write) -> io::Result<()> {
+        write!(w, "{}{}", Cursor::Hide, Cursor::ToStart)?;
+        w.write_all(self.win_lines.as_bytes())?;
+        w.write_all(self.status_bar.as_bytes())?;
+        if self.show_mb {
+            w.write_all(self.mb_lines.as_bytes())?;
+        }
+        if self.show_msg_bar {
+            w.write_all(self.msg_bar.as_bytes())?;
+        }
+
+        write!(
+            w,
+            "{}{}",
+            Cursor::To(self.cur_x + 1, self.cur_y + 1),
+            Cursor::Show
+        )
+    }
+
+    fn render_windows(
+        &mut self,
+        layout: &Layout,
         load_exec_range: Option<(bool, Range)>,
         screen_rows: usize,
         tabstop: usize,
-        tui: &'a GenericTui<W>,
-        cs: &'a ColorScheme,
-    ) -> Self {
-        let col_iters: Vec<_> = layout
+        cs: &ColorScheme,
+    ) {
+        self.win_lines.clear();
+
+        let mut col_renderers: Vec<_> = layout
             .cols
             .iter()
             .map(|(is_focus, col)| {
                 let rng = if is_focus { load_exec_range } else { None };
-                ColIter::new(
-                    col,
-                    layout,
-                    rng,
-                    screen_rows,
-                    tabstop,
-                    cs,
-                    tui.style_cache.clone(),
-                )
+                ColRenderer::new(col, layout, rng, screen_rows, tabstop, cs)
             })
             .collect();
-        let buf = Vec::with_capacity(col_iters.len());
 
-        Self {
-            col_iters,
-            buf,
-            vstr: &tui.vstr,
-            xstr: &tui.xstr,
-            tstr: &tui.tstr,
-            hvh: &tui.hvh,
-            vh: &tui.vh,
+        let n_cols = col_renderers.len();
+        'outer: loop {
+            for (i, cr) in col_renderers.iter_mut().enumerate() {
+                let remaining = cr.render_next_line(&mut self.win_lines, &mut self.style_cache);
+                if i < n_cols - 1 {
+                    self.win_lines.push_str(&self.vstr);
+                }
+                if i == n_cols - 1 && !remaining {
+                    _ = write!(&mut self.win_lines, "{}\r\n", Cursor::ClearRight);
+                    break 'outer;
+                }
+            }
+
+            // col_buf = col_buf
+            //     .replace(&self.hvh, &self.xstr)
+            //     .replace(&self.vh, &self.tstr);
+            // self.win_lines.push_str(&col_buf);
+            _ = write!(&mut self.win_lines, "{}\r\n", Cursor::ClearRight);
         }
+    }
+
+    fn render_status_bar(
+        &mut self,
+        cs: &ColorScheme,
+        mode_name: &str,
+        n_running: usize,
+        b: &Buffer,
+        screen_cols: usize,
+    ) {
+        self.status_bar.clear();
+
+        let lstatus = format!(
+            "{} {} - {} lines {}",
+            mode_name,
+            b.display_name(),
+            b.len_lines(),
+            if b.dirty { "[+]" } else { "" }
+        );
+        let rstatus = format!(
+            "{}{}",
+            if n_running == 0 {
+                String::new()
+            } else {
+                format!("[{n_running} running] ")
+            },
+            b.dot.addr(b)
+        );
+        let width = screen_cols.saturating_sub(UnicodeWidthStr::width(lstatus.as_str()));
+
+        _ = write!(
+            &mut self.status_bar,
+            "{}{}{lstatus}{rstatus:>width$}{}\r\n",
+            Style::Bg(cs.bar_bg),
+            Style::Fg(cs.fg),
+            Style::Reset
+        );
+    }
+
+    // current prompt and pending chars
+    fn render_message_bar(
+        &mut self,
+        cs: &ColorScheme,
+        pending_keys: &[Input],
+        status_timeout: u64,
+        mut msg: String,
+        last_status: Instant,
+        screen_cols: usize,
+    ) {
+        self.msg_bar.clear();
+        self.msg_bar.push_str(&Cursor::ClearRight.to_string());
+        msg.truncate(screen_cols.saturating_sub(10));
+
+        let pending = render_pending(pending_keys);
+        let delta = (Instant::now() - last_status).as_secs();
+
+        if !msg.is_empty() && delta < status_timeout {
+            let width = screen_cols.saturating_sub(msg.len()).saturating_sub(10);
+            _ = write!(
+                &mut self.msg_bar,
+                "{}{}{msg}{pending:>width$}          ",
+                Style::Fg(cs.fg),
+                Style::Bg(cs.bg)
+            );
+        } else {
+            let width = screen_cols.saturating_sub(10);
+            _ = write!(
+                &mut self.msg_bar,
+                "{}{}{pending:>width$}          ",
+                Style::Fg(cs.fg),
+                Style::Bg(cs.bg)
+            );
+        }
+    }
+
+    fn render_minibuffer_state(
+        &mut self,
+        mb: &MiniBufferState<'_>,
+        tabstop: usize,
+        cs: &ColorScheme,
+        screen_cols: usize,
+    ) {
+        self.mb_lines.clear();
+
+        if let Some(b) = mb.b {
+            for i in mb.top..=mb.bottom {
+                let slice = b.line(i).unwrap();
+                let bg = if i == mb.selected_line_idx {
+                    cs.minibuffer_hl
+                } else {
+                    cs.bg
+                };
+
+                let mut cols = 0;
+                let mut chars = slice.chars().peekable();
+                _ = write!(
+                    &mut self.mb_lines,
+                    "{}",
+                    Styles {
+                        fg: Some(cs.fg),
+                        bg: Some(bg),
+                        ..Default::default()
+                    }
+                );
+
+                render_chars(
+                    &mut chars,
+                    None,
+                    screen_cols,
+                    tabstop,
+                    &mut cols,
+                    &mut self.mb_lines,
+                );
+
+                if cols < screen_cols {
+                    self.mb_lines.push_str(&Style::Bg(bg).to_string());
+                }
+
+                let width = screen_cols;
+                _ = write!(&mut self.mb_lines, "{:>width$}\r\n", Cursor::ClearRight);
+            }
+        }
+
+        _ = write!(
+            &mut self.mb_lines,
+            "{}{}{}{}{}",
+            Style::Fg(cs.fg),
+            Style::Bg(cs.bg),
+            mb.prompt,
+            mb.input,
+            Cursor::ClearRight
+        );
     }
 }
 
-impl Iterator for WinsIter<'_> {
-    type Item = String;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.buf.clear();
-
-        for it in self.col_iters.iter_mut() {
-            self.buf.push(it.next()?);
-        }
-
-        let mut buf = self.buf.join(self.vstr);
-        buf = buf.replace(self.hvh, self.xstr).replace(self.vh, self.tstr);
-        buf.push_str(&format!("{}\r\n", Cursor::ClearRight));
-
-        Some(buf)
-    }
-}
-
-struct ColIter<'a> {
+struct ColRenderer<'a> {
     inner: ziplist::Iter<'a, Window>,
-    current: Option<WinIter<'a>>,
+    current: Option<WinRenderer<'a>>,
     layout: &'a Layout,
     cs: &'a ColorScheme,
-    style_cache: Rc<RefCell<HashMap<String, String>>>,
     load_exec_range: Option<(bool, Range)>,
     screen_rows: usize,
     tabstop: usize,
     n_cols: usize,
-    yielded: usize,
+    row: usize,
 }
 
-impl<'a> ColIter<'a> {
+impl<'a> ColRenderer<'a> {
     fn new(
         col: &'a Column,
         layout: &'a Layout,
@@ -519,25 +561,21 @@ impl<'a> ColIter<'a> {
         screen_rows: usize,
         tabstop: usize,
         cs: &'a ColorScheme,
-        style_cache: Rc<RefCell<HashMap<String, String>>>,
     ) -> Self {
-        ColIter {
+        ColRenderer {
             inner: col.wins.iter(),
             current: None,
             layout,
             cs,
-            style_cache,
             load_exec_range,
             screen_rows,
             tabstop,
             n_cols: col.n_cols,
-            yielded: 0,
+            row: 0,
         }
     }
-}
 
-impl<'a> ColIter<'a> {
-    fn next_win_iter(&mut self) -> Option<WinIter<'a>> {
+    fn next_window(&mut self) -> Option<WinRenderer<'a>> {
         let (is_focus, w) = self.inner.next()?;
         let b = self
             .layout
@@ -548,7 +586,7 @@ impl<'a> ColIter<'a> {
         let rng = if is_focus { self.load_exec_range } else { None };
         let it = b.iter_tokenized_lines_from(w.view.row_off, rng);
 
-        Some(WinIter {
+        Some(WinRenderer {
             y: 0,
             w_lnum,
             n_cols: self.n_cols,
@@ -557,36 +595,47 @@ impl<'a> ColIter<'a> {
             gb: &b.txt,
             w,
             cs: self.cs,
-            style_cache: self.style_cache.clone(),
         })
     }
-}
 
-impl Iterator for ColIter<'_> {
-    type Item = String;
-
-    fn next(&mut self) -> Option<Self::Item> {
+    /// Render the next available line into the provided buffer.
+    ///
+    /// Returns false if there are no more lines to render.
+    fn render_next_line(
+        &mut self,
+        buf: &mut String,
+        style_cache: &mut HashMap<String, String>,
+    ) -> bool {
         if self.current.is_none() {
-            self.current = Some(self.next_win_iter()?);
-        }
-
-        let next_line = self.current.as_mut()?.next();
-        if self.yielded == self.screen_rows {
-            return None;
-        }
-        self.yielded += 1;
-
-        match next_line {
-            Some(line) => Some(line),
-            None => {
-                self.current = None;
-                Some(box_draw_str(&HLINE.repeat(self.n_cols), self.cs))
+            self.current = match self.next_window() {
+                Some(w) => Some(w),
+                None => return false,
             }
         }
+
+        let lines_remaining = self
+            .current
+            .as_mut()
+            .unwrap()
+            .render_next_line(buf, style_cache);
+        self.row += 1;
+
+        if !lines_remaining {
+            self.current = None;
+            _ = write!(
+                buf,
+                "{}{}{}",
+                Style::Fg(self.cs.minibuffer_hl),
+                Style::Bg(self.cs.bg),
+                HLINE.repeat(self.n_cols)
+            );
+        }
+
+        self.row < self.screen_rows
     }
 }
 
-struct WinIter<'a> {
+struct WinRenderer<'a> {
     y: usize,
     w_lnum: usize,
     n_cols: usize,
@@ -595,18 +644,18 @@ struct WinIter<'a> {
     gb: &'a GapBuffer,
     w: &'a Window,
     cs: &'a ColorScheme,
-    style_cache: Rc<RefCell<HashMap<String, String>>>,
 }
 
-impl<'a> WinIter<'a> {
-    fn new_scratch_iter(
+impl<'a> WinRenderer<'a> {
+    fn render_scratch(
         scratch: &'a Scratch,
         load_exec_range: Option<(bool, Range)>,
         n_cols: usize,
         tabstop: usize,
         cs: &'a ColorScheme,
-        style_cache: Rc<RefCell<HashMap<String, String>>>,
-    ) -> Self {
+        buf: &mut String,
+        style_cache: &mut HashMap<String, String>,
+    ) {
         let b = scratch.b.buffer();
         let (w_lnum, _) = b.sign_col_dims();
         let rng = if scratch.is_focused {
@@ -616,7 +665,7 @@ impl<'a> WinIter<'a> {
         };
         let it = b.iter_tokenized_lines_from(scratch.w.view.row_off, rng);
 
-        WinIter {
+        let mut wr = WinRenderer {
             y: 0,
             w_lnum,
             n_cols,
@@ -625,26 +674,27 @@ impl<'a> WinIter<'a> {
             gb: &b.txt,
             w: &scratch.w,
             cs,
-            style_cache,
-        }
+        };
+
+        while wr.render_next_line(buf, style_cache) {}
     }
-}
 
-impl Iterator for WinIter<'_> {
-    type Item = String;
-
-    fn next(&mut self) -> Option<Self::Item> {
+    fn render_next_line(
+        &mut self,
+        buf: &mut String,
+        style_cache: &mut HashMap<String, String>,
+    ) -> bool {
         if self.y >= self.w.n_rows {
-            return None;
+            return false;
         }
+
         let file_row = self.y + self.w.view.row_off;
         self.y += 1;
 
-        let next = self.it.next();
-
-        let line = match next {
+        match self.it.next() {
             None => {
-                let mut buf = format!(
+                _ = write!(
+                    buf,
                     "{}{}~ {VLINE:>width$}{}",
                     Style::Fg(self.cs.signcol_fg),
                     Style::Bg(self.cs.bg),
@@ -653,34 +703,35 @@ impl Iterator for WinIter<'_> {
                 );
                 let padding = self.n_cols.saturating_sub(self.w_lnum).saturating_sub(2);
                 buf.push_str(&" ".repeat(padding));
-
-                buf
             }
 
             Some(it) => {
                 // +2 for the leading space and vline chars
                 let padding = self.w_lnum + 2;
 
-                format!(
-                    "{}{} {:>width$}{VLINE}{}",
+                _ = write!(
+                    buf,
+                    "{}{} {:>width$}{VLINE}",
                     Style::Fg(self.cs.signcol_fg),
                     Style::Bg(self.cs.bg),
                     file_row + 1,
-                    render_line(
-                        self.gb,
-                        it,
-                        self.w.view.col_off,
-                        self.n_cols.saturating_sub(padding),
-                        self.tabstop,
-                        self.cs,
-                        &mut self.style_cache
-                    ),
                     width = self.w_lnum
-                )
+                );
+
+                render_line(
+                    self.gb,
+                    it,
+                    self.w.view.col_off,
+                    self.n_cols.saturating_sub(padding),
+                    self.tabstop,
+                    self.cs,
+                    style_cache,
+                    buf,
+                );
             }
         };
 
-        Some(line)
+        true
     }
 }
 
@@ -794,6 +845,7 @@ fn render_chars(
     buf.push_str(RESET_STYLE);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_line<'a>(
     gb: &'a GapBuffer,
     it: impl Iterator<Item = RangeToken<'a>>,
@@ -801,9 +853,9 @@ fn render_line<'a>(
     max_cols: usize,
     tabstop: usize,
     cs: &ColorScheme,
-    style_cache: &mut Rc<RefCell<HashMap<String, String>>>,
-) -> String {
-    let mut buf = String::new();
+    style_cache: &mut HashMap<String, String>,
+    buf: &mut String,
+) {
     let mut to_skip = col_off;
     let mut cols = 0;
 
@@ -828,23 +880,17 @@ fn render_line<'a>(
         // The cache styles are also stored against the original tag rather so they can be looked
         // up directly each time they are used, rather than need to to traverse the fallback path
         // as done in ColorScheme::styles_for.
-        //
-        // We always assume that it safe to borrow the style_cache mutably at this point as we are
-        // only expecting this function to be called as part of a render pass where the clones of
-        // the style_cache Rc are held in different iterators that are processed sequentially in a
-        // single thread.
-        let mut guard = style_cache.borrow_mut();
-        let style_str = match guard.get(tk.tag) {
+        let style_str = match style_cache.get(tk.tag) {
             Some(s) => s,
             None => {
                 let s = cs.styles_for(tk.tag).to_string();
-                guard.insert(tk.tag.to_string(), s);
-                guard.get(tk.tag).unwrap()
+                style_cache.insert(tk.tag.to_string(), s);
+                style_cache.get(tk.tag).unwrap()
             }
         };
 
         buf.push_str(style_str);
-        render_chars(&mut chars, spaces, max_cols, tabstop, &mut cols, &mut buf);
+        render_chars(&mut chars, spaces, max_cols, tabstop, &mut cols, buf);
 
         if cols == max_cols {
             break;
@@ -855,8 +901,6 @@ fn render_line<'a>(
         buf.push_str(&Style::Bg(cs.bg).to_string());
         buf.extend(repeat_n(' ', max_cols - cols));
     }
-
-    buf
 }
 
 #[derive(Debug)]
@@ -1100,21 +1144,23 @@ mod tests {
         ];
 
         let cs = ColorScheme::default();
-        let style_cache: HashMap<String, String> = [
+        let mut style_cache: HashMap<String, String> = [
             ("a".to_owned(), "!".to_owned()),
             (TK_DEFAULT.to_owned(), "|".to_owned()),
         ]
         .into_iter()
         .collect();
 
-        let s = render_line(
+        let mut s = String::new();
+        render_line(
             &gb,
             range_tokens.into_iter(),
             col_off,
             max_cols,
             2,
             &cs,
-            &mut Rc::new(RefCell::new(style_cache)),
+            &mut style_cache,
+            &mut s,
         );
 
         let expected = expected_template
@@ -1148,6 +1194,7 @@ mod tests {
         // as a raw byte offset. The fix is simply not to truncate in that way as render_chars is
         // already ensuring that the buffer it is building up is staying within the available
         // screen space.
-        tui.render_minibuffer_state(&mb, 4, &Default::default());
+        tui.frame
+            .render_minibuffer_state(&mb, 4, &Default::default(), tui.screen_cols);
     }
 }

--- a/tests/scenario_tests.rs
+++ b/tests/scenario_tests.rs
@@ -436,7 +436,7 @@ impl UserInterface for ScriptedUi {
     fn refresh(
         &mut self,
         _mode_name: &str,
-        _layout: &Layout,
+        _layout: &mut Layout,
         _n_running: usize,
         _pending_keys: &[Input],
         _held_click: Option<&Click>,


### PR DESCRIPTION
Fixes #143

This brings the sum of all allocations made for opening a 2000 line file and scrolling to the bottom (for the duration of the program) down from just over 300MB to around 27MB. The typical RAM usage still sits at around 10-15MB for opening a single large file.

> **NOTE**: this is the total number of bytes allocated for the duration of the program, rather than the peak allocation size. What I was observing before this change was a relatively small amount of RAM being used (around 10-15MB as stated above) but with a _lot_ of churn on small allocations from the TUI rendering logic.

In addition to the obvious "store the rendered text in buffers rather than writing to new strings each time" there are a couple of things changing in this PR that give us a significant performance improvement, both in terms of memory churn and rendering speed (see below):
1. The `Buffer` and `Layout` structs now track when they have had UI altering changes made to them within a given frame, allowing for smarter caching and re-use of previous frames where possible.
2. Frames that only alter the message bar (e.g. LSP server startup messages) update the message bar directly rather than re-rendering the entire screen.
3. Setting box corners around individual windows is now handled while producing the individual screen rows rather than as a call to `str::replace` after the fact. (This one alone fixed a lot of the allocation problems)

There is still a lot more that can be done to improve the caching and underlying rendering logic but for now this is a good start I think.

<img width="1203" height="331" alt="2025-10-12_09-51_1" src="https://github.com/user-attachments/assets/97176014-8939-4475-9f89-fcaec432e997" />

<img width="1202" height="400" alt="2025-10-12_09-51" src="https://github.com/user-attachments/assets/b6436664-b72d-45e8-ae08-e0c189ec2771" />

### Generating the above flamegraphs
The data for these are gathered using [bpftrace](https://github.com/bpftrace/bpftrace) so this approach will only work on linux. Something similar should be possible with `dtrace` but I've not tried that out yet.

```bash
# build with frame pointers and debug symbols
$ RUSTFLAGS="-C force-frame-pointers=yes" cargo build --profile flamegraph

# kick off in a separate terminal before running ad
$ sudo bpftrace \
  -e '
  u:/lib/x86_64-linux-gnu/libc.so.6:malloc /comm == "ad"/ {
    @[ustack] = sum(arg0);
  }
' > out.stacks

# open the file and then scroll to the bottom using the mouse wheel before ctrl-C-ing bpftrace
$ ./target/flamegraph/ad src/buffer/internal.rs

# produce the flamegraphs
$ git clone https://github.com/brendangregg/FlameGraph
$ cd FlameGraph
$ ./stackcollapse-bpftrace.pl < out.stacks | ./flamegraph.pl --hash \
--color=mem --count=bytes --title="malloc() Bytes Flame Graph (PR build)" > out.svg
```

You can also spot check the allocations being made as a histogram like this:
```bash
$ sudo bpftrace \
  -e '
  u:/lib/x86_64-linux-gnu/libc.so.6:malloc /comm == "ad"/ {
    @allocs = hist(arg0);
  }
'

Attaching 1 probe...
^C

@allocs:
[1]                   65 |                                                    |
[2, 4)               209 |                                                    |
[4, 8)             14413 |@@@@@@@@@@@                                         |
[8, 16)            64199 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[16, 32)            6505 |@@@@@                                               |
[32, 64)           17698 |@@@@@@@@@@@@@@                                      |
[64, 128)          31643 |@@@@@@@@@@@@@@@@@@@@@@@@@                           |
[128, 256)          4943 |@@@@                                                |
[256, 512)          7286 |@@@@@                                               |
[512, 1K)           5005 |@@@@                                                |
[1K, 2K)             944 |                                                    |
[2K, 4K)              20 |                                                    |
[4K, 8K)              12 |                                                    |
[8K, 16K)             14 |                                                    |
[16K, 32K)           893 |                                                    |
[32K, 64K)             4 |                                                    |
[64K, 128K)            5 |                                                    |
[128K, 256K)           2 |                                                    |

```

### Benchmark improvements

It's not surprising that moving over to using internal buffers instead of allocating all over the place in the TUI renderer gives a further speed-up over #139 but this is a little silly to be honest.

#### TUI render/two windows
> This one is mostly down to no longer doing a full re-render when the UI hasn't changed.
<img width="993" height="376" alt="2025-10-11_15-47" src="https://github.com/user-attachments/assets/bc239165-b4ca-442b-b97f-2d5eef570e48" />

#### TUI render/single window editor scroll inputs sink
<img width="980" height="376" alt="2025-10-11_15-47_1" src="https://github.com/user-attachments/assets/35d57e8c-87ef-4394-b4ce-7000452b692d" />

#### TUI render/single window editor scroll inputs stdout
> Run under `st`
<img width="977" height="375" alt="2025-10-11_15-47_2" src="https://github.com/user-attachments/assets/06d86979-47e2-4ade-bee5-c00c0a2aad72" />
 