### PR TITLE
Prevent crash in keybinding parsing for Config

### DIFF
--- a/data/config_tests/valid/all-keybinding-types.toml
+++ b/data/config_tests/valid/all-keybinding-types.toml
@@ -1,0 +1,66 @@
+[editor]
+show_splash = true
+expand_tab = true
+tabstop = 4
+match_indent = true
+status_timeout = 3
+double_click_ms = 200
+minibuffer_lines = 8
+find_command = "fd -t f"
+
+[filesystem]
+enabled = true
+auto_mount = false
+
+[tree_sitter]
+parser_dir = "~/.ad/tree-sitter/parsers"
+syntax_query_dir = "~/.ad/tree-sitter/queries"
+
+[colorscheme]
+bg = "#1B1720"
+fg = "#E6D29E"
+bar_bg = "#4E415C"
+signcol_fg = "#544863"
+minibuffer_hl = "#3E3549"
+
+[colorscheme.syntax]
+default = { fg = "#E6D29E", bg = "#1B1720" }
+
+[keys.normal]
+"A" = { run = "echo hello world" }
+"1" = { run = "echo hello world" }
+"A-a" = { run = "echo hello world" }
+"C-a" = { run = "echo hello world" }
+"C-A-a" = { run = "echo hello world" }
+"<backspace>" = { run = "echo hello world" }
+"<delete>" = { run = "echo hello world" }
+"<end>" = { run = "echo hello world" }
+"<esc>" = { run = "echo hello world" }
+"<home>" = { run = "echo hello world" }
+"<page-up>" = { run = "echo hello world" }
+"<page-down>" = { run = "echo hello world" }
+"<space>" = { run = "echo hello world" }
+"<tab>" = { run = "echo hello world" }
+"X" = { send_keys = "a 1 A-b C-c C-A-d <backspace> <delete> <end> <esc> <home> <page-up> <page-down> <space> <tab>" }
+
+[keys.insert]
+"A" = { run = "echo hello world" }
+"1" = { run = "echo hello world" }
+"A-a" = { run = "echo hello world" }
+"C-a" = { run = "echo hello world" }
+"C-A-a" = { run = "echo hello world" }
+"<backspace>" = { run = "echo hello world" }
+"<delete>" = { run = "echo hello world" }
+"<end>" = { run = "echo hello world" }
+"<esc>" = { run = "echo hello world" }
+"<home>" = { run = "echo hello world" }
+"<page-up>" = { run = "echo hello world" }
+"<page-down>" = { run = "echo hello world" }
+"<space>" = { run = "echo hello world" }
+"<tab>" = { run = "echo hello world" }
+"X" = { send_keys = "a 1 A-b C-c C-A-d <backspace> <delete> <end> <esc> <home> <page-up> <page-down> <space> <tab>" }
+
+[filetypes.rust]
+extensions = ["rs"]
+lsp.command = "rust-analyzer"
+lsp.roots = ["Cargo.toml"]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -310,13 +310,56 @@ impl TryFrom<String> for Inputs {
     type Error = String;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        let mut inputs = Vec::new();
+        let inputs = value
+            .split_whitespace()
+            .map(try_input_from_str_template)
+            .collect::<Result<Vec<_>, _>>()?;
 
-        for s in value.split_whitespace() {
-            inputs.push(Input::try_from_str_template(s)?);
+        if inputs.is_empty() {
+            return Err("empty key inputs string".to_owned());
         }
 
         Ok(Self(inputs))
+    }
+}
+
+/// Only supporting a subset of inputs for now
+fn try_input_from_str_template(s: &str) -> Result<Input, String> {
+    if s.len() == 1 {
+        Ok(Input::Char(s.chars().next().unwrap()))
+    } else if let Some(suffix) = s.strip_prefix("C-A-") {
+        if suffix.len() == 1 {
+            Ok(Input::CtrlAlt(suffix.chars().next().unwrap()))
+        } else {
+            Err(format!("invalid send_key value: C-A-{suffix}"))
+        }
+    } else if let Some(suffix) = s.strip_prefix("C-") {
+        if suffix.len() == 1 {
+            Ok(Input::Ctrl(suffix.chars().next().unwrap()))
+        } else {
+            Err(format!("invalid send_key value: C-{suffix}"))
+        }
+    } else if let Some(suffix) = s.strip_prefix("A-") {
+        if suffix.len() == 1 {
+            Ok(Input::Alt(suffix.chars().next().unwrap()))
+        } else {
+            Err(format!("invalid send_key value: A-{suffix}"))
+        }
+    } else {
+        let i = match s {
+            "<backspace>" => Input::Backspace,
+            "<delete>" => Input::Del,
+            "<end>" => Input::End,
+            "<esc>" => Input::Esc,
+            "<home>" => Input::Home,
+            "<page-down>" => Input::PageDown,
+            "<page-up>" => Input::PageUp,
+            "<space>" => Input::Char(' '),
+            "<tab>" => Input::Tab,
+            _ => return Err(format!("unknown key {s}")),
+        };
+
+        Ok(i)
     }
 }
 
@@ -325,30 +368,18 @@ where
     D: Deserializer<'de>,
 {
     let raw_map: HashMap<String, KeyAction> = Deserialize::deserialize(deserializer)?;
-    let mut raw = Vec::with_capacity(raw_map.len());
-
-    for (k, action) in raw_map.into_iter() {
-        let keys: Vec<Input> = k
-            .split_whitespace()
-            .filter_map(|s| {
-                if s.len() == 1 {
-                    let c = s.chars().next().unwrap();
-                    if c.is_whitespace() {
-                        None
-                    } else {
-                        Some(Input::Char(c))
-                    }
-                } else {
-                    match s {
-                        "<space>" => Some(Input::Char(' ')),
-                        _ => None,
-                    }
-                }
-            })
-            .collect();
-
-        raw.push((keys, action));
+    if raw_map.is_empty() {
+        return Err(de::Error::custom("empty key map"));
     }
+
+    let raw = raw_map
+        .into_iter()
+        .map(|(k, action)| {
+            Inputs::try_from(k)
+                .map(|Inputs(keys)| (keys, action))
+                .map_err(de::Error::custom)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     Trie::from_pairs(raw).map_err(de::Error::custom)
 }
@@ -356,9 +387,45 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use simple_test_case::test_case;
 
     #[test]
     fn default_config_is_valid() {
         Config::default(); // will panic if default config is invalid
+    }
+
+    #[test_case("A", &[Input::Char('A')]; "single letter key")]
+    #[test_case("5", &[Input::Char('5')]; "single digit key")]
+    #[test_case("A-y", &[Input::Alt('y')]; "alt letter")]
+    #[test_case("C-y", &[Input::Ctrl('y')]; "control letter")]
+    #[test_case("C-A-y", &[Input::CtrlAlt('y')]; "control alt letter")]
+    #[test_case("<backspace>", &[Input::Backspace]; "backspace")]
+    #[test_case("<delete>", &[Input::Del]; "delete")]
+    #[test_case("<end>", &[Input::End]; "end")]
+    #[test_case("<esc>", &[Input::Esc]; "escape")]
+    #[test_case("<home>", &[Input::Home]; "home")]
+    #[test_case("<page-up>", &[Input::PageUp]; "page up")]
+    #[test_case("<page-down>", &[Input::PageDown]; "page down")]
+    #[test_case("<space>", &[Input::Char(' ')]; "space")]
+    #[test_case("<tab>", &[Input::Tab]; "tab")]
+    #[test_case("A B C", &[Input::Char('A'), Input::Char('B'), Input::Char('C')]; "sequence")]
+    #[test]
+    fn inputs_try_from_string_works(raw: &str, expected: &[Input]) {
+        let inputs = Inputs::try_from(raw.to_owned()).unwrap();
+        assert_eq!(&inputs.0, expected);
+    }
+
+    #[test]
+    fn inputs_try_from_empty_string_errors() {
+        assert_eq!(
+            &Inputs::try_from(String::new()).unwrap_err(),
+            "empty key inputs string"
+        );
+    }
+
+    #[test]
+    fn parsing_an_empty_keymap_errors() {
+        let res: Result<KeyBindings, _> = toml::from_str("[normal]");
+        assert!(res.is_err());
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -72,34 +72,6 @@ impl fmt::Display for Input {
 }
 
 impl Input {
-    /// Only supporting a subset of inputs for now
-    pub fn try_from_str_template(s: &str) -> Result<Self, String> {
-        if s.len() == 1 {
-            Ok(Input::Char(s.chars().next().unwrap()))
-        } else if let Some(suffix) = s.strip_prefix("C-") {
-            if suffix.len() == 1 {
-                Ok(Input::Ctrl(suffix.chars().next().unwrap()))
-            } else {
-                Err(format!("invalid send_key value: C-{suffix}"))
-            }
-        } else if let Some(suffix) = s.strip_prefix("A-") {
-            if suffix.len() == 1 {
-                Ok(Input::Alt(suffix.chars().next().unwrap()))
-            } else {
-                Err(format!("invalid send_key value: A-{suffix}"))
-            }
-        } else {
-            let i = match s {
-                "<esc>" => Input::Esc,
-                "<space>" => Input::Char(' '),
-                "<tab>" => Input::Tab,
-                _ => return Err(format!("unknown key {s}")),
-            };
-
-            Ok(i)
-        }
-    }
-
     pub fn from_char(c: char) -> Self {
         match c {
             '\x1b' => Input::Esc,


### PR DESCRIPTION
As reported in #158, the simple parser for custom keybindings was triggering a panic for some keybindings that looked like they should have been valid. The parser was only supporting a subset of the keys that ad can handle in the form of simple string templates, and was intending to return an error if it didn't recognise the key template it had been given. This error was being dropped due to a flat_map though and there was no guard against attempting to construct a Trie from an empty input which was where the panic was coming from.

This commit extends the parser to cover inputs other than arrows and mouse clicks and provides some tests for the behaviour of the parser.