### PR TITLE
Custom keymaps should override

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -328,18 +328,24 @@ fn try_input_from_str_template(s: &str) -> Result<Input, String> {
     } else if let Some(suffix) = s.strip_prefix("C-A-") {
         if suffix.len() == 1 {
             Ok(Input::CtrlAlt(suffix.chars().next().unwrap()))
+        } else if suffix == "<space>" {
+            Ok(Input::CtrlAlt(' '))
         } else {
             Err(format!("invalid send_key value: C-A-{suffix}"))
         }
     } else if let Some(suffix) = s.strip_prefix("C-") {
         if suffix.len() == 1 {
             Ok(Input::Ctrl(suffix.chars().next().unwrap()))
+        } else if suffix == "<space>" {
+            Ok(Input::Ctrl(' '))
         } else {
             Err(format!("invalid send_key value: C-{suffix}"))
         }
     } else if let Some(suffix) = s.strip_prefix("A-") {
         if suffix.len() == 1 {
             Ok(Input::Alt(suffix.chars().next().unwrap()))
+        } else if suffix == "<space>" {
+            Ok(Input::Alt(' '))
         } else {
             Err(format!("invalid send_key value: A-{suffix}"))
         }
@@ -401,6 +407,9 @@ mod tests {
     #[test_case("A-y", &[Input::Alt('y')]; "alt letter")]
     #[test_case("C-y", &[Input::Ctrl('y')]; "control letter")]
     #[test_case("C-A-y", &[Input::CtrlAlt('y')]; "control alt letter")]
+    #[test_case("A-<space>", &[Input::Alt(' ')]; "alt space")]
+    #[test_case("C-<space>", &[Input::Ctrl(' ')]; "control space")]
+    #[test_case("C-A-<space>", &[Input::CtrlAlt(' ')]; "control alt space")]
     #[test_case("<backspace>", &[Input::Backspace]; "backspace")]
     #[test_case("<delete>", &[Input::Del]; "delete")]
     #[test_case("<end>", &[Input::End]; "end")]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -269,16 +269,16 @@ impl LspConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct KeyBindings {
     #[serde(default, deserialize_with = "de_serde_trie")]
-    pub normal: Trie<Input, KeyAction>,
+    pub normal: Trie<Input, Actions>,
     #[serde(default, deserialize_with = "de_serde_trie")]
-    pub insert: Trie<Input, KeyAction>,
+    pub insert: Trie<Input, Actions>,
 }
 
 impl Default for KeyBindings {
     fn default() -> Self {
         KeyBindings {
-            normal: Trie::from_pairs(Vec::new()).unwrap(),
-            insert: Trie::from_pairs(Vec::new()).unwrap(),
+            normal: Trie::try_from_iter(Vec::new()).unwrap(),
+            insert: Trie::try_from_iter(Vec::new()).unwrap(),
         }
     }
 }
@@ -291,12 +291,10 @@ pub enum KeyAction {
 }
 
 impl KeyAction {
-    pub fn as_actions(&self) -> Actions {
+    fn into_actions(self) -> Actions {
         match self {
-            Self::Execute { run } => Actions::Single(Action::ExecuteString { s: run.clone() }),
-            Self::Keys { send_keys } => Actions::Single(Action::SendKeys {
-                ks: send_keys.0.clone(),
-            }),
+            Self::Execute { run } => Actions::Single(Action::ExecuteString { s: run }),
+            Self::Keys { send_keys } => Actions::Single(Action::SendKeys { ks: send_keys.0 }),
         }
     }
 }
@@ -304,7 +302,7 @@ impl KeyAction {
 /// Raw inputs to be sent through to the main editor event loop
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(try_from = "String")]
-pub struct Inputs(Vec<Input>);
+pub struct Inputs(pub(crate) Vec<Input>);
 
 impl TryFrom<String> for Inputs {
     type Error = String;
@@ -367,7 +365,7 @@ fn try_input_from_str_template(s: &str) -> Result<Input, String> {
     }
 }
 
-fn de_serde_trie<'de, D>(deserializer: D) -> Result<Trie<Input, KeyAction>, D::Error>
+fn de_serde_trie<'de, D>(deserializer: D) -> Result<Trie<Input, Actions>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -380,12 +378,12 @@ where
         .into_iter()
         .map(|(k, action)| {
             Inputs::try_from(k)
-                .map(|Inputs(keys)| (keys, action))
+                .map(|Inputs(keys)| (keys, action.into_actions()))
                 .map_err(de::Error::custom)
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    Trie::from_pairs(raw).map_err(de::Error::custom)
+    Trie::try_from_iter(raw).map_err(de::Error::custom)
 }
 
 #[cfg(test)]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -149,6 +149,7 @@ where
             config.lsp_autostart,
         ));
 
+        let modes = modes(&config.keys);
         let config = Arc::new(RwLock::new(config));
 
         let ui = Ui::new(mode, config.clone());
@@ -166,7 +167,7 @@ where
             ui,
             cwd,
             running: true,
-            modes: modes(),
+            modes,
             pending_keys: Vec::new(),
             layout,
             lsp_manager,
@@ -521,8 +522,7 @@ where
 
     pub fn handle_input(&mut self, input: Input) {
         self.pending_keys.push(input);
-        let maybe_actions =
-            self.modes[0].handle_keys(&mut self.pending_keys, &*config_handle!(self));
+        let maybe_actions = self.modes[0].handle_keys(&mut self.pending_keys);
 
         if let Some(actions) = maybe_actions {
             self.handle_actions(actions, Source::Keyboard);
@@ -530,7 +530,7 @@ where
     }
 
     fn handle_explicit_inputs(&mut self, inputs: &mut Vec<Input>) {
-        let maybe_actions = self.modes[0].handle_keys(inputs, &*config_handle!(self));
+        let maybe_actions = self.modes[0].handle_keys(inputs);
 
         if let Some(actions) = maybe_actions {
             self.handle_actions(actions, Source::Keyboard);

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -529,11 +529,9 @@ where
         }
     }
 
-    fn handle_explicit_inputs(&mut self, inputs: &mut Vec<Input>) {
-        let maybe_actions = self.modes[0].handle_keys(inputs);
-
-        if let Some(actions) = maybe_actions {
-            self.handle_actions(actions, Source::Keyboard);
+    fn handle_explicit_inputs(&mut self, inputs: Vec<Input>) {
+        for i in inputs.into_iter() {
+            self.handle_input(i);
         }
     }
 
@@ -693,7 +691,7 @@ where
             SaveBufferAs { path, force } => self.save_current_buffer(Some(path), force),
             SaveBuffer { force } => self.save_current_buffer(None, force),
             SearchInCurrentBuffer => self.search_in_current_buffer(),
-            SendKeys { mut ks } => self.handle_explicit_inputs(&mut ks),
+            SendKeys { ks } => self.handle_explicit_inputs(ks),
             SelectBuffer => self.select_buffer(),
             SetMode { m } => self.set_mode(m),
             SetStatusMessage { message } => self.set_status_message(&message),

--- a/src/mode/insert.rs
+++ b/src/mode/insert.rs
@@ -6,7 +6,6 @@ use crate::{
     keymap,
     mode::Mode,
     term::CurShape,
-    trie::QueryResult,
 };
 
 pub(crate) fn insert_mode() -> (Mode, Vec<(String, &'static str)>) {
@@ -54,7 +53,7 @@ pub(crate) fn insert_mode() -> (Mode, Vec<(String, &'static str)>) {
         cur_shape: CurShape::Bar,
         keymap,
         handle_expired_pending: |keys| {
-            QueryResult::Val(if keys.len() == 1 {
+            Some(if keys.len() == 1 {
                 Actions::Single(RawInput { i: keys[0] })
             } else {
                 Actions::Multi(keys.iter().map(|&i| RawInput { i }).collect())

--- a/src/mode/insert.rs
+++ b/src/mode/insert.rs
@@ -53,20 +53,64 @@ pub(crate) fn insert_mode() -> (Mode, Vec<(String, &'static str)>) {
         name: "INSERT".to_string(),
         cur_shape: CurShape::Bar,
         keymap,
-        handle_expired_pending: |keys, cfg| {
-            let res = cfg.keys.insert.get(keys).map(|ka| ka.as_actions());
-
-            match res {
-                QueryResult::Val(_) => res,
-                QueryResult::Partial => QueryResult::Partial,
-                QueryResult::Missing => QueryResult::Val(if keys.len() == 1 {
-                    Actions::Single(RawInput { i: keys[0] })
-                } else {
-                    Actions::Multi(keys.iter().map(|&i| RawInput { i }).collect())
-                }),
-            }
+        handle_expired_pending: |keys| {
+            QueryResult::Val(if keys.len() == 1 {
+                Actions::Single(RawInput { i: keys[0] })
+            } else {
+                Actions::Multi(keys.iter().map(|&i| RawInput { i }).collect())
+            })
         },
     };
 
     (mode, docs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::{Inputs, KeyBindings},
+        editor::Action,
+        key::Input,
+    };
+    use simple_test_case::test_case;
+
+    #[test_case("C-a", Some(Actions::Single(Action::DotSet(LineStart, 1))); "direct override single")]
+    #[test]
+    fn overrides_work(binding: &str, expected_default_actions: Option<Actions>) {
+        let action = r#"{ send_keys = "A" }"#;
+        let overrides: KeyBindings =
+            toml::from_str(&format!("[insert]\n\"{binding}\" = {action}")).unwrap();
+
+        let mut mode = insert_mode().0;
+
+        // Without the overrides in place we should get the default behaviour
+        let Inputs(mut keys) = Inputs::try_from(binding.to_owned()).unwrap();
+        let default_actions = mode.handle_keys(&mut keys);
+        assert_eq!(default_actions, expected_default_actions, "default");
+
+        mode.keymap = mode.keymap.merge_overriding(overrides.insert).unwrap();
+
+        // With the overrides we should see the send_keys action
+        let Inputs(mut keys) = Inputs::try_from(binding.to_owned()).unwrap();
+        let override_actions = mode.handle_keys(&mut keys);
+        assert_eq!(
+            override_actions,
+            Some(Actions::Single(Action::SendKeys {
+                ks: vec![Input::Char('A')]
+            })),
+            "override"
+        );
+    }
+
+    #[test_case("C-a g"; "shadowing an existing binding")]
+    #[test]
+    fn overrides_shadowing_defaults_error(binding: &str) {
+        let action = r#"{ send_keys = "A" }"#;
+        let overrides: KeyBindings =
+            toml::from_str(&format!("[normal]\n\"{binding}\" = {action}")).unwrap();
+
+        let mut mode = insert_mode().0;
+        assert!(mode.with_overrides(overrides.normal).is_err());
+    }
 }

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -40,7 +40,7 @@ pub(crate) struct Mode {
     pub(crate) name: String,
     pub(crate) cur_shape: CurShape,
     pub(crate) keymap: Trie<Input, Actions>,
-    handle_expired_pending: fn(&[Input]) -> QueryResult<Actions>,
+    handle_expired_pending: fn(&[Input]) -> Option<Actions>,
 }
 
 impl fmt::Display for Mode {
@@ -55,7 +55,7 @@ impl Mode {
             name: name.to_string(),
             cur_shape: CurShape::Block,
             keymap: Trie::try_from_iter(Vec::new()).unwrap(),
-            handle_expired_pending: |_| QueryResult::Missing,
+            handle_expired_pending: |_| None,
         }
     }
 
@@ -74,17 +74,8 @@ impl Mode {
             QueryResult::Partial => None,
             QueryResult::Missing => {
                 let res = (self.handle_expired_pending)(keys);
-                match res {
-                    QueryResult::Val(actions) => {
-                        keys.clear();
-                        Some(actions)
-                    }
-                    QueryResult::Missing => {
-                        keys.clear();
-                        None
-                    }
-                    QueryResult::Partial => None,
-                }
+                keys.clear();
+                res
             }
         }
     }

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -69,7 +69,7 @@ impl Mode {
         match self.keymap.get(keys) {
             QueryResult::Val(actions) => {
                 keys.clear();
-                Some(actions)
+                Some(actions.clone())
             }
             QueryResult::Partial => None,
             QueryResult::Missing => {

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -1,19 +1,30 @@
 //! Modal editing support.
 use crate::{
-    config::Config,
+    config::KeyBindings,
     editor::Actions,
     key::Input,
     term::CurShape,
     trie::{QueryResult, Trie},
 };
 use std::fmt;
+use tracing::error;
 
 mod insert;
 mod normal;
 
 /// The modes available for ad
-pub(crate) fn modes() -> Vec<Mode> {
-    vec![normal::normal_mode().0, insert::insert_mode().0]
+pub(crate) fn modes(custom_bindings: &KeyBindings) -> Vec<Mode> {
+    let mut normal = normal::normal_mode().0;
+    if let Err(e) = normal.with_overrides(custom_bindings.normal.clone()) {
+        error!("unable to apply keymap overrides for NORMAL mode: {e}");
+    }
+
+    let mut insert = insert::insert_mode().0;
+    if let Err(e) = insert.with_overrides(custom_bindings.insert.clone()) {
+        error!("unable to apply keymap overrides for INSERT mode: {e}");
+    }
+
+    vec![normal, insert]
 }
 
 /// Docs for the different keybindings available in each mode
@@ -29,7 +40,7 @@ pub(crate) struct Mode {
     pub(crate) name: String,
     pub(crate) cur_shape: CurShape,
     pub(crate) keymap: Trie<Input, Actions>,
-    handle_expired_pending: fn(&[Input], &Config) -> QueryResult<Actions>,
+    handle_expired_pending: fn(&[Input]) -> QueryResult<Actions>,
 }
 
 impl fmt::Display for Mode {
@@ -43,24 +54,30 @@ impl Mode {
         Mode {
             name: name.to_string(),
             cur_shape: CurShape::Block,
-            keymap: Trie::from_pairs(Vec::new()).unwrap(),
-            handle_expired_pending: |_, _| QueryResult::Missing,
+            keymap: Trie::try_from_iter(Vec::new()).unwrap(),
+            handle_expired_pending: |_| QueryResult::Missing,
         }
     }
 
-    pub fn handle_keys(&self, keys: &mut Vec<Input>, config: &Config) -> Option<Actions> {
+    fn with_overrides(&mut self, overrides: Trie<Input, Actions>) -> Result<(), &'static str> {
+        self.keymap = self.keymap.clone().merge_overriding(overrides)?;
+
+        Ok(())
+    }
+
+    pub fn handle_keys(&self, keys: &mut Vec<Input>) -> Option<Actions> {
         match self.keymap.get(keys) {
-            QueryResult::Val(outcome) => {
+            QueryResult::Val(actions) => {
                 keys.clear();
-                Some(outcome)
+                Some(actions)
             }
             QueryResult::Partial => None,
             QueryResult::Missing => {
-                let res = (self.handle_expired_pending)(keys, config);
+                let res = (self.handle_expired_pending)(keys);
                 match res {
-                    QueryResult::Val(outcome) => {
+                    QueryResult::Val(actions) => {
                         keys.clear();
-                        Some(outcome)
+                        Some(actions)
                     }
                     QueryResult::Missing => {
                         keys.clear();
@@ -90,7 +107,7 @@ macro_rules! keymap {
                 docs.push((doc_key, $docs));
             )+
 
-            ($crate::trie::Trie::from_pairs(pairs).unwrap(), docs)
+            ($crate::trie::Trie::try_from_iter(pairs).unwrap(), docs)
         }
     };
 
@@ -108,6 +125,6 @@ mod tests {
     // making sure we've not messed anything up.
     #[test]
     fn mode_keymaps_have_no_collisions() {
-        _ = modes();
+        _ = modes(&KeyBindings::default());
     }
 }

--- a/src/mode/normal.rs
+++ b/src/mode/normal.rs
@@ -6,6 +6,7 @@ use crate::{
     keymap,
     mode::Mode,
     term::CurShape,
+    trie::QueryResult,
 };
 
 pub(crate) fn normal_mode() -> (Mode, Vec<(String, &'static str)>) {
@@ -249,8 +250,61 @@ pub(crate) fn normal_mode() -> (Mode, Vec<(String, &'static str)>) {
         name: "NORMAL".to_string(),
         cur_shape: CurShape::Block,
         keymap,
-        handle_expired_pending: |keys, cfg| cfg.keys.normal.get(keys).map(|ka| ka.as_actions()),
+        handle_expired_pending: |_| QueryResult::Missing,
     };
 
     (mode, docs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::{Inputs, KeyBindings},
+        editor::Action,
+        key::Input,
+    };
+    use simple_test_case::test_case;
+
+    #[test_case("C-k", Some(Actions::Single(Action::LspHover)); "direct override single")]
+    #[test_case("g d", Some(Actions::Single(Action::LspGotoDefinition)); "direct override sequence")]
+    #[test_case("z x", None; "sharing prefix with defaults")]
+    #[test]
+    fn overrides_work(binding: &str, expected_default_actions: Option<Actions>) {
+        let action = r#"{ send_keys = "A" }"#;
+        let overrides: KeyBindings =
+            toml::from_str(&format!("[normal]\n\"{binding}\" = {action}")).unwrap();
+
+        let mut mode = normal_mode().0;
+
+        // Without the overrides in place we should get the default behaviour
+        let Inputs(mut keys) = Inputs::try_from(binding.to_owned()).unwrap();
+        let default_actions = mode.handle_keys(&mut keys);
+        assert_eq!(default_actions, expected_default_actions, "default");
+
+        mode.keymap = mode.keymap.merge_overriding(overrides.normal).unwrap();
+
+        // With the overrides we should see the send_keys action
+        let Inputs(mut keys) = Inputs::try_from(binding.to_owned()).unwrap();
+        let override_actions = mode.handle_keys(&mut keys);
+        assert_eq!(
+            override_actions,
+            Some(Actions::Single(Action::SendKeys {
+                ks: vec![Input::Char('A')]
+            })),
+            "override"
+        );
+    }
+
+    #[test_case("d g"; "shadowing an existing binding")]
+    #[test_case("g g g"; "shadowing an existing sequence")]
+    #[test]
+    fn overrides_shadowing_defaults_error(binding: &str) {
+        let action = r#"{ send_keys = "A" }"#;
+        let overrides: KeyBindings =
+            toml::from_str(&format!("[normal]\n\"{binding}\" = {action}")).unwrap();
+
+        let mut mode = normal_mode().0;
+        assert!(mode.with_overrides(overrides.normal).is_err());
+    }
 }

--- a/src/mode/normal.rs
+++ b/src/mode/normal.rs
@@ -6,13 +6,12 @@ use crate::{
     keymap,
     mode::Mode,
     term::CurShape,
-    trie::QueryResult,
 };
 
 pub(crate) fn normal_mode() -> (Mode, Vec<(String, &'static str)>) {
     let leader = Char(' ');
 
-    let (mut keymap, docs) = keymap! {
+    let (keymap, docs) = keymap! {
         // Exiting
         "close window";
         [ leader, Char('q') ] => [ DeleteWindow { force: false } ],
@@ -241,16 +240,20 @@ pub(crate) fn normal_mode() -> (Mode, Vec<(String, &'static str)>) {
         [ Ctrl('k') ] => [ LspHover ],
     };
 
-    keymap.set_default(|&i| match i {
-        Mouse(_) | Arrow(_) | PageUp | PageDown => Some(Actions::Single(RawInput { i })),
-        _ => None,
-    });
-
     let mode = Mode {
         name: "NORMAL".to_string(),
         cur_shape: CurShape::Block,
         keymap,
-        handle_expired_pending: |_| QueryResult::Missing,
+        handle_expired_pending: |keys| {
+            if keys.len() > 1 {
+                return None;
+            }
+            let i = keys[0];
+            match i {
+                Mouse(_) | Arrow(_) | PageUp | PageDown => Some(Actions::Single(RawInput { i })),
+                _ => None,
+            }
+        },
     };
 
     (mode, docs)

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -1,48 +1,48 @@
-//! A trie data structure with modifications for supporting key bindings and autocompletions in a
-//! composible way with the rest of the ad internal APIs.
-use std::{cmp, fmt};
+//! A simple trie data structure for supporting key bindings and autocompletions in a composible
+//! way with the rest of the ad internal APIs.
+use std::{collections::BTreeMap, fmt, ops::Range};
 
-/// A singly initialised Trie mapping sequences to a value
+/// A singly initialised Trie mapping key sequences to a value.
 ///
-/// NOTE: It is not permitted for values to be mapped to a key that is a prefix of another key also
-/// existing in the same Try.
+/// It is not permitted for values to be mapped to a key that is a prefix of another key also
+/// existing in the same Trie.
 ///
 /// There are convenience methods provided for `Trie<char, V>` for when &str values are used as keys.
 #[allow(unpredictable_function_pointer_comparisons)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct Trie<K, V>
 where
-    K: Clone + PartialEq,
+    K: Clone + PartialEq + Ord,
     V: Clone,
 {
-    parent_key: Option<Vec<K>>,
-    roots: Vec<Node<K, V>>,
+    nodes: Vec<Node<K, V>>,
+    n_roots: usize,
     default: Option<DefaultMapping<K, V>>,
 }
 
 impl<K, V> fmt::Debug for Trie<K, V>
 where
-    K: Clone + PartialEq + fmt::Debug,
+    K: Clone + PartialEq + Ord + fmt::Debug,
     V: Clone + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Trie")
-            .field("parent_key", &self.parent_key)
-            .field("roots", &self.roots)
-            .field("default", &stringify!(self.default))
+            .field("nodes", &self.nodes)
+            .field("n_roots", &self.n_roots)
+            .field("default", &"<function>")
             .finish()
     }
 }
 
 impl<K, V> Default for Trie<K, V>
 where
-    K: Clone + PartialEq,
+    K: Clone + PartialEq + Ord,
     V: Clone,
 {
     fn default() -> Self {
         Self {
-            parent_key: None,
-            roots: Vec::new(),
+            nodes: Vec::new(),
+            n_roots: 0,
             default: None,
         }
     }
@@ -50,123 +50,195 @@ where
 
 impl<K, V> Trie<K, V>
 where
-    K: Clone + PartialEq,
+    K: Clone + PartialEq + Ord,
     V: Clone,
 {
+    /// Construct a new Trie from key-value pairs.
+    ///
     /// Will panic if there are any key collisions or if there are any sequences that nest
     /// under a prefix that is already required to hold a value
-    pub fn from_pairs(pairs: Vec<(Vec<K>, V)>) -> Result<Self, &'static str> {
+    pub fn try_from_iter(it: impl IntoIterator<Item = (Vec<K>, V)>) -> Result<Self, &'static str> {
         let mut roots = Vec::new();
-
-        for (k, v) in pairs.into_iter() {
-            insert(k, v, &mut roots)?;
+        for (key, value) in it.into_iter() {
+            insert(key, value, &mut roots)?;
         }
 
-        Ok(Self {
-            parent_key: None,
-            roots,
+        if roots.is_empty() {
+            return Ok(Self::default());
+        }
+
+        let mut nodes = Vec::new();
+        let (_, n_roots) = flatten(roots, &mut nodes);
+
+        Ok(Trie {
+            nodes,
+            n_roots,
             default: None,
         })
     }
 
-    // TODO: re-use this when dynamic config updates are supported
-    // pub(crate) fn extend_from_pairs(
-    //     &mut self,
-    //     pairs: Vec<(Vec<K>, V)>,
-    // ) -> Result<(), &'static str> {
-    //     for (k, v) in pairs.into_iter() {
-    //         insert(k, v, &mut self.roots)?;
-    //     }
-    //
-    //     Ok(())
-    // }
+    /// Merge two Tries.
+    ///
+    /// If the resulting Trie would be invalid to construct directly, an error is returned.
+    ///
+    /// Consumes both inputs.
+    pub fn merge(self, other: Self) -> Result<Self, &'static str> {
+        if self.is_empty() {
+            return Ok(other);
+        } else if other.is_empty() {
+            return Ok(self);
+        }
+
+        let mut pairs = Vec::with_capacity(self.len() + other.len());
+        self.extract_pairs(&mut pairs, Vec::new(), 0..self.n_roots);
+        other.extract_pairs(&mut pairs, Vec::new(), 0..other.n_roots);
+
+        Self::try_from_iter(pairs)
+    }
+
+    /// Merge two Tries preferring keys from `other` in the case of collisions.
+    ///
+    /// If the resulting Trie would be invalid to construct directly, an error is returned.
+    ///
+    /// Consumes both inputs.
+    pub fn merge_overriding(self, other: Self) -> Result<Self, &'static str> {
+        if self.is_empty() {
+            return Ok(other);
+        } else if other.is_empty() {
+            return Ok(self);
+        }
+
+        let mut pairs = Vec::with_capacity(self.len() + other.len());
+        self.extract_pairs(&mut pairs, Vec::new(), 0..self.n_roots);
+
+        let mut m = BTreeMap::from_iter(pairs.drain(..));
+        other.extract_pairs(&mut pairs, Vec::new(), 0..other.n_roots);
+        m.extend(pairs.drain(..));
+
+        Self::try_from_iter(m)
+    }
+
+    fn extract_pairs(&self, pairs: &mut Vec<(Vec<K>, V)>, key: Vec<K>, indices: Range<usize>) {
+        for i in indices {
+            let node = &self.nodes[i];
+            let mut child_key = key.clone();
+            child_key.push(node.key.clone());
+
+            match &node.data {
+                Data::Leaf { value } => pairs.push((child_key, value.clone())),
+
+                Data::Internal {
+                    child_start,
+                    n_children,
+                } => self.extract_pairs(pairs, child_key, *child_start..*child_start + *n_children),
+            }
+        }
+    }
 
     /// Set the default handler for unmatched single element keys
     pub fn set_default(&mut self, default: DefaultMapping<K, V>) {
         self.default = Some(default);
     }
 
-    /// Query this Try for a given key or key prefix.
+    /// Query this [Trie] for a given key or key prefix
     ///
     /// If the key maps to a leaf then the value is returned, if it maps to a sub-trie then
     /// `Partial` is returned to denote that the given key is a parent of one or more values. If
     /// the key is not found within the `Try` then `Missing` is returned.
+    ///
+    /// If this [Trie] contains a default mapping, it will be applied to missing single element
+    /// keys.
     pub fn get(&self, key: &[K]) -> QueryResult<V> {
-        match get_node(key, &self.roots) {
-            Some(Node {
-                d: Data::Val(v), ..
-            }) => QueryResult::Val(v.clone()),
-
-            Some(_) => QueryResult::Partial,
-
-            None => match self.default {
-                Some(f) if key.len() == 1 => f(&key[0]).into(),
-                _ => QueryResult::Missing,
-            },
+        match self.find_node(key) {
+            QueryResult::Missing if key.len() == 1 => self.default.and_then(|f| f(&key[0])).into(),
+            qr => qr,
         }
     }
 
     /// Query this Try for a given key or key prefix requiring the key to match exactly.
     ///
     /// If the key maps to a leaf then the `Some(value)` is returned, otherwise `None`.
+    ///
+    /// If this [Trie] contains a default mapping, it will be applied to missing single element
+    /// keys.
     pub fn get_exact(&self, key: &[K]) -> Option<V> {
-        match get_node(key, &self.roots) {
-            Some(Node {
-                d: Data::Val(v), ..
-            }) => Some(v.clone()),
-
-            Some(_) => None,
-
-            None => match self.default {
-                Some(f) if key.len() == 1 => f(&key[0]),
-                _ => None,
-            },
+        match self.find_node(key) {
+            QueryResult::Val(v) => Some(v),
+            QueryResult::Missing if key.len() == 1 => self.default.and_then(|f| f(&key[0])),
+            _ => None,
         }
     }
 
-    /// Find all candidate keys with the given key as a prefix (up to and including the given
-    /// prefix itself).
-    pub fn candidates(&self, key: &[K]) -> Vec<Vec<K>> {
-        match get_node(key, &self.roots) {
-            None => vec![],
-            Some(n) => n.resolved_keys(key),
+    fn find_node(&self, key: &[K]) -> QueryResult<V> {
+        if key.is_empty() {
+            return QueryResult::Missing;
         }
+
+        let mut indices = 0..self.n_roots;
+        let mut key_index = 0;
+
+        'outer: while key_index < key.len() {
+            let target = &key[key_index];
+
+            // Binary search within the current level (assumes sorted children)
+            for i in indices {
+                let node = &self.nodes[i];
+                if &node.key == target {
+                    key_index += 1;
+
+                    match &node.data {
+                        Data::Leaf { value } => {
+                            return if key_index == key.len() {
+                                QueryResult::Val(value.clone())
+                            } else {
+                                QueryResult::Missing
+                            };
+                        }
+
+                        Data::Internal {
+                            child_start,
+                            n_children,
+                        } => {
+                            indices = *child_start..*child_start + *n_children;
+                            continue 'outer;
+                        }
+                    }
+                } else if node.key > *target {
+                    // We've moved past where the node would be in sorted order
+                    return QueryResult::Missing;
+                }
+            }
+
+            return QueryResult::Missing;
+        }
+
+        QueryResult::Partial
     }
 
-    /// The number of leaf nodes in this Try
+    /// The number of leaf values in this Trie
     pub fn len(&self) -> usize {
-        self.roots.iter().map(|r| r.len()).sum()
+        self.nodes.iter().filter(|n| n.is_leaf()).count()
     }
 
-    /// The number of leaf nodes in this Try
+    /// Whether this Trie is empty
     pub fn is_empty(&self) -> bool {
-        self.roots.is_empty()
-    }
-
-    /// Whether the given key is present in this [Trie] either as a full key or a partial prefix to
-    /// multiple keys.
-    pub fn contains_key_or_prefix(&self, key: &[K]) -> bool {
-        !matches!(self.get(key), QueryResult::Missing)
+        self.nodes.is_empty()
     }
 }
 
+// Implementation for char-based convenience methods
 impl<V> Trie<char, V>
 where
     V: Clone,
 {
-    /// Construct a new [Trie] with char internal keys from the given string keys.
+    /// Construct a new [Trie] with [char] internal keys from string keys.
     pub fn from_str_keys(pairs: Vec<(&str, V)>) -> Result<Self, &'static str> {
-        let mut roots = Vec::new();
+        let char_pairs: Vec<(Vec<char>, V)> = pairs
+            .into_iter()
+            .map(|(k, v)| (k.chars().collect(), v))
+            .collect();
 
-        for (k, v) in pairs.into_iter() {
-            insert(k.chars().collect(), v, &mut roots)?;
-        }
-
-        Ok(Self {
-            parent_key: None,
-            roots,
-            default: None,
-        })
+        Self::try_from_iter(char_pairs)
     }
 
     /// Query this [Trie] using a string key.
@@ -182,15 +254,168 @@ where
     pub fn get_str_exact(&self, key: &str) -> Option<V> {
         self.get_exact(&key.chars().collect::<Vec<_>>())
     }
+}
 
-    /// Show all partial and full matches for the given key.
-    pub fn candidate_strings(&self, key: &str) -> Vec<String> {
-        let raw = self.candidates(&key.chars().collect::<Vec<_>>());
-        let mut strings: Vec<String> = raw.into_iter().map(|v| v.into_iter().collect()).collect();
-        strings.sort();
+/// The internal data held at each node in a Trie.
+///
+/// Internal nodes are "pointers" to their children while leaves hold the value associated with the
+/// full key used to traverse down to them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Data<V> {
+    Internal {
+        /// Index of the first child node
+        child_start: usize,
+        /// Number of child nodes
+        n_children: usize,
+    },
+    Leaf {
+        // Value associated with the full key-path down to this node
+        value: V,
+    },
+}
 
-        strings
+/// A single node within a [Trie].
+///
+/// Contains the last element of the key that traverses down to this node alongside [Data] that
+/// identifies this node as being internal or a leaf.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Node<K, V>
+where
+    K: Clone + PartialEq + Ord,
+    V: Clone,
+{
+    key: K,
+    data: Data<V>,
+}
+
+impl<K, V> Node<K, V>
+where
+    K: Clone + PartialEq + PartialOrd + Ord,
+    V: Clone,
+{
+    fn new_internal(key: K, children_start: usize, children_count: usize) -> Self {
+        Self {
+            key,
+            data: Data::Internal {
+                child_start: children_start,
+                n_children: children_count,
+            },
+        }
     }
+
+    fn new_leaf(key: K, value: V) -> Self {
+        Self {
+            key,
+            data: Data::Leaf { value },
+        }
+    }
+
+    fn is_leaf(&self) -> bool {
+        matches!(self.data, Data::Leaf { .. })
+    }
+}
+
+#[derive(Debug)]
+struct BuildNode<K, V>
+where
+    K: PartialEq + Ord,
+{
+    k: K,
+    data: BuildNodeData<K, V>,
+}
+
+#[derive(Debug)]
+enum BuildNodeData<K, V>
+where
+    K: PartialEq + Ord,
+{
+    Internal(Vec<BuildNode<K, V>>),
+    Leaf(V),
+}
+
+fn insert<K, V>(
+    mut key: Vec<K>,
+    v: V,
+    current: &mut Vec<BuildNode<K, V>>,
+) -> Result<(), &'static str>
+where
+    K: PartialEq + Ord,
+{
+    for n in current.iter_mut() {
+        if key[0] == n.k {
+            if key.len() <= 1 {
+                return Err("duplicate entry for key");
+            }
+
+            key.remove(0);
+            return match &mut n.data {
+                BuildNodeData::Internal(nodes) => insert(key, v, nodes),
+                BuildNodeData::Leaf(_) => Err("attempt to insert into value node"),
+            };
+        }
+    }
+
+    let k = key.remove(0);
+
+    if key.is_empty() {
+        current.push(BuildNode {
+            k,
+            data: BuildNodeData::Leaf(v),
+        });
+    } else {
+        let mut children = vec![];
+        insert(key, v, &mut children)?;
+        current.push(BuildNode {
+            k,
+            data: BuildNodeData::Internal(children),
+        });
+    }
+
+    Ok(())
+}
+
+fn flatten<K, V>(mut roots: Vec<BuildNode<K, V>>, nodes: &mut Vec<Node<K, V>>) -> (usize, usize)
+where
+    K: Clone + PartialEq + Ord,
+    V: Clone,
+{
+    roots.sort_by(|l, r| l.k.cmp(&r.k));
+
+    let child_start = nodes.len();
+    let n_children = roots.len();
+
+    let mut child_stack = Vec::new();
+
+    // Insert roots first, storing any child nodes that need to be inserted later.
+    for BuildNode { k, data } in roots.into_iter() {
+        match data {
+            BuildNodeData::Internal(children) => {
+                let i = nodes.len();
+                nodes.push(Node::new_internal(k, 0, children.len()));
+                child_stack.push((i, children));
+            }
+
+            BuildNodeData::Leaf(v) => nodes.push(Node::new_leaf(k, v)),
+        }
+    }
+
+    // Insert the child nodes for each root node, updating their state now that we know the offsets
+    // of their children.
+    for (i, children) in child_stack.into_iter() {
+        let (start, _) = flatten(children, nodes);
+        match &mut nodes[i] {
+            Node {
+                data: Data::Internal { child_start, .. },
+                ..
+            } => {
+                *child_start = start;
+            }
+
+            _ => unreachable!(),
+        }
+    }
+
+    (child_start, n_children)
 }
 
 /// A default handler for mapping a single length key to an `Option<V>`.
@@ -204,7 +429,7 @@ pub type DefaultMapping<K, V> = fn(&K) -> Option<V>;
 pub enum QueryResult<V> {
     /// A leaf value associated with the key used in the query
     Val(V),
-    /// The key used to query is a prefix to multiple targets
+    /// The key used to query is a prefix to multiple values
     Partial,
     /// The key does not exist within the [Trie]
     Missing,
@@ -241,141 +466,6 @@ impl<V> QueryResult<V> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum Data<K, V>
-where
-    K: Clone + PartialEq,
-{
-    Val(V),
-    Children(Vec<Node<K, V>>),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct Node<K, V>
-where
-    K: Clone + PartialEq,
-{
-    k: K,
-    d: Data<K, V>,
-}
-
-impl<K, V> Node<K, V>
-where
-    K: Clone + PartialEq,
-{
-    fn len(&self) -> usize {
-        match &self.d {
-            Data::Children(nodes) => nodes.iter().map(|n| n.len()).sum(),
-            Data::Val(_) => 1,
-        }
-    }
-
-    // Errors if this node already holds a value
-    fn insert(&mut self, k: Vec<K>, v: V) -> Result<(), &'static str> {
-        match &mut self.d {
-            Data::Children(nodes) => insert(k, v, nodes),
-            Data::Val(_) => Err("attempt to insert into value node"),
-        }
-    }
-
-    fn get_child<'s>(&'s self, k: &[K]) -> Option<&'s Node<K, V>> {
-        match &self.d {
-            Data::Children(nodes) => get_node(k, nodes),
-            Data::Val(_) => None,
-        }
-    }
-
-    fn resolved_keys(&self, prefix: &[K]) -> Vec<Vec<K>> {
-        match &self.d {
-            Data::Val(_) => vec![prefix.to_vec()],
-            Data::Children(nodes) => nodes
-                .iter()
-                .flat_map(|n| {
-                    let mut so_far = prefix.to_vec();
-                    so_far.push(n.k.clone());
-                    n.resolved_keys(&so_far)
-                })
-                .collect(),
-        }
-    }
-}
-
-fn insert<K, V>(mut key: Vec<K>, v: V, current: &mut Vec<Node<K, V>>) -> Result<(), &'static str>
-where
-    K: Clone + PartialEq,
-{
-    for n in current.iter_mut() {
-        if key[0] == n.k {
-            if key.len() > 1 {
-                key.remove(0);
-                n.insert(key, v)?;
-                return Ok(());
-            }
-            return Err("duplicate entry for key");
-        }
-    }
-
-    let k = key.remove(0);
-
-    // No matching root so create a new one
-    if key.is_empty() {
-        current.push(Node { k, d: Data::Val(v) });
-    } else {
-        let mut children = vec![];
-        insert(key, v, &mut children)?;
-
-        let d = Data::Children(children);
-        current.push(Node { k, d });
-    }
-
-    Ok(())
-}
-
-fn get_node<'n, K, V>(key: &[K], nodes: &'n [Node<K, V>]) -> Option<&'n Node<K, V>>
-where
-    K: Clone + PartialEq,
-{
-    if key.is_empty() {
-        return None;
-    }
-
-    for n in nodes.iter() {
-        if key[0] == n.k {
-            return if key.len() == 1 {
-                Some(n)
-            } else {
-                n.get_child(&key[1..])
-            };
-        }
-    }
-
-    None
-}
-
-/// A match function to use as part of a wildcard match
-pub type WildcardFn<K> = fn(&K) -> bool;
-
-/// A wildcard node in a key sequence that can conditionally match a single key element.
-#[derive(Debug)]
-pub enum WildCard<K> {
-    /// A literal key
-    Lit(K),
-    /// A predicate function for checking whether a key should be considered a match
-    Wild(WildcardFn<K>),
-}
-
-impl<K> cmp::PartialEq<K> for WildCard<K>
-where
-    K: PartialEq,
-{
-    fn eq(&self, other: &K) -> bool {
-        match self {
-            WildCard::Lit(k) => k == other,
-            WildCard::Wild(f) => f(other),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -383,12 +473,25 @@ mod tests {
 
     #[test]
     fn duplicate_keys_errors() {
-        assert!(Trie::from_pairs(vec![(vec![42], 1), (vec![42], 2)]).is_err());
+        assert!(Trie::try_from_iter(vec![(vec![42], 1), (vec![42], 2)]).is_err());
     }
 
     #[test]
     fn children_under_a_value_node_errors() {
-        assert!(Trie::from_pairs(vec![(vec![42], 1), (vec![42, 69], 2)]).is_err());
+        assert!(Trie::try_from_iter(vec![(vec![42], 1), (vec![42, 69], 2)]).is_err());
+    }
+
+    #[test_case("foo", QueryResult::Val(1); "val 1")]
+    #[test_case("bar", QueryResult::Val(2); "val 2")]
+    #[test_case("baz", QueryResult::Val(3); "val 3")]
+    #[test_case("ba", QueryResult::Partial; "partial 1")] // typos:ignore
+    #[test_case("fo", QueryResult::Partial; "partial 2")] // typos:ignore
+    #[test_case("barf", QueryResult::Missing; "overshoot")]
+    #[test_case("have you any wool?", QueryResult::Missing; "fully missing")]
+    #[test]
+    fn get_works(key: &str, expected: QueryResult<usize>) {
+        let t = Trie::from_str_keys(vec![("foo", 1), ("bar", 2), ("baz", 3)]).unwrap();
+        assert_eq!(t.get_str(key), expected);
     }
 
     #[test_case(&[42], None; "partial should be None")]
@@ -396,87 +499,91 @@ mod tests {
     #[test_case(&[42, 69, 144], None; "overshoot should be None")]
     #[test_case(&[42, 69], Some(1); "exact should be Some")]
     #[test]
-    fn get_exact_works(k: &[usize], expected: Option<usize>) {
-        let t = Trie::from_pairs(vec![(vec![42, 69], 1)]).unwrap();
-
-        assert_eq!(t.get_exact(k), expected);
+    fn get_exact_works(key: &[usize], expected: Option<usize>) {
+        let t = Trie::try_from_iter(vec![(vec![42, 69], 1)]).unwrap();
+        assert_eq!(t.get_exact(key), expected);
     }
 
-    #[test_case("fo", None; "partial should be None")] // typos:ignore
-    #[test_case("bar", None; "missing should be None")]
-    #[test_case("fooo", None; "overshoot should be None")]
-    #[test_case("foo", Some(1); "exact should be Some")]
+    #[test_case("fo", None; "partial")] // typos:ignore
+    #[test_case("bar", None; "missing")]
+    #[test_case("fool", None; "overshoot")]
+    #[test_case("foo", Some(1); "found")]
     #[test]
-    fn get_str_exact_works(k: &str, expected: Option<usize>) {
+    fn get_str_exact_works(key: &str, expected: Option<usize>) {
         let t = Trie::from_str_keys(vec![("foo", 1)]).unwrap();
-
-        assert_eq!(t.get_str_exact(k), expected);
+        assert_eq!(t.get_str_exact(key), expected);
     }
 
-    #[test_case("ba", QueryResult::Partial; "partial match")] // typos:ignore
-    #[test_case("bar", QueryResult::Val(2); "exact match")]
-    #[test_case("baz", QueryResult::Val(3); "exact match with shared prefix")]
-    #[test_case("barf", QueryResult::Missing; "overshot known key")]
-    #[test_case("have you any wool?", QueryResult::Missing; "completely missing")]
     #[test]
-    fn get_works(k: &str, expected: QueryResult<usize>) {
-        let t = Trie::from_str_keys(vec![("foo", 1), ("bar", 2), ("baz", 3)]).unwrap();
+    fn merge_works() {
+        let t1 = Trie::from_str_keys(vec![("foo", 1), ("bar", 2)]).unwrap();
+        let t2 = Trie::from_str_keys(vec![("baz", 3), ("qux", 4)]).unwrap();
 
-        assert_eq!(t.get_str(k), expected);
+        let merged = t1.merge(t2).unwrap();
+
+        assert_eq!(merged.get_str_exact("foo"), Some(1));
+        assert_eq!(merged.get_str_exact("bar"), Some(2));
+        assert_eq!(merged.get_str_exact("baz"), Some(3));
+        assert_eq!(merged.get_str_exact("qux"), Some(4));
+        assert_eq!(merged.len(), 4);
     }
 
-    #[test_case("f", &["fold", "food", "fool"]; "first char")]
-    #[test_case("fo", &["fold", "food", "fool"]; "shared prefix")] // typos:ignore
-    #[test_case("foo", &["food", "fool"]; "shared prefix not all match")]
-    #[test_case("food", &["food"]; "exact match")]
-    #[test_case("foods", &[]; "overshot")]
-    #[test_case("q", &[]; "unknown first char")]
-    #[test_case("quux", &[]; "unknown full key")]
-    #[test_case("", &[]; "empty string")]
     #[test]
-    fn candidate_strings_works(k: &str, expected: &[&str]) {
-        let expected: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
-        let t = Trie::from_str_keys(
-            ["fool", "fold", "food"]
-                .into_iter()
-                .enumerate()
-                .map(|(i, s)| (s, i))
-                .collect(),
-        )
-        .unwrap();
+    fn merge_conflicts_error() {
+        let t1 = Trie::from_str_keys(vec![("foo", 1)]).unwrap();
+        let t2 = Trie::from_str_keys(vec![("foo", 2)]).unwrap();
 
-        assert_eq!(t.candidate_strings(k), expected);
+        assert!(t1.merge(t2).is_err());
+    }
+
+    #[test]
+    fn merge_overriding_works() {
+        let t1 = Trie::from_str_keys(vec![("foo", 1), ("bar", 2)]).unwrap();
+        let t2 = Trie::from_str_keys(vec![("baz", 3), ("foo", 4)]).unwrap();
+
+        let merged = t1.merge_overriding(t2).unwrap();
+
+        assert_eq!(merged.get_str_exact("foo"), Some(4));
+        assert_eq!(merged.get_str_exact("bar"), Some(2));
+        assert_eq!(merged.get_str_exact("baz"), Some(3));
+        assert_eq!(merged.len(), 3);
+    }
+
+    #[test]
+    fn merge_overriding_conflicts_are_ok() {
+        let t1 = Trie::from_str_keys(vec![("foo", 1)]).unwrap();
+        let t2 = Trie::from_str_keys(vec![("foo", 2)]).unwrap();
+
+        assert!(t1.merge_overriding(t2).is_ok());
     }
 
     fn usize_default_handler(n: &usize) -> Option<usize> {
         Some(n + 1)
     }
 
-    #[test_case(&[42], QueryResult::Val(1); "exact single should match from the Try")]
-    #[test_case(&[12, 13], QueryResult::Val(2); "exact multi should match from the Try")]
+    #[test_case(&[42], QueryResult::Val(1); "exact single should match from the Trie")]
+    #[test_case(&[12, 13], QueryResult::Val(2); "exact multi should match from the Trie")]
     #[test_case(&[69], QueryResult::Val(70); "missing single should be defaulted")]
-    #[test_case(&[69, 420], QueryResult::Missing; "missing multi should always be missing")]
+    #[test_case(&[69, 420], QueryResult::Missing; "missing multi should remain missing")]
     #[test_case(&[12], QueryResult::Partial; "partial should remain partial")]
     #[test]
-    fn default_handlers_work(k: &[usize], expected: QueryResult<usize>) {
-        let mut t = Trie::from_pairs(vec![(vec![42], 1), (vec![12, 13], 2)]).unwrap();
+    fn get_uses_default_correctly(k: &[usize], expected: QueryResult<usize>) {
+        let mut t = Trie::try_from_iter(vec![(vec![42], 1), (vec![12, 13], 2)]).unwrap();
         t.set_default(usize_default_handler);
 
         assert_eq!(t.get(k), expected);
-
-        let expected_opt: Option<usize> = expected.into();
-        assert_eq!(t.get_exact(k), expected_opt);
     }
 
+    #[test_case(&[42], Some(1); "exact single should match from the Trie")]
+    #[test_case(&[12, 13], Some(2); "exact multi should match from the Trie")]
+    #[test_case(&[69], Some(70); "missing single should be defaulted")]
+    #[test_case(&[69, 420], None; "missing multi should remain None")]
+    #[test_case(&[12], None; "partial should remain None")]
     #[test]
-    fn wildcards_match_correctly() {
-        fn is_valid(c: &char) -> bool {
-            *c == 'i' || *c == 'a'
-        }
+    fn get_exact_uses_default_correctly(k: &[usize], expected: Option<usize>) {
+        let mut t = Trie::try_from_iter(vec![(vec![42], 1), (vec![12, 13], 2)]).unwrap();
+        t.set_default(usize_default_handler);
 
-        let w = WildCard::Wild(is_valid);
-
-        assert!(w == 'a');
-        assert!(w != 'b');
+        assert_eq!(t.get_exact(k), expected);
     }
 }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -1,6 +1,6 @@
 //! A simple trie data structure for supporting key bindings and autocompletions in a composible
 //! way with the rest of the ad internal APIs.
-use std::{collections::BTreeMap, fmt, ops::Range};
+use std::{collections::BTreeMap, fmt, ops::Range, sync::Arc};
 
 /// A singly initialised Trie mapping key sequences to a value.
 ///
@@ -15,7 +15,7 @@ where
     K: Clone + PartialEq + Ord,
     V: Clone,
 {
-    nodes: Vec<Node<K, V>>,
+    nodes: Arc<[Node<K, V>]>,
     n_roots: usize,
     default: Option<DefaultMapping<K, V>>,
 }
@@ -41,7 +41,7 @@ where
 {
     fn default() -> Self {
         Self {
-            nodes: Vec::new(),
+            nodes: Arc::from(Vec::new()),
             n_roots: 0,
             default: None,
         }
@@ -71,7 +71,7 @@ where
         let (_, n_roots) = flatten(roots, &mut nodes);
 
         Ok(Trie {
-            nodes,
+            nodes: Arc::from(nodes),
             n_roots,
             default: None,
         })

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -8,7 +8,6 @@ use std::{collections::BTreeMap, fmt, ops::Range, sync::Arc};
 /// existing in the same Trie.
 ///
 /// There are convenience methods provided for `Trie<char, V>` for when &str values are used as keys.
-#[allow(unpredictable_function_pointer_comparisons)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct Trie<K, V>
 where
@@ -18,7 +17,6 @@ where
     nodes: Arc<[Node<K>]>,
     values: Arc<[V]>,
     n_roots: usize,
-    default: Option<DefaultMapping<K, V>>,
 }
 
 impl<K, V> fmt::Debug for Trie<K, V>
@@ -31,7 +29,6 @@ where
             .field("nodes", &self.nodes)
             .field("values", &self.values)
             .field("n_roots", &self.n_roots)
-            .field("default", &"<function>")
             .finish()
     }
 }
@@ -46,7 +43,6 @@ where
             nodes: Arc::from(Vec::new()),
             values: Arc::from(Vec::new()),
             n_roots: 0,
-            default: None,
         }
     }
 }
@@ -78,7 +74,6 @@ where
             nodes: Arc::from(nodes),
             values: Arc::from(values),
             n_roots,
-            default: None,
         })
     }
 
@@ -140,41 +135,12 @@ where
         }
     }
 
-    /// Set the default handler for unmatched single element keys
-    pub fn set_default(&mut self, default: DefaultMapping<K, V>) {
-        self.default = Some(default);
-    }
-
     /// Query this [Trie] for a given key or key prefix
     ///
     /// If the key maps to a leaf then the value is returned, if it maps to a sub-trie then
     /// `Partial` is returned to denote that the given key is a parent of one or more values. If
     /// the key is not found within the `Trie` then `Missing` is returned.
-    ///
-    /// If this [Trie] contains a default mapping, it will be applied to missing single element
-    /// keys.
     pub fn get(&self, key: &[K]) -> QueryResult<V> {
-        match self.find_node(key) {
-            QueryResult::Missing if key.len() == 1 => self.default.and_then(|f| f(&key[0])).into(),
-            qr => qr,
-        }
-    }
-
-    /// Query this [Trie] for a given key or key prefix requiring the key to match exactly.
-    ///
-    /// If the key maps to a leaf then the `Some(value)` is returned, otherwise `None`.
-    ///
-    /// If this [Trie] contains a default mapping, it will be applied to missing single element
-    /// keys.
-    pub fn get_exact(&self, key: &[K]) -> Option<V> {
-        match self.find_node(key) {
-            QueryResult::Val(v) => Some(v),
-            QueryResult::Missing if key.len() == 1 => self.default.and_then(|f| f(&key[0])),
-            _ => None,
-        }
-    }
-
-    fn find_node(&self, key: &[K]) -> QueryResult<V> {
         if key.is_empty() {
             return QueryResult::Missing;
         }
@@ -218,6 +184,13 @@ where
         }
 
         QueryResult::Partial
+    }
+
+    /// Query this [Trie] for a given key or key prefix requiring the key to match exactly.
+    ///
+    /// If the key maps to a leaf then the `Some(value)` is returned, otherwise `None`.
+    pub fn get_exact(&self, key: &[K]) -> Option<V> {
+        self.get(key).into()
     }
 
     /// The number of leaf values in this Trie
@@ -566,35 +539,5 @@ mod tests {
         let t2 = Trie::from_str_keys(vec![("foo", 2)]).unwrap();
 
         assert!(t1.merge_overriding(t2).is_ok());
-    }
-
-    fn usize_default_handler(n: &usize) -> Option<usize> {
-        Some(n + 1)
-    }
-
-    #[test_case(&[42], QueryResult::Val(1); "exact single should match from the Trie")]
-    #[test_case(&[12, 13], QueryResult::Val(2); "exact multi should match from the Trie")]
-    #[test_case(&[69], QueryResult::Val(70); "missing single should be defaulted")]
-    #[test_case(&[69, 420], QueryResult::Missing; "missing multi should remain missing")]
-    #[test_case(&[12], QueryResult::Partial; "partial should remain partial")]
-    #[test]
-    fn get_uses_default_correctly(k: &[usize], expected: QueryResult<usize>) {
-        let mut t = Trie::try_from_iter(vec![(vec![42], 1), (vec![12, 13], 2)]).unwrap();
-        t.set_default(usize_default_handler);
-
-        assert_eq!(t.get(k), expected);
-    }
-
-    #[test_case(&[42], Some(1); "exact single should match from the Trie")]
-    #[test_case(&[12, 13], Some(2); "exact multi should match from the Trie")]
-    #[test_case(&[69], Some(70); "missing single should be defaulted")]
-    #[test_case(&[69, 420], None; "missing multi should remain None")]
-    #[test_case(&[12], None; "partial should remain None")]
-    #[test]
-    fn get_exact_uses_default_correctly(k: &[usize], expected: Option<usize>) {
-        let mut t = Trie::try_from_iter(vec![(vec![42], 1), (vec![12, 13], 2)]).unwrap();
-        t.set_default(usize_default_handler);
-
-        assert_eq!(t.get_exact(k), expected);
     }
 }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -144,7 +144,7 @@ where
     ///
     /// If the key maps to a leaf then the value is returned, if it maps to a sub-trie then
     /// `Partial` is returned to denote that the given key is a parent of one or more values. If
-    /// the key is not found within the `Try` then `Missing` is returned.
+    /// the key is not found within the `Trie` then `Missing` is returned.
     ///
     /// If this [Trie] contains a default mapping, it will be applied to missing single element
     /// keys.
@@ -155,7 +155,7 @@ where
         }
     }
 
-    /// Query this Try for a given key or key prefix requiring the key to match exactly.
+    /// Query this [Trie] for a given key or key prefix requiring the key to match exactly.
     ///
     /// If the key maps to a leaf then the `Some(value)` is returned, otherwise `None`.
     ///

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -15,7 +15,8 @@ where
     K: Clone + PartialEq + Ord,
     V: Clone,
 {
-    nodes: Arc<[Node<K, V>]>,
+    nodes: Arc<[Node<K>]>,
+    values: Arc<[V]>,
     n_roots: usize,
     default: Option<DefaultMapping<K, V>>,
 }
@@ -28,6 +29,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Trie")
             .field("nodes", &self.nodes)
+            .field("values", &self.values)
             .field("n_roots", &self.n_roots)
             .field("default", &"<function>")
             .finish()
@@ -42,6 +44,7 @@ where
     fn default() -> Self {
         Self {
             nodes: Arc::from(Vec::new()),
+            values: Arc::from(Vec::new()),
             n_roots: 0,
             default: None,
         }
@@ -68,10 +71,12 @@ where
         }
 
         let mut nodes = Vec::new();
-        let (_, n_roots) = flatten(roots, &mut nodes);
+        let mut values = Vec::new();
+        let (_, n_roots) = flatten(roots, &mut nodes, &mut values);
 
         Ok(Trie {
             nodes: Arc::from(nodes),
+            values: Arc::from(values),
             n_roots,
             default: None,
         })
@@ -124,13 +129,13 @@ where
             let mut child_key = key.clone();
             child_key.push(node.key.clone());
 
-            match &node.data {
-                Data::Leaf { value } => pairs.push((child_key, value.clone())),
+            match node.data {
+                Data::Leaf { i } => pairs.push((child_key, self.values[i].clone())),
 
                 Data::Internal {
                     child_start,
                     n_children,
-                } => self.extract_pairs(pairs, child_key, *child_start..*child_start + *n_children),
+                } => self.extract_pairs(pairs, child_key, child_start..child_start + n_children),
             }
         }
     }
@@ -186,10 +191,10 @@ where
                 if &node.key == target {
                     key_index += 1;
 
-                    match &node.data {
-                        Data::Leaf { value } => {
+                    match node.data {
+                        Data::Leaf { i } => {
                             return if key_index == key.len() {
-                                QueryResult::Val(value.clone())
+                                QueryResult::Val(self.values[i].clone())
                             } else {
                                 QueryResult::Missing
                             };
@@ -199,7 +204,7 @@ where
                             child_start,
                             n_children,
                         } => {
-                            indices = *child_start..*child_start + *n_children;
+                            indices = child_start..child_start + n_children;
                             continue 'outer;
                         }
                     }
@@ -256,12 +261,51 @@ where
     }
 }
 
+/// A single node within a [Trie].
+///
+/// Contains the last element of the key that traverses down to this node alongside [Data] that
+/// identifies this node as being internal or a leaf.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Node<K>
+where
+    K: Clone + PartialEq + Ord,
+{
+    key: K,
+    data: Data,
+}
+
+impl<K> Node<K>
+where
+    K: Clone + PartialEq + PartialOrd + Ord,
+{
+    fn new_internal(key: K, child_start: usize, n_children: usize) -> Self {
+        Self {
+            key,
+            data: Data::Internal {
+                child_start,
+                n_children,
+            },
+        }
+    }
+
+    fn new_leaf(key: K, i: usize) -> Self {
+        Self {
+            key,
+            data: Data::Leaf { i },
+        }
+    }
+
+    fn is_leaf(&self) -> bool {
+        matches!(self.data, Data::Leaf { .. })
+    }
+}
+
 /// The internal data held at each node in a Trie.
 ///
 /// Internal nodes are "pointers" to their children while leaves hold the value associated with the
 /// full key used to traverse down to them.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum Data<V> {
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum Data {
     Internal {
         /// Index of the first child node
         child_start: usize,
@@ -269,50 +313,9 @@ enum Data<V> {
         n_children: usize,
     },
     Leaf {
-        // Value associated with the full key-path down to this node
-        value: V,
+        // Index of the value associated with the full key-path down to this node
+        i: usize,
     },
-}
-
-/// A single node within a [Trie].
-///
-/// Contains the last element of the key that traverses down to this node alongside [Data] that
-/// identifies this node as being internal or a leaf.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct Node<K, V>
-where
-    K: Clone + PartialEq + Ord,
-    V: Clone,
-{
-    key: K,
-    data: Data<V>,
-}
-
-impl<K, V> Node<K, V>
-where
-    K: Clone + PartialEq + PartialOrd + Ord,
-    V: Clone,
-{
-    fn new_internal(key: K, children_start: usize, children_count: usize) -> Self {
-        Self {
-            key,
-            data: Data::Internal {
-                child_start: children_start,
-                n_children: children_count,
-            },
-        }
-    }
-
-    fn new_leaf(key: K, value: V) -> Self {
-        Self {
-            key,
-            data: Data::Leaf { value },
-        }
-    }
-
-    fn is_leaf(&self) -> bool {
-        matches!(self.data, Data::Leaf { .. })
-    }
 }
 
 #[derive(Debug)]
@@ -374,7 +377,11 @@ where
     Ok(())
 }
 
-fn flatten<K, V>(mut roots: Vec<BuildNode<K, V>>, nodes: &mut Vec<Node<K, V>>) -> (usize, usize)
+fn flatten<K, V>(
+    mut roots: Vec<BuildNode<K, V>>,
+    nodes: &mut Vec<Node<K>>,
+    values: &mut Vec<V>,
+) -> (usize, usize)
 where
     K: Clone + PartialEq + Ord,
     V: Clone,
@@ -395,14 +402,18 @@ where
                 child_stack.push((i, children));
             }
 
-            BuildNodeData::Leaf(v) => nodes.push(Node::new_leaf(k, v)),
+            BuildNodeData::Leaf(v) => {
+                let i = values.len();
+                values.push(v);
+                nodes.push(Node::new_leaf(k, i))
+            }
         }
     }
 
     // Insert the child nodes for each root node, updating their state now that we know the offsets
     // of their children.
     for (i, children) in child_stack.into_iter() {
-        let (start, _) = flatten(children, nodes);
+        let (start, _) = flatten(children, nodes, values);
         match &mut nodes[i] {
             Node {
                 data: Data::Internal { child_start, .. },

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -140,7 +140,7 @@ where
     /// If the key maps to a leaf then the value is returned, if it maps to a sub-trie then
     /// `Partial` is returned to denote that the given key is a parent of one or more values. If
     /// the key is not found within the `Trie` then `Missing` is returned.
-    pub fn get(&self, key: &[K]) -> QueryResult<V> {
+    pub fn get<'a>(&'a self, key: &[K]) -> QueryResult<'a, V> {
         if key.is_empty() {
             return QueryResult::Missing;
         }
@@ -160,7 +160,7 @@ where
                     match node.data {
                         Data::Leaf { i } => {
                             return if key_index == key.len() {
-                                QueryResult::Val(self.values[i].clone())
+                                QueryResult::Val(&self.values[i])
                             } else {
                                 QueryResult::Missing
                             };
@@ -189,7 +189,7 @@ where
     /// Query this [Trie] for a given key or key prefix requiring the key to match exactly.
     ///
     /// If the key maps to a leaf then the `Some(value)` is returned, otherwise `None`.
-    pub fn get_exact(&self, key: &[K]) -> Option<V> {
+    pub fn get_exact<'a>(&'a self, key: &[K]) -> Option<&'a V> {
         self.get(key).into()
     }
 
@@ -222,14 +222,14 @@ where
     /// Query this [Trie] using a string key.
     ///
     /// Both full and partial matches are possible.
-    pub fn get_str(&self, key: &str) -> QueryResult<V> {
+    pub fn get_str<'a>(&'a self, key: &str) -> QueryResult<'a, V> {
         self.get(&key.chars().collect::<Vec<_>>())
     }
 
     /// Query this [Trie] using a string key.
     ///
     /// Only fll matches will be returned.
-    pub fn get_str_exact(&self, key: &str) -> Option<V> {
+    pub fn get_str_exact<'a>(&'a self, key: &str) -> Option<&'a V> {
         self.get_exact(&key.chars().collect::<Vec<_>>())
     }
 }
@@ -410,17 +410,17 @@ pub type DefaultMapping<K, V> = fn(&K) -> Option<V>;
 
 /// The result of querying a [Trie] for a particular Key.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum QueryResult<V> {
+pub enum QueryResult<'a, V> {
     /// A leaf value associated with the key used in the query
-    Val(V),
+    Val(&'a V),
     /// The key used to query is a prefix to multiple values
     Partial,
     /// The key does not exist within the [Trie]
     Missing,
 }
 
-impl<V> From<Option<V>> for QueryResult<V> {
-    fn from(opt: Option<V>) -> Self {
+impl<'a, V> From<Option<&'a V>> for QueryResult<'a, V> {
+    fn from(opt: Option<&'a V>) -> Self {
         match opt {
             Some(v) => QueryResult::Val(v),
             None => QueryResult::Missing,
@@ -428,24 +428,11 @@ impl<V> From<Option<V>> for QueryResult<V> {
     }
 }
 
-impl<V> From<QueryResult<V>> for Option<V> {
-    fn from(q: QueryResult<V>) -> Self {
+impl<'a, V> From<QueryResult<'a, V>> for Option<&'a V> {
+    fn from(q: QueryResult<'a, V>) -> Self {
         match q {
             QueryResult::Val(v) => Some(v),
             _ => None,
-        }
-    }
-}
-
-impl<V> QueryResult<V> {
-    pub fn map<F, U>(self, f: F) -> QueryResult<U>
-    where
-        F: Fn(V) -> U,
-    {
-        match self {
-            Self::Val(v) => QueryResult::Val(f(v)),
-            Self::Partial => QueryResult::Partial,
-            Self::Missing => QueryResult::Missing,
         }
     }
 }
@@ -465,15 +452,15 @@ mod tests {
         assert!(Trie::try_from_iter(vec![(vec![42], 1), (vec![42, 69], 2)]).is_err());
     }
 
-    #[test_case("foo", QueryResult::Val(1); "val 1")]
-    #[test_case("bar", QueryResult::Val(2); "val 2")]
-    #[test_case("baz", QueryResult::Val(3); "val 3")]
+    #[test_case("foo", QueryResult::Val(&1); "val 1")]
+    #[test_case("bar", QueryResult::Val(&2); "val 2")]
+    #[test_case("baz", QueryResult::Val(&3); "val 3")]
     #[test_case("ba", QueryResult::Partial; "partial 1")] // typos:ignore
     #[test_case("fo", QueryResult::Partial; "partial 2")] // typos:ignore
     #[test_case("barf", QueryResult::Missing; "overshoot")]
     #[test_case("have you any wool?", QueryResult::Missing; "fully missing")]
     #[test]
-    fn get_works(key: &str, expected: QueryResult<usize>) {
+    fn get_works(key: &str, expected: QueryResult<'_, usize>) {
         let t = Trie::from_str_keys(vec![("foo", 1), ("bar", 2), ("baz", 3)]).unwrap();
         assert_eq!(t.get_str(key), expected);
     }
@@ -485,7 +472,7 @@ mod tests {
     #[test]
     fn get_exact_works(key: &[usize], expected: Option<usize>) {
         let t = Trie::try_from_iter(vec![(vec![42, 69], 1)]).unwrap();
-        assert_eq!(t.get_exact(key), expected);
+        assert_eq!(t.get_exact(key), expected.as_ref());
     }
 
     #[test_case("fo", None; "partial")] // typos:ignore
@@ -495,7 +482,7 @@ mod tests {
     #[test]
     fn get_str_exact_works(key: &str, expected: Option<usize>) {
         let t = Trie::from_str_keys(vec![("foo", 1)]).unwrap();
-        assert_eq!(t.get_str_exact(key), expected);
+        assert_eq!(t.get_str_exact(key), expected.as_ref());
     }
 
     #[test]
@@ -505,10 +492,10 @@ mod tests {
 
         let merged = t1.merge(t2).unwrap();
 
-        assert_eq!(merged.get_str_exact("foo"), Some(1));
-        assert_eq!(merged.get_str_exact("bar"), Some(2));
-        assert_eq!(merged.get_str_exact("baz"), Some(3));
-        assert_eq!(merged.get_str_exact("qux"), Some(4));
+        assert_eq!(merged.get_str_exact("foo"), Some(&1));
+        assert_eq!(merged.get_str_exact("bar"), Some(&2));
+        assert_eq!(merged.get_str_exact("baz"), Some(&3));
+        assert_eq!(merged.get_str_exact("qux"), Some(&4));
         assert_eq!(merged.len(), 4);
     }
 
@@ -527,9 +514,9 @@ mod tests {
 
         let merged = t1.merge_overriding(t2).unwrap();
 
-        assert_eq!(merged.get_str_exact("foo"), Some(4));
-        assert_eq!(merged.get_str_exact("bar"), Some(2));
-        assert_eq!(merged.get_str_exact("baz"), Some(3));
+        assert_eq!(merged.get_str_exact("foo"), Some(&4));
+        assert_eq!(merged.get_str_exact("bar"), Some(&2));
+        assert_eq!(merged.get_str_exact("baz"), Some(&3));
         assert_eq!(merged.len(), 3);
     }
 

--- a/tests/data/config/with-custom-bindings.toml
+++ b/tests/data/config/with-custom-bindings.toml
@@ -1,0 +1,23 @@
+[editor]
+show_splash = true
+expand_tab = true
+tabstop = 4
+match_indent = true
+status_timeout = 3
+double_click_ms = 200
+minibuffer_lines = 8
+find_command = "fd -t f"
+
+[filesystem]
+enabled = false
+auto_mount = false
+
+[keys.normal]
+"C-k" =     { send_keys = "i A <esc>" } # override single
+"g g" =     { send_keys = "i B <esc>" } # override seq
+"C-A-T" =   { send_keys = "i C <esc>" } # new single
+"C-A-B X" = { send_keys = "i D <esc>" } # new seq
+
+[keys.insert]
+"C-a" =   { send_keys = "A" } # override single
+"C-A-T" = { send_keys = "B" } # new single

--- a/tests/data/editor-scenarios/general/custom_keybindings_insert.txtar
+++ b/tests/data/editor-scenarios/general/custom_keybindings_insert.txtar
@@ -1,0 +1,21 @@
+Open an empty file and trigger each of the custom insert mode key bindings
+defined in with-custom-bindings.toml.
+
+-- config --
+path: tests/data/config/with-custom-bindings.toml
+-- file-new.txt --
+-- actions --
+# enter insert mode
+type: i
+
+# override single key (A)
+type: <ctrl>a
+
+# new single key      (B)
+type: <ctrl-alt>T
+-- buffer-list --
+1    * new.txt
+-- expected-windows --
+1
+-- expected-buffer-1 --
+AB

--- a/tests/data/editor-scenarios/general/custom_keybindings_normal.txtar
+++ b/tests/data/editor-scenarios/general/custom_keybindings_normal.txtar
@@ -1,0 +1,25 @@
+Open an empty file and trigger each of the custom normal mode key bindings
+defined in with-custom-bindings.toml.
+
+-- config --
+path: tests/data/config/with-custom-bindings.toml
+-- file-new.txt --
+-- actions --
+# override single key (A)
+type: <ctrl>k
+
+# override sequence   (B)
+type: gg
+
+# new single key      (C)
+type: <ctrl-alt>T
+
+# new sequence        (D)
+type: <ctrl-alt>B
+type: X
+-- buffer-list --
+1    * new.txt
+-- expected-windows --
+1
+-- expected-buffer-1 --
+ABCD

--- a/tests/scenario_tests.rs
+++ b/tests/scenario_tests.rs
@@ -524,6 +524,8 @@ enum TestAction {
     /// type: ihello, world!
     /// type: <esc>
     /// type: <alt>$single_character
+    /// type: <ctrl>$single_character
+    /// type: <ctrl-alt>$single_character
     Input(Input),
     /// Sleep for a given number of milliseconds.
     /// This may be required when running external programs through loading and executing.
@@ -584,6 +586,20 @@ fn parse_actions(raw: &str) -> Vec<TestAction> {
                         (None, _) => panic!("invalid <ctrl> input: expected a character"),
                         (_, Some(_)) => {
                             panic!("invalid <ctrl> input: expected a single char, got {tail:?}");
+                        }
+                    }
+                }
+
+                s if s.starts_with("<ctrl-alt>") => {
+                    let tail = escape(s.strip_prefix("<ctrl-alt>").unwrap().trim());
+                    let mut it = tail.chars();
+                    match (it.next(), it.next()) {
+                        (Some(ch), None) => actions.push(TestAction::Input(Input::CtrlAlt(ch))),
+                        (None, _) => panic!("invalid <ctrl-alt> input: expected a character"),
+                        (_, Some(_)) => {
+                            panic!(
+                                "invalid <ctrl-alt> input: expected a single char, got {tail:?}"
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
As identified in #158, the current behaviour for custom keybindings is for them to be used as a fallback rather than an override. This meant that it was not possible for users to change the behaviour of the built in keybindings, only _add_ to the set of known bindings.

This PR updates the `Trie` implementation used to support merging two tries together, optionally allowing overrides to occur, and updates the way that keybinding lookup happens to no longer need the keymap coming from `Config` to be passed every time the current input is checked. Overhauling the trie implementation is long overdue as it was one of the first things I worked on for `ad`, actually as part of an earlier editor project that never saw the light of day. In addition to refactoring the internal structure I've also taken the opportunity to remove functionality that wasn't being used anywhere such as the support for wildcard matching. (The original idea was to use this datastructure for autocomplete as well but that was never implemented).