### PR TITLE
Add syntax highlighting and LSP support for Haskell

### DIFF
--- a/data/config.toml
+++ b/data/config.toml
@@ -144,6 +144,9 @@ lsp.roots = ["melos.yaml", "pubspec.yaml"]
 [filetypes.graphql]
 extensions = ["graphql"]
 
+[filetypes.haskell]
+extensions = ["hs"]
+
 [filetypes.json]
 extensions = ["json"]
 

--- a/data/config_tests/valid-ftypes.toml
+++ b/data/config_tests/valid-ftypes.toml
@@ -12,6 +12,9 @@ lsp.roots = ["melos.yaml", "pubspec.yaml"]
 [graphql]
 extensions = ["graphql"]
 
+[haskell]
+extensions = ["hs"]
+
 [json]
 extensions = ["json"]
 

--- a/data/config_tests/valid/all-inline.toml
+++ b/data/config_tests/valid/all-inline.toml
@@ -79,6 +79,9 @@ lsp.roots = ["melos.yaml", "pubspec.yaml"]
 [filetypes.graphql]
 extensions = ["graphql"]
 
+[filetypes.haskell]
+extensions = ["hs"]
+
 [filetypes.json]
 extensions = ["json"]
 

--- a/data/lib/ftype-comment-chars.txt
+++ b/data/lib/ftype-comment-chars.txt
@@ -2,6 +2,7 @@ bash #
 c //
 dart //
 graphql #
+haskell --
 just #
 make #
 plumbingrules #

--- a/data/tree-sitter/queries/haskell/highlights.scm
+++ b/data/tree-sitter/queries/haskell/highlights.scm
@@ -1,0 +1,467 @@
+; ----------------------------------------------------------------------------
+; Parameters and variables
+; NOTE: These are at the top, so that they have low priority,
+; and don't override destructured parameters
+(variable) @variable
+
+(decl/function
+  patterns: (patterns
+    (_) @variable.parameter))
+
+(expression/lambda
+  (_)+ @variable.parameter
+  "->")
+
+(decl/function
+  (infix
+    (pattern) @variable.parameter))
+
+; ----------------------------------------------------------------------------
+; Literals and comments
+(integer) @number
+
+(negation) @number
+
+(expression/literal
+  (float)) @number.float
+
+(char) @character
+
+(string) @string
+
+(comment) @comment
+
+(haddock) @comment.documentation
+
+; ----------------------------------------------------------------------------
+; Punctuation
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ","
+  ";"
+] @punctuation.delimiter
+
+; ----------------------------------------------------------------------------
+; Keywords, operators, includes
+[
+  "forall"
+  ; "∀" ; utf-8 is not cross-platform safe
+] @keyword.repeat
+
+(pragma) @keyword.directive
+
+[
+  "if"
+  "then"
+  "else"
+  "case"
+  "of"
+] @keyword.conditional
+
+[
+  "import"
+  "qualified"
+  "module"
+] @keyword.import
+
+[
+  (operator)
+  (constructor_operator)
+  (all_names)
+  "."
+  ".."
+  "="
+  "|"
+  "::"
+  "=>"
+  "->"
+  "<-"
+  "\\"
+  "`"
+  "@"
+] @operator
+
+(wildcard) @character.special
+
+(module
+  (module_id) @module)
+
+[
+  "where"
+  "let"
+  "in"
+  "class"
+  "instance"
+  "pattern"
+  "data"
+  "newtype"
+  "family"
+  "type"
+  "as"
+  "hiding"
+  "deriving"
+  "via"
+  "stock"
+  "anyclass"
+  "do"
+  "mdo"
+  "rec"
+  "infix"
+  "infixl"
+  "infixr"
+] @keyword
+
+; ----------------------------------------------------------------------------
+; Functions and variables
+(decl
+  [
+    name: (variable) @function
+    names: (binding_list
+      (variable) @function)
+  ])
+
+(decl/bind
+  name: (variable) @variable)
+
+; Consider signatures (and accompanying functions)
+; with only one value on the rhs as variables
+(decl/signature
+  name: (variable) @variable
+  type: (type))
+
+((decl/signature
+  name: (variable) @_name
+  type: (type))
+  .
+  (decl
+    name: (variable) @variable)
+  match: (_)
+  (#eq? @_name @variable))
+
+; but consider a type that involves 'IO' a decl/function
+(decl/signature
+  name: (variable) @function
+  type: (type/apply
+    constructor: (name) @_type)
+  (#eq? @_type "IO"))
+
+((decl/signature
+  name: (variable) @_name
+  type: (type/apply
+    constructor: (name) @_type)
+  (#eq? @_type "IO"))
+  .
+  (decl
+    name: (variable) @function)
+  match: (_)
+  (#eq? @_name @function))
+
+((decl/signature) @function
+  .
+  (decl/function
+    name: (variable) @function))
+
+(decl/bind
+  name: (variable) @function
+  (match
+    expression: (expression/lambda)))
+
+; view patterns
+(view_pattern
+  [
+    (expression/variable) @function.call
+    (expression/qualified
+      (variable) @function.call)
+  ])
+
+; consider infix functions as operators
+(infix_id
+  [
+    (variable) @operator
+    (qualified
+      (variable) @operator)
+  ])
+
+; decl/function calls with an infix operator
+; e.g. func <$> a <*> b
+(infix
+  left_operand: [
+    (variable) @function.call
+    (qualified
+      ((module) @module
+        (variable) @function.call))
+  ])
+
+; infix operators applied to variables
+((expression/variable) @variable
+  .
+  (operator))
+
+((operator)
+  .
+  [
+    (expression/variable) @variable
+    (expression/qualified
+      (variable) @variable)
+  ])
+
+; infix operator function definitions
+(function
+  (infix
+    left_operand: [
+      (variable) @variable
+      (qualified
+        ((module) @module
+          (variable) @variable))
+    ])
+  match: (match))
+
+; decl/function calls with infix operators
+([
+  (expression/variable) @function.call
+  (expression/qualified
+    (variable) @function.call)
+]
+  .
+  (operator) @_op
+  (#any-of? @_op "$" "<$>" ">>=" "=<<"))
+
+; right hand side of infix operator
+((infix
+  [
+    (operator)
+    (infix_id
+      (variable))
+  ] ; infix or `func`
+  .
+  [
+    (variable) @function.call
+    (qualified
+      (variable) @function.call)
+  ])
+  .
+  (operator) @_op
+  (#any-of? @_op "$" "<$>" "=<<"))
+
+; decl/function composition, arrows, monadic composition (lhs)
+([
+  (expression/variable) @function
+  (expression/qualified
+    (variable) @function)
+]
+  .
+  (operator) @_op
+  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
+
+; right hand side of infix operator
+((infix
+  [
+    (operator)
+    (infix_id
+      (variable))
+  ] ; infix or `func`
+  .
+  [
+    (variable) @function
+    (qualified
+      (variable) @function)
+  ])
+  .
+  (operator) @_op
+  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
+
+; function composition, arrows, monadic composition (rhs)
+((operator) @_op
+  .
+  [
+    (expression/variable) @function
+    (expression/qualified
+      (variable) @function)
+  ]
+  (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))
+
+; function defined in terms of a function composition
+(decl/function
+  name: (variable) @function
+  (match
+    expression: (infix
+      operator: (operator) @_op
+      (#any-of? @_op "." ">>>" "***" ">=>" "<=<"))))
+
+(apply
+  [
+    (expression/variable) @function.call
+    (expression/qualified
+      (variable) @function.call)
+  ])
+
+; function compositions, in parentheses, applied
+; lhs
+(apply
+  .
+  (expression/parens
+    (infix
+      [
+        (variable) @function.call
+        (qualified
+          (variable) @function.call)
+      ]
+      .
+      (operator))))
+
+; rhs
+(apply
+  .
+  (expression/parens
+    (infix
+      (operator)
+      .
+      [
+        (variable) @function.call
+        (qualified
+          (variable) @function.call)
+      ])))
+
+; variables being passed to a function call
+(apply
+  (_)
+  .
+  [
+    (expression/variable) @variable
+    (expression/qualified
+      (variable) @variable)
+  ])
+
+; main is always a function
+; (this prevents `main = undefined` from being highlighted as a variable)
+(decl/bind
+  name: (variable) @function
+  (#eq? @function "main"))
+
+; scoped function types (func :: a -> b)
+(signature
+  pattern: (pattern/variable) @function
+  type: (function))
+
+; signatures that have a function type
+; + binds that follow them
+(decl/signature
+  name: (variable) @function
+  type: (function))
+
+((decl/signature
+  name: (variable) @_name
+  type: (quantified_type))
+  .
+  (decl/bind
+    (variable) @function)
+  (#eq? @function @_name))
+
+; Treat constructor assignments (smart constructors) as functions, e.g. mkJust = Just
+(bind
+  name: (variable) @function
+  match: (match
+    expression: (constructor)))
+
+; Function composition
+(bind
+  name: (variable) @function
+  match: (match
+    expression: (infix
+      operator: (operator) @_op
+      (#eq? @_op "."))))
+
+; ----------------------------------------------------------------------------
+; Types
+(name) @type
+
+(type/unit) @type
+
+(type/unit
+  [
+    "("
+    ")"
+  ] @type)
+
+(type/list
+  [
+    "["
+    "]"
+  ] @type)
+
+(type/star) @type
+
+(constructor) @constructor
+
+; True or False
+((constructor) @boolean
+  (#any-of? @boolean "True" "False"))
+
+; otherwise (= True)
+((variable) @boolean
+  (#eq? @boolean "otherwise"))
+
+; ----------------------------------------------------------------------------
+; Quasi-quotes
+(quoter) @function.call
+
+(quasiquote
+  quoter: [
+    (quoter) @_name
+    (quoter
+      (qualified
+        id: (variable) @_name))
+  ]
+  (#eq? @_name "qq")
+  body: (quasiquote_body) @string)
+
+; namespaced quasi-quoter
+(quoter
+  [
+    (variable) @function.call
+    (_
+      (module) @module
+      .
+      (variable) @function.call)
+  ])
+
+; Highlighting of quasiquote_body for other languages is handled by injections.scm
+; ----------------------------------------------------------------------------
+; Exceptions/error handling
+((variable) @keyword.exception
+  (#any-of? @keyword.exception
+    "error" "undefined" "try" "tryJust" "tryAny" "catch" "catches" "catchJust" "handle" "handleJust"
+    "throw" "throwIO" "throwTo" "throwError" "ioError" "mask" "mask_" "uninterruptibleMask"
+    "uninterruptibleMask_" "bracket" "bracket_" "bracketOnErrorSource" "finally" "fail"
+    "onException" "expectationFailure"))
+
+; ----------------------------------------------------------------------------
+; Debugging
+((variable) @keyword.debug
+  (#any-of? @keyword.debug
+    "trace" "traceId" "traceShow" "traceShowId" "traceWith" "traceShowWith" "traceStack" "traceIO"
+    "traceM" "traceShowM" "traceEvent" "traceEventWith" "traceEventIO" "flushEventLog" "traceMarker"
+    "traceMarkerIO"))
+
+; ----------------------------------------------------------------------------
+; Fields
+(field_name
+  (variable) @variable.member)
+
+(import_name
+  (name)
+  .
+  (children
+    (variable) @variable.member))
+
+; ----------------------------------------------------------------------------
+; Spell checking
+(comment) @spell


### PR DESCRIPTION
This is both a pull request and a issue.

# Pull Request

highlights.scm is copied direct from the nvim-treesitter repository with the latest commit that touched it being 188b1a6d01fd9bcf04bf2bc932d611809b154acc.

From what I understand you usually vendor the query file from tree sitter, but the user themselves need to install the parser? I guess the parser is platform dependent and you need to build it for each platform?

# Issue

The reason I include the issue with the pull request is that I'm having an issue, and I want to make sure that it isn't related to my PR.

- ad Version: 9f33bcc1d87958586003f1b8d065da1b9d3c220e (branch `feature/add-haskell-lsp`)
- OS: FreeBSD
- Distribution: N/A
- OS Version: 14.3


### Describe the bug

When I press `<space> l c` (I've the line `"<space> l c" = { run = "lsp-completion" }` in my `~/.ad/config.toml`) while having selected a symbol I get an error message (see attached image). The error message says

> unable to send textDocument/didChange LSP notification: Broken pipe (os error 32)

### To Reproduce

I created my `haskell.so` parser by
1. `git clone https://github.com/tree-sitter-grammars/tree-sitter-haskell.git`
2. `cd tree-sitter-haskell`
3. Execute `tree-sitter build`
4. `cp haskell.so ~/.ad/tree-sitter/parsers/`

The `tree-sitter` CLI is installed from FreeBSD's port collection.

I hope I've configured everything correctly. I've created a new Haskell project by running `stack new foo` and manually adding `hie.yaml` to the project root with the content

```
cradle:
  stack:
    - path: "."
      component: "foo:exe:Setup.hs"
    - path: "app/Main.hs"
      component: "foo:exe:foo-exe"
    - path: "src"
      component: "foo:lib"
    - path: "test/Spec.hs"
      component: "foo:test:foo-test"
```

When I start ad with `ad ./app/Main.hs` i get the messages `LSP server started` and a little while later `Setting up foo (for app/Main.hs):.


### Expected behavior

Some form of completion suggestions showing up.

### Screenshots

<img width="826" height="415" alt="Felmeddelande LSP ad" src="https://github.com/user-attachments/assets/a9b0e7e8-e3b2-443d-9196-4942ca8c9d48" />

### Additional context




