### PR TITLE
Fix invalid leading literal calculations #165

### DIFF
--- a/src/regex/ast.rs
+++ b/src/regex/ast.rs
@@ -7,6 +7,10 @@ use std::{collections::HashSet, iter::Peekable, mem::swap, str::Chars};
 /// exponentially longer to compute. We impose a hard limit on the number of patterns we collect in
 /// order to keep this under control at the expense of not being able to always find leading
 /// literals for complex patterns.
+/// When combining leading literals we check using this constant to see if we are exceeding this
+/// limit and cancel the calculation (returning no leading literals at all) if the correct set
+/// would need to be truncated. This prevents us running an invalid fast path optimisation that can
+/// end up advancing us too far through the input.
 const MAX_LEADING_LITERALS: usize = 50;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,10 +48,7 @@ impl Ast {
             Self::Comp(Comp::Char(c)) => (std::iter::once(c.to_string()).collect(), true),
             Self::Comp(Comp::Numeric) => (('0'..='9').map(String::from).collect(), true),
 
-            // FIXME: fan out from character classes in this way can result in a LOT of leading
-            // literals and really we should be keeping the leading prefixes where possible rather
-            // than the first MAX_LEADING_LITERALS we encounter.
-            Self::Comp(Comp::Class(cls)) if !cls.negated => (
+            Self::Comp(Comp::Class(cls)) if !cls.negated && cls.size() <= MAX_LEADING_LITERALS => (
                 cls.chars
                     .iter()
                     .map(|ch| ch.to_string())
@@ -56,7 +57,6 @@ impl Ast {
                             .iter()
                             .flat_map(|(start, end)| (*start..=*end).map(String::from)),
                     )
-                    .take(MAX_LEADING_LITERALS)
                     .collect(),
                 true,
             ),
@@ -70,14 +70,18 @@ impl Ast {
             // Nested structure we need to combine
             Self::Concat(nodes) => leading_literals_for_concat(nodes.iter()),
 
-            Self::Alt(nodes) => (
-                nodes
-                    .iter()
-                    .flat_map(|node| node.leading_literals())
-                    .take(MAX_LEADING_LITERALS)
-                    .collect(),
-                true,
-            ),
+            Self::Alt(nodes) => {
+                let mut lits = HashSet::new();
+                for node in nodes {
+                    lits.extend(node.leading_literals());
+                    if lits.len() > MAX_LEADING_LITERALS {
+                        lits.clear();
+                        return (lits, false);
+                    }
+                }
+
+                (lits, true)
+            }
 
             Self::Rep(r, node) => {
                 let mut lits = node.leading_literals();
@@ -186,10 +190,6 @@ fn leading_literals_for_concat(mut it: std::slice::Iter<'_, Ast>) -> (HashSet<St
     while let Some(node) = it.next()
         && ongoing
     {
-        if lits.len() > MAX_LEADING_LITERALS {
-            break;
-        }
-
         // We stop at assertions and repetitions alter how we proceed
         let rep = match node {
             Ast::Assertion(_) => {
@@ -209,6 +209,11 @@ fn leading_literals_for_concat(mut it: std::slice::Iter<'_, Ast>) -> (HashSet<St
             // and include all of the literals that come afterwards directly.
             Some(Rep::Plus(_)) => {
                 lits = combine(&lits, &node_lits);
+                if lits.len() > MAX_LEADING_LITERALS {
+                    lits.clear();
+                    return (lits, false);
+                }
+
                 break;
             }
 
@@ -220,12 +225,21 @@ fn leading_literals_for_concat(mut it: std::slice::Iter<'_, Ast>) -> (HashSet<St
                     star_lits.extend(combine(&lits, &without_star_lits));
                     lits = star_lits;
                 }
+                if lits.len() > MAX_LEADING_LITERALS {
+                    lits.clear();
+                    return (lits, false);
+                }
+
                 lits.remove("");
                 break;
             }
 
             _ => {
                 lits = combine(&lits, &node_lits);
+                if lits.len() > MAX_LEADING_LITERALS {
+                    lits.clear();
+                    return (lits, false);
+                }
             }
         };
     }
@@ -818,6 +832,10 @@ mod tests {
     #[test_case(".+a", &[]; "leading dot plus")]
     #[test_case(".?a", &[]; "leading dot question mark")]
     #[test_case("([0-2]+)-more", &["0", "1", "2"]; "leading submatch")]
+    // Cases where we exceed MAX_LEADING_LITERALS and therefor return nothing
+    #[test_case("[a-zA-Z]+foo", &[]; "char class exceeds limit")]
+    #[test_case("[a-z]|[A-Z]|[0-9]", &[]; "alt branches exceed limit")]
+    #[test_case("[a-z][a-c]foo", &[]; "concat product exceeds limit")]
     #[test]
     fn ast_leading_literal_patterns_works(re: &str, expected: &[&str]) {
         let ast = parse(re).unwrap();

--- a/src/regex/mod.rs
+++ b/src/regex/mod.rs
@@ -146,6 +146,15 @@ impl CharClass {
 
         if self.negated { !res } else { res }
     }
+
+    fn size(&self) -> usize {
+        self.chars.len()
+            + self
+                .ranges
+                .iter()
+                .map(|(s, e)| (*e as u32 - *s as u32 + 1) as usize)
+                .sum::<usize>()
+    }
 }
 
 fn next_char(it: &mut Peekable<Chars<'_>>) -> Result<Option<(char, bool)>, Error> {

--- a/src/regex/vm.rs
+++ b/src/regex/vm.rs
@@ -885,4 +885,16 @@ impl Editor {
             assert!(r.find(&"foo").is_none());
         }
     }
+
+    // Regression case for https://github.com/sminez/ad/issues/165
+    #[test_case("Tracing_Summit_2025_Perfet_RYQoyoF.pdf"; "tracing")]
+    #[test_case("Bracing_Summit_2025_Perfet_RYQoyoF.pdf"; "bracing")]
+    #[test]
+    fn leading_literal_truncation_doesnt_affect_matching(s: &str) {
+        let re = "([a-zA-Z¡-�0-9_\\-./@]+).[Pp][Dd][Ff]";
+        let r = Regex::compile(re).unwrap();
+        let m = r.find(&s).unwrap();
+
+        assert_eq!(m.match_text(&s), s);
+    }
 }


### PR DESCRIPTION
As reported in #165, there is a bug in the Regex engine following the addition of the aho-corasick based search for leading literals. I had a `FIXME` comment around the behaviour for character classes (which is the cause of the reported bug) but my understanding of what the issue would be was incorrect. Instead of not being able to find the correct leading literal in some cases, the behaviour I had lead to the search advancing too far through the input.

The _correct_ behaviour is to stop building up the set of leading literals if we hit our hard limit (currently 50). There are several other approaches to take here that would allow for preserving more partial leading literals in certain cases but I'm opting to keep the logic as simple as possible given that this is an optimisation and that the existing approach has already proven to be buggy.

This PR adds a regression test for #165 along with extending the existing test suite to cover the three cases where we need to abandon the search for leading literals.