### PR TITLE
Support resizing UI layout using the mouse

### DIFF
--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -6,7 +6,7 @@ use crate::{
     fsys::LogEvent,
     key::{MouseButton, MouseEvent, MouseEventKind, MouseMod},
     system::System,
-    ui::SCRATCH_ID,
+    ui::{Border, SCRATCH_ID},
 };
 use ad_event::Source;
 use std::time::Instant;
@@ -19,32 +19,33 @@ const FAST_SCROLL_ROWS: usize = 5;
 /// Transient state that we hold to track the last mouse click we saw while
 /// we wait for it to be released or if the buffer changes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Click {
-    /// The button being held down
-    pub(crate) btn: MouseButton,
-    /// The current state of the dot associated with this click. This is updated
-    /// by Hold events and matches the buffer Dot for Left clicks. For Right and
-    /// Middle clicks this is a separate selection that is used on release.
-    pub(crate) selection: Range,
-    cut_handled: bool,
-    paste_handled: bool,
+pub enum Click {
+    Text {
+        /// The button being held down
+        btn: MouseButton,
+        /// The current state of the dot associated with this click. This is updated
+        /// by Hold events and matches the buffer Dot for Left clicks. For Right and
+        /// Middle clicks this is a separate selection that is used on release.
+        selection: Range,
+        cut_handled: bool,
+        paste_handled: bool,
+    },
+    ResizeColumn {
+        last_x: usize,
+    },
+    ResizeWindow {
+        last_y: usize,
+    },
 }
 
 impl Click {
-    fn new(btn: MouseButton, selection: Range) -> Self {
-        Self {
+    pub(super) fn text(btn: MouseButton, selection: Range) -> Self {
+        Self::Text {
             btn,
             selection,
             cut_handled: false,
             paste_handled: false,
         }
-    }
-
-    /// Only needed for Left clicks. Used to ensure that once the user has made
-    /// a chorded action we still support the other remaining action but we
-    /// stop setting the buffer Dot.
-    fn chord_handled(&self) -> bool {
-        self.btn == MouseButton::Left && (self.cut_handled || self.paste_handled)
     }
 }
 
@@ -102,6 +103,23 @@ where
                     return;
                 }
 
+                // Check border hits first as they don't attempt to modify the focus state in the
+                // same way that `set_dot_from_screen_coords` does.
+                if let Some(border) = self.layout.border_at_coords(x, y) {
+                    match border {
+                        Border::Vertical { col_idx } => {
+                            self.layout.focus_column_for_resize(col_idx);
+                            self.held_click = Some(Click::ResizeColumn { last_x: x });
+                        }
+                        Border::Horizontal { col_idx, win_idx } => {
+                            self.layout
+                                .focus_column_and_window_for_resize(col_idx, win_idx);
+                            self.held_click = Some(Click::ResizeWindow { last_y: y });
+                        }
+                    }
+                    return;
+                }
+
                 let click_in_active_buffer = self.layout.set_dot_from_screen_coords(x, y);
                 let b = self.layout.active_buffer_mut();
                 if !click_in_active_buffer && b.id != SCRATCH_ID {
@@ -116,7 +134,7 @@ where
                     }
                 }
 
-                self.held_click = Some(Click::new(Left, b.dot.as_range()));
+                self.held_click = Some(Click::text(Left, b.dot.as_range()));
                 self.last_click_was_left = true;
             }
 
@@ -127,22 +145,45 @@ where
                 self.handle_right_or_middle_click(false, x, y)
             }
 
-            (Hold, _, _) => {
-                if let Some(click) = &mut self.held_click {
-                    if click.chord_handled() {
+            (Hold, _, _) => match &mut self.held_click {
+                Some(Click::Text {
+                    btn,
+                    selection,
+                    cut_handled,
+                    paste_handled,
+                }) => {
+                    if *btn == Left && (*cut_handled || *paste_handled) {
                         return;
                     }
 
                     match self.layout.try_active_cur_from_screen_coords(x, y) {
-                        Some(cur) => click.selection.set_active_cursor(cur),
+                        Some(cur) => selection.set_active_cursor(cur),
                         None => return,
                     }
 
-                    if click.btn == Left {
-                        self.layout.active_buffer_mut().dot = Dot::from(click.selection);
+                    if *btn == Left {
+                        self.layout.active_buffer_mut().dot = Dot::from(*selection);
                     }
                 }
-            }
+
+                Some(Click::ResizeColumn { last_x }) => {
+                    let delta = x as i16 - *last_x as i16;
+                    if delta != 0 {
+                        self.layout.resize_active_column_against_next(delta);
+                        *last_x = x;
+                    }
+                }
+
+                Some(Click::ResizeWindow { last_y }) => {
+                    let delta = y as i16 - *last_y as i16;
+                    if delta != 0 {
+                        self.layout.resize_active_window_against_next(delta);
+                        *last_y = y;
+                    }
+                }
+
+                None => (),
+            },
 
             (Press, _, WheelUp) => {
                 self.last_click_was_left = false;
@@ -157,32 +198,43 @@ where
             }
 
             (Release, m, b) => {
-                if let Some(click) = self.held_click
-                    && click.btn == Left
+                if let Some(Click::Text { btn, .. }) = self.held_click
+                    && btn == Left
                     && (b == Right || b == Middle)
                 {
                     return; // paste and cut are handled on click
                 }
 
-                let mut click = match self.held_click.take() {
-                    Some(click) => click,
+                let held = match self.held_click.take() {
+                    Some(held) => held,
                     None => return,
                 };
 
-                if click.chord_handled() {
+                // Only Text clicks need further processing on release
+                let (btn, mut selection, cut_handled, paste_handled) = match held {
+                    Click::Text {
+                        btn,
+                        selection,
+                        cut_handled,
+                        paste_handled,
+                    } => (btn, selection, cut_handled, paste_handled),
+                    Click::ResizeColumn { .. } | Click::ResizeWindow { .. } => return,
+                };
+
+                if btn == Left && (cut_handled || paste_handled) {
                     return;
                 }
 
                 // Support releasing the mouse over a different window as actioning the selection
                 // as it was present in the active buffer
                 if let Some(cur) = self.layout.try_active_cur_from_screen_coords(x, y) {
-                    click.selection.set_active_cursor(cur);
+                    selection.set_active_cursor(cur);
                 }
 
-                match click.btn {
+                match btn {
                     Left | WheelUp | WheelDown => (),
                     Right | Middle => {
-                        self.handle_right_or_middle_release(click.btn == Right, click, m == Alt)
+                        self.handle_right_or_middle_release(btn == Right, selection, m == Alt)
                     }
                 }
             }
@@ -196,30 +248,39 @@ where
         use MouseButton::*;
 
         self.last_click_was_left = false;
-        match self.held_click {
-            Some(mut click) => {
+
+        match &mut self.held_click {
+            Some(Click::Text {
+                btn,
+                selection,
+                cut_handled,
+                paste_handled,
+            }) => {
                 // Mouse chords execute on the click of the second button rather than the release
-                if click.btn == Left {
-                    if is_right && !click.paste_handled {
+                if *btn == Left {
+                    if is_right && !*paste_handled {
+                        *paste_handled = true;
                         self.paste_from_clipboard(Source::Mouse);
-                        click.paste_handled = true;
-                        self.held_click = Some(click);
-                    } else if !is_right && !click.cut_handled {
+                    } else if !is_right && !*cut_handled {
+                        *selection = self.layout.active_buffer().dot.as_range();
+                        *cut_handled = true;
                         self.forward_action_to_active_buffer(Action::Delete, Source::Mouse);
-                        click.selection = self.layout.active_buffer().dot.as_range();
-                        click.cut_handled = true;
-                        self.held_click = Some(click);
                     }
-                } else if (is_right && click.btn == Middle) || (!is_right && click.btn == Right) {
+                } else if (is_right && *btn == Middle) || (!is_right && *btn == Right) {
                     self.held_click = None;
                 }
+            }
+
+            Some(_) => {
+                // ResizeColumn or ResizeWindow - cancel on other button press
+                self.held_click = None;
             }
 
             None => {
                 let btn = if is_right { Right } else { Middle };
                 let (id, cur) = self.layout.focus_cur_from_screen_coords(x, y);
                 _ = self.tx_fsys.send(LogEvent::Focus(id));
-                self.held_click = Some(Click::new(btn, Range::from_cursors(cur, cur, false)));
+                self.held_click = Some(Click::text(btn, Range::from_cursors(cur, cur, false)));
             }
         };
     }
@@ -228,19 +289,19 @@ where
     fn handle_right_or_middle_release(
         &mut self,
         is_right: bool,
-        click: Click,
+        selection: Range,
         load_in_new_window: bool,
     ) {
-        if click.selection.start != click.selection.end {
+        if selection.start != selection.end {
             // In the case where the click selection is a range we Load/Execute it directly.
             // For Middle clicks, if there is also a range dot in the buffer then that is
             // used as an argument to the command being executed.
             if is_right {
-                self.layout.active_buffer_mut().dot = Dot::from(click.selection);
+                self.layout.active_buffer_mut().dot = Dot::from(selection);
                 self.default_load_dot(Source::Mouse, load_in_new_window);
             } else {
                 let dot = self.layout.active_buffer().dot;
-                self.layout.active_buffer_mut().dot = Dot::from(click.selection);
+                self.layout.active_buffer_mut().dot = Dot::from(selection);
 
                 if dot.is_range() {
                     // Execute as if the click selection was dot then reset dot
@@ -255,13 +316,8 @@ where
             // In the case where the click selection was a Cur rather than a Range we
             // set the buffer dot to the click location if it is outside of the current buffer
             // dot (and allow smart expand to handle generating the selection) before we Load/Execute
-            if !self
-                .layout
-                .active_buffer()
-                .dot
-                .contains(&click.selection.start)
-            {
-                self.layout.active_buffer_mut().dot = Dot::from(click.selection.start);
+            if !self.layout.active_buffer().dot.contains(&selection.start) {
+                self.layout.active_buffer_mut().dot = Dot::from(selection.start);
             }
 
             if is_right {
@@ -319,6 +375,8 @@ mod tests {
         }
     }
 
+    // NOTE: All mouse tests use 1-indexed terminal coordinates
+
     #[test_case(
         &[
             MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
@@ -367,7 +425,7 @@ mod tests {
             MouseEvent { k: Press, m: NoMod, b: Left, x: 3, y: 1 },
             MouseEvent { k: Hold, m: NoMod, b: Left, x: 7, y: 1 },
         ],
-        Some(Click::new(Left, r(0, 3, false))),
+        Some(Click::text(Left, r(0, 3, false))),
         "some",
         "some text to test with",
         "X",
@@ -379,7 +437,7 @@ mod tests {
             MouseEvent { k: Press, m: NoMod, b: Right, x: 3, y: 1 },
             MouseEvent { k: Hold, m: NoMod, b: Right, x: 7, y: 1 },
         ],
-        Some(Click::new(Right, r(0, 3, false))),
+        Some(Click::text(Right, r(0, 3, false))),
         "t",  // default dot position
         "some text to test with",
         "X",
@@ -391,7 +449,7 @@ mod tests {
             MouseEvent { k: Press, m: NoMod, b: Middle, x: 3, y: 1 },
             MouseEvent { k: Hold, m: NoMod, b: Middle, x: 7, y: 1 },
         ],
-        Some(Click::new(Middle, r(0, 3, false))),
+        Some(Click::text(Middle, r(0, 3, false))),
         "t",  // default dot position
         "some text to test with",
         "X",
@@ -724,4 +782,225 @@ mod tests {
     //   - test that each mouse click and scroll informs fsys that the appropriate
     //     window is focused
     //   - test that focus events aren't sent when they aren't needed
+
+    fn editor_with_layout(n_cols: usize, n_wins: usize) -> Editor<TestSystem> {
+        let mut ed = Editor::new_with_system(
+            Default::default(),
+            Default::default(),
+            EditorMode::Headless,
+            LogBuffer::default(),
+            TestSystem::default(),
+        );
+        ed.update_window_size(80, 100);
+        ed.layout.open_virtual("test", "test content", false);
+
+        for _ in 1..n_cols {
+            ed.layout.new_column();
+        }
+        for _ in 1..n_wins {
+            ed.layout.new_window();
+        }
+
+        ed
+    }
+
+    #[test_case(5; "drag right grows first column")]
+    #[test_case(-5; "drag left shrinks first column")]
+    #[test]
+    fn resize_column_drag(delta: i16) {
+        let mut ed = editor_with_layout(2, 1);
+        let initial_sizes = ed.layout.column_widths();
+        let border_x = initial_sizes[0] + 1;
+
+        ed.handle_mouse_event(MouseEvent {
+            k: Press,
+            m: NoMod,
+            b: Left,
+            x: border_x,
+            y: 10,
+        });
+        assert!(matches!(ed.held_click, Some(Click::ResizeColumn { .. })));
+
+        let target_x = (border_x as i16 + delta) as usize;
+        ed.handle_mouse_event(MouseEvent {
+            k: Hold,
+            m: NoMod,
+            b: Left,
+            x: target_x,
+            y: 10,
+        });
+        ed.handle_mouse_event(MouseEvent {
+            k: Release,
+            m: NoMod,
+            b: Left,
+            x: target_x,
+            y: 10,
+        });
+
+        assert!(ed.held_click.is_none());
+
+        let final_sizes = ed.layout.column_widths();
+        assert_eq!(
+            final_sizes[0] as i16,
+            initial_sizes[0] as i16 + delta,
+            "first column"
+        );
+        assert_eq!(
+            final_sizes[1] as i16,
+            initial_sizes[1] as i16 - delta,
+            "second column"
+        );
+    }
+
+    #[test_case(5; "drag down grows first window")]
+    #[test_case(-5; "drag up shrinks first window")]
+    #[test]
+    fn resize_window_drag(delta: i16) {
+        let mut ed = editor_with_layout(1, 2);
+        let initial_sizes = ed.layout.window_heights();
+        let border_y = initial_sizes[0] + 1;
+
+        ed.handle_mouse_event(MouseEvent {
+            k: Press,
+            m: NoMod,
+            b: Left,
+            x: 10,
+            y: border_y,
+        });
+        assert!(matches!(ed.held_click, Some(Click::ResizeWindow { .. })));
+
+        let target_y = (border_y as i16 + delta) as usize;
+        ed.handle_mouse_event(MouseEvent {
+            k: Hold,
+            m: NoMod,
+            b: Left,
+            x: 10,
+            y: target_y,
+        });
+        ed.handle_mouse_event(MouseEvent {
+            k: Release,
+            m: NoMod,
+            b: Left,
+            x: 10,
+            y: target_y,
+        });
+
+        assert!(ed.held_click.is_none());
+
+        let final_sizes = ed.layout.window_heights();
+        assert_eq!(
+            final_sizes[0] as i16,
+            initial_sizes[0] as i16 + delta,
+            "first window"
+        );
+        assert_eq!(
+            final_sizes[1] as i16,
+            initial_sizes[1] as i16 - delta,
+            "second window"
+        );
+    }
+
+    #[test]
+    fn resize_sets_correct_focus() {
+        let mut ed = editor_with_layout(3, 1);
+
+        ed.layout.focus_column_for_resize(0);
+        assert_eq!(ed.layout.cols_before_focus(), 0, "initially on column 0");
+
+        let widths = ed.layout.column_widths();
+        let border_x = widths[0] + widths[1] + 2;
+
+        ed.handle_mouse_event(MouseEvent {
+            k: Press,
+            m: NoMod,
+            b: Left,
+            x: border_x,
+            y: 10,
+        });
+
+        assert_eq!(ed.layout.cols_before_focus(), 1, "focus moved to column 1");
+    }
+
+    #[test]
+    fn click_on_border_without_drag_is_noop() {
+        let mut ed = editor_with_layout(2, 1);
+        let initial_sizes = ed.layout.column_widths();
+        let border_x = initial_sizes[0] + 1;
+
+        ed.handle_mouse_event(MouseEvent {
+            k: Press,
+            m: NoMod,
+            b: Left,
+            x: border_x,
+            y: 10,
+        });
+        ed.handle_mouse_event(MouseEvent {
+            k: Release,
+            m: NoMod,
+            b: Left,
+            x: border_x,
+            y: 10,
+        });
+
+        let final_sizes = ed.layout.column_widths();
+        assert_eq!(initial_sizes, final_sizes, "sizes unchanged");
+    }
+
+    #[test_case(Right; "right click")]
+    #[test_case(Middle; "middle click")]
+    #[test]
+    fn non_left_click_on_border_is_noop(btn: MouseButton) {
+        let mut ed = editor_with_layout(2, 1);
+        let initial_sizes = ed.layout.column_widths();
+        let border_x = initial_sizes[0] + 1;
+
+        ed.handle_mouse_event(MouseEvent {
+            k: Press,
+            m: NoMod,
+            b: btn,
+            x: border_x,
+            y: 10,
+        });
+        ed.handle_mouse_event(MouseEvent {
+            k: Release,
+            m: NoMod,
+            b: btn,
+            x: border_x,
+            y: 10,
+        });
+
+        assert!(ed.held_click.is_none());
+
+        let final_sizes = ed.layout.column_widths();
+        assert_eq!(initial_sizes, final_sizes, "sizes unchanged");
+    }
+
+    #[test]
+    fn resize_cancelled_by_right_click() {
+        let mut ed = editor_with_layout(2, 1);
+        let initial_sizes = ed.layout.column_widths();
+
+        let border_x = initial_sizes[0] + 1;
+
+        ed.handle_mouse_event(MouseEvent {
+            k: Press,
+            m: NoMod,
+            b: Left,
+            x: border_x,
+            y: 10,
+        });
+        assert!(matches!(ed.held_click, Some(Click::ResizeColumn { .. })));
+
+        ed.handle_mouse_event(MouseEvent {
+            k: Press,
+            m: NoMod,
+            b: Right,
+            x: border_x,
+            y: 10,
+        });
+        assert!(ed.held_click.is_none(), "resize cancelled");
+
+        let final_sizes = ed.layout.column_widths();
+        assert_eq!(initial_sizes, final_sizes, "sizes unchanged after cancel");
+    }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -405,6 +405,53 @@ impl Layout {
         self.buffers.focus_id_silent(id);
     }
 
+    /// Focus the column at the given index without recording a jump.
+    ///
+    /// # Panics
+    /// Panics if col_idx is out of bounds.
+    pub fn focus_column_for_resize(&mut self, col_idx: usize) {
+        assert!(col_idx < self.cols.len(), "col_idx out of bounds");
+
+        self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
+        self.cols.focus_head();
+        for _ in 0..col_idx {
+            self.cols.focus_down();
+        }
+
+        self.buffers.focus_id_silent(self.focused_view().bufid);
+    }
+
+    /// Focus the window at the given index within the currently focused column,
+    /// without recording a jump.
+    ///
+    /// # Panics
+    /// Panics if win_idx is out of bounds.
+    pub fn focus_window_for_resize(&mut self, win_idx: usize) {
+        let wins = &mut self.cols.focus.wins;
+        assert!(win_idx < wins.len(), "win_idx out of bounds");
+
+        self.scratch.is_focused = false;
+        self.changed_since_last_render = true;
+
+        wins.focus_head();
+        for _ in 0..win_idx {
+            wins.focus_down();
+        }
+
+        self.buffers.focus_id_silent(self.focused_view().bufid);
+    }
+
+    /// Focus the column and window at the given indices without recording a jump.
+    ///
+    /// # Panics
+    /// Panics if either index is out of bounds.
+    pub fn focus_column_and_window_for_resize(&mut self, col_idx: usize, win_idx: usize) {
+        self.focus_column_for_resize(col_idx);
+        self.focus_window_for_resize(win_idx);
+    }
+
     pub(crate) fn focus_next_buffer(&mut self) -> BufferId {
         self.scratch.is_focused = false;
         self.changed_since_last_render = true;
@@ -735,6 +782,18 @@ impl Layout {
         self.cols.focus.wins.grow_focus(delta_rows);
     }
 
+    /// Resize the active column against the column to its right.
+    pub fn resize_active_column_against_next(&mut self, delta: i16) {
+        self.changed_since_last_render = true;
+        self.cols.grow_focus_against_next(delta);
+    }
+
+    /// Resize the active window against the window below it.
+    pub fn resize_active_window_against_next(&mut self, delta: i16) {
+        self.changed_since_last_render = true;
+        self.cols.focus.wins.grow_focus_against_next(delta);
+    }
+
     /// Update the current layout state to reflect a new physical screen size given in terms
     /// of the number of character rows and columns.
     ///
@@ -1011,6 +1070,46 @@ impl Layout {
         }
 
         y > (self.screen_rows - self.scratch.w.n_rows + 1)
+    }
+
+    pub fn border_at_coords(&self, x: usize, y: usize) -> Option<Border> {
+        if self.row_is_scratch(y) {
+            return None;
+        }
+
+        let n_cols = self.cols.len();
+        let mut x_offset = 0;
+
+        for (col_idx, (_, col)) in self.cols.iter().enumerate() {
+            let border_x = x_offset + col.n_cols + 1;
+
+            if x == border_x && col_idx < n_cols - 1 {
+                return Some(Border::Vertical { col_idx });
+            } else if x > border_x {
+                x_offset = border_x;
+                continue;
+            }
+
+            let n_wins = col.wins.len();
+            let mut y_offset = 0;
+
+            for (win_idx, (_, win)) in col.wins.iter().enumerate() {
+                let border_y = y_offset + win.n_rows + 1;
+
+                if y == border_y && win_idx < n_wins - 1 {
+                    return Some(Border::Horizontal { col_idx, win_idx });
+                } else if y > border_y {
+                    y_offset = border_y;
+                    continue;
+                }
+
+                return None; // Click was inside a window
+            }
+
+            return None;
+        }
+
+        None
     }
 
     /// If the given coordinates lie within the scratch buffer return None, otherwise return the ID
@@ -1544,6 +1643,24 @@ where
         }
     }
 
+    /// Resize the focused element against the next element (down[0]).
+    ///
+    /// No-op if there's no next element to resize against.
+    fn grow_focus_against_next(&mut self, delta: i16) {
+        if self.down.is_empty() || delta == 0 {
+            return;
+        }
+
+        let other = &mut self.down[0];
+        if delta < 0 {
+            let actual = self.focus.clamped_sub((-delta) as usize, MIN_DIM);
+            *other.size() += actual;
+        } else {
+            let actual = other.clamped_sub(delta as usize, MIN_DIM);
+            *self.focus.size() += actual;
+        }
+    }
+
     /// Attempt to preserve the current relative size of each element when the
     /// overall available space changes.
     fn scale_sizes(&mut self, ratio: f32, new_total: usize) {
@@ -1563,6 +1680,15 @@ where
             }
         }
     }
+}
+
+/// A border that can be dragged to resize
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Border {
+    /// Vertical border after column at index `col_idx`
+    Vertical { col_idx: usize },
+    /// Horizontal border after window at index `win_idx` within column at index `col_idx`
+    Horizontal { col_idx: usize, win_idx: usize },
 }
 
 /// Calculate the size (rows/cols) for n blocks within an available space of t
@@ -1642,6 +1768,20 @@ mod tests {
     };
     use simple_test_case::test_case;
     use std::{path::PathBuf, sync::mpsc::channel};
+
+    impl Layout {
+        pub fn column_widths(&self) -> Vec<usize> {
+            self.cols.iter().map(|(_, c)| c.n_cols).collect()
+        }
+
+        pub fn window_heights(&self) -> Vec<usize> {
+            self.cols.focus.wins.iter().map(|(_, w)| w.n_rows).collect()
+        }
+
+        pub fn cols_before_focus(&self) -> usize {
+            self.cols.up.len()
+        }
+    }
 
     fn test_layout(col_wins: &[usize], n_rows: usize, n_cols: usize) -> Layout {
         let mut cols = Vec::with_capacity(col_wins.len());
@@ -2065,5 +2205,223 @@ mod tests {
         assert_eq!(l.cols[0].wins[0].n_rows, 80);
         assert_eq!(l.cols[1].wins[0].n_rows, 40);
         assert_eq!(l.cols[1].wins[1].n_rows, 39);
+    }
+
+    #[test]
+    fn single_column_single_window_has_no_borders() {
+        let l = test_layout(&[1], 80, 100);
+
+        for x in 1..=100 {
+            for y in 1..=80 {
+                assert_eq!(
+                    l.border_at_coords(x, y),
+                    None,
+                    "unexpected hit @ ({x}, {y})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn single_column_multiple_windows_has_horizontal_borders() {
+        let l = test_layout(&[3], 80, 100);
+
+        assert_eq!(l.cols[0].wins[0].n_rows, 26);
+        assert_eq!(l.cols[0].wins[1].n_rows, 26);
+        assert_eq!(l.cols[0].wins[2].n_rows, 26);
+
+        assert_eq!(
+            l.border_at_coords(50, 27),
+            Some(Border::Horizontal {
+                col_idx: 0,
+                win_idx: 0
+            })
+        );
+
+        assert_eq!(
+            l.border_at_coords(50, 54),
+            Some(Border::Horizontal {
+                col_idx: 0,
+                win_idx: 1
+            })
+        );
+
+        assert_eq!(l.border_at_coords(50, 81), None); // past last window
+        assert_eq!(l.border_at_coords(50, 1), None); // inside first window
+        assert_eq!(l.border_at_coords(50, 26), None); // last row of first window
+        assert_eq!(l.border_at_coords(50, 28), None); // first row of second window
+    }
+
+    #[test]
+    fn multiple_columns_single_window_each_has_vertical_borders() {
+        let l = test_layout(&[1, 1, 1], 80, 100);
+
+        assert_eq!(l.cols[0].n_cols, 33);
+        assert_eq!(l.cols[1].n_cols, 33);
+        assert_eq!(l.cols[2].n_cols, 32);
+
+        assert_eq!(
+            l.border_at_coords(34, 40),
+            Some(Border::Vertical { col_idx: 0 })
+        );
+
+        assert_eq!(
+            l.border_at_coords(68, 40),
+            Some(Border::Vertical { col_idx: 1 })
+        );
+
+        assert_eq!(l.border_at_coords(101, 40), None); // past last column
+        assert_eq!(l.border_at_coords(1, 40), None); // inside first column
+        assert_eq!(l.border_at_coords(33, 40), None); // last char of first column
+        assert_eq!(l.border_at_coords(35, 40), None); // first char of second column
+    }
+
+    #[test]
+    fn multiple_columns_multiple_windows_has_both_border_types() {
+        let l = test_layout(&[2, 2], 80, 100);
+
+        let col0_width = l.cols[0].n_cols;
+        let win0_height = l.cols[0].wins[0].n_rows;
+
+        assert_eq!(
+            l.border_at_coords(col0_width + 1, 20),
+            Some(Border::Vertical { col_idx: 0 })
+        );
+
+        assert_eq!(
+            l.border_at_coords(10, win0_height + 1),
+            Some(Border::Horizontal {
+                col_idx: 0,
+                win_idx: 0
+            })
+        );
+
+        let col1_x = col0_width + 1 + 10; // inside col1
+        assert_eq!(
+            l.border_at_coords(col1_x, win0_height + 1),
+            Some(Border::Horizontal {
+                col_idx: 1,
+                win_idx: 0
+            })
+        );
+
+        assert_eq!(l.border_at_coords(10, 10), None); // inside window
+        assert_eq!(l.border_at_coords(col1_x, 10), None); // inside window in col1
+    }
+
+    #[test]
+    fn border_coords_at_screen_edges() {
+        let l = test_layout(&[1, 1], 80, 100);
+
+        assert_eq!(l.border_at_coords(1, 1), None); // top-left corner, inside first window
+        assert_eq!(l.border_at_coords(101, 40), None); // past right edge
+        assert_eq!(l.border_at_coords(10, 81), None); // past bottom edge
+    }
+
+    #[test]
+    fn focus_column_for_resize_works() {
+        let mut l = test_layout(&[1, 1, 1], 80, 100);
+        assert_eq!(l.cols.up.len(), 0);
+
+        l.focus_column_for_resize(1);
+        assert_eq!(l.cols.up.len(), 1);
+        assert_eq!(l.cols.down.len(), 1);
+
+        l.focus_column_for_resize(2);
+        assert_eq!(l.cols.up.len(), 2);
+        assert_eq!(l.cols.down.len(), 0);
+
+        l.focus_column_for_resize(0);
+        assert_eq!(l.cols.up.len(), 0);
+        assert_eq!(l.cols.down.len(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "col_idx out of bounds")]
+    fn focus_column_for_resize_panics_on_out_of_bounds() {
+        let mut l = test_layout(&[1, 1, 1], 80, 100);
+        l.focus_column_for_resize(99);
+    }
+
+    #[test]
+    fn focus_window_for_resize_works() {
+        let mut l = test_layout(&[3], 80, 100);
+        assert_eq!(l.cols.focus.wins.up.len(), 0);
+
+        l.focus_window_for_resize(1);
+        assert_eq!(l.cols.focus.wins.up.len(), 1);
+        assert_eq!(l.cols.focus.wins.down.len(), 1);
+
+        l.focus_window_for_resize(2);
+        assert_eq!(l.cols.focus.wins.up.len(), 2);
+        assert_eq!(l.cols.focus.wins.down.len(), 0);
+
+        l.focus_window_for_resize(0);
+        assert_eq!(l.cols.focus.wins.up.len(), 0);
+        assert_eq!(l.cols.focus.wins.down.len(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "win_idx out of bounds")]
+    fn focus_window_for_resize_panics_on_out_of_bounds() {
+        let mut l = test_layout(&[3], 80, 100);
+        l.focus_window_for_resize(99);
+    }
+
+    #[test]
+    fn focus_column_and_window_for_resize_works() {
+        let mut l = test_layout(&[2, 2], 80, 100);
+
+        l.focus_column_and_window_for_resize(1, 1);
+        assert_eq!(l.cols.up.len(), 1);
+        assert_eq!(l.cols.focus.wins.up.len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "col_idx out of bounds")]
+    fn focus_column_and_window_for_resize_panics_on_bad_col() {
+        let mut l = test_layout(&[2, 2], 80, 100);
+        l.focus_column_and_window_for_resize(99, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "win_idx out of bounds")]
+    fn focus_column_and_window_for_resize_panics_on_bad_win() {
+        let mut l = test_layout(&[2, 2], 80, 100);
+        l.focus_column_and_window_for_resize(0, 99);
+    }
+
+    #[test_case(2, 0, 10, &[60, 39]; "two cols grow first against second")]
+    #[test_case(2, 0, -10, &[40, 59]; "two cols shrink first against second")]
+    #[test_case(3, 1, 10, &[33, 43, 22]; "three cols grow middle against last")]
+    #[test_case(3, 1, -10, &[33, 23, 42]; "three cols shrink middle against last")]
+    #[test_case(2, 0, -200, &[MIN_DIM, 100 - MIN_DIM - 1]; "clamps to MIN_DIM")]
+    #[test_case(2, 1, 10, &[50, 49]; "last column has no next so noop")]
+    #[test]
+    fn resize_column_against_next(n_cols: usize, focus_idx: usize, delta: i16, expected: &[usize]) {
+        let mut l = test_layout(&vec![1; n_cols], 80, 100);
+        l.focus_column_for_resize(focus_idx);
+        l.resize_active_column_against_next(delta);
+
+        for (i, (_, c)) in l.cols.iter().enumerate() {
+            assert_eq!(c.n_cols, expected[i], "column {i}");
+        }
+    }
+
+    #[test_case(2, 0, 10, &[50, 29]; "two wins grow first against second")]
+    #[test_case(2, 0, -10, &[30, 49]; "two wins shrink first against second")]
+    #[test_case(3, 1, 10, &[26, 36, 16]; "three wins grow middle against last")]
+    #[test_case(3, 1, -10, &[26, 16, 36]; "three wins shrink middle against last")]
+    #[test_case(2, 0, -200, &[MIN_DIM, 80 - MIN_DIM - 1]; "clamps to MIN_DIM")]
+    #[test_case(2, 1, 10, &[40, 39]; "last window has no next so noop")]
+    #[test]
+    fn resize_window_against_next(n_wins: usize, focus_idx: usize, delta: i16, expected: &[usize]) {
+        let mut l = test_layout(&[n_wins], 80, 100);
+        l.focus_window_for_resize(focus_idx);
+        l.resize_active_window_against_next(delta);
+
+        for (i, (_, w)) in l.cols.focus.wins.iter().enumerate() {
+            assert_eq!(w.n_rows, expected[i], "window {i}");
+        }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,7 +14,7 @@ use std::{
 mod layout;
 mod tui;
 
-pub use layout::{Layout, SCRATCH_ID};
+pub use layout::{Border, Layout, SCRATCH_ID};
 pub use tui::{GenericTui, Tui};
 
 /// Something that can be used as a user interface

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -130,8 +130,10 @@ impl<W: Write> GenericTui<W> {
         let effective_screen_rows = self.frame.screen_rows.saturating_sub(offset);
 
         let load_exec_range = match held_click {
-            Some(click) if click.btn == MouseButton::Right || click.btn == MouseButton::Middle => {
-                Some((click.btn == MouseButton::Right, click.selection))
+            Some(Click::Text { btn, selection, .. })
+                if *btn == MouseButton::Right || *btn == MouseButton::Middle =>
+            {
+                Some((*btn == MouseButton::Right, *selection))
             }
             _ => None,
         };


### PR DESCRIPTION
(Finally) closes #98 by adding support for resizing the UI using the mouse by dragging on window / column borders.

@davcam sorry this took so long to implement!

https://github.com/user-attachments/assets/e781cf26-77ad-4cce-8e99-07ad23f33623

