### PR TITLE
fix a painc in Buffer substr_from function

### DIFF
--- a/src/buffer/internal.rs
+++ b/src/buffer/internal.rs
@@ -311,7 +311,13 @@ impl GapBuffer {
     /// You must call [GapBuffer::make_contiguous] before calling this method.
     pub unsafe fn substr_from(&self, byte_offset: usize) -> &str {
         // SAFETY: See above
-        unsafe { std::str::from_utf8_unchecked(&self.data[byte_offset..]) }
+        let (start, end) = if self.gap_start == 0 {
+            (self.gap_end + byte_offset, self.cap)
+        } else {
+            (byte_offset, self.gap_start)
+        };
+        // SAFETY: We know that buffer is contiguous and that indices are within bounds
+        unsafe { std::str::from_utf8_unchecked(&self.data[start..end]) }
     }
 
     /// Assume that the gap is at 0 and return the full contents of the inner buffer as a slice of
@@ -2412,5 +2418,55 @@ mod tests {
 
         assert_eq!(s, "foo bar");
         assert_eq!(gb.gap_start, 0);
+    }
+
+    #[test]
+    fn substr_from_works_when_gap_at_start() {
+        let mut gb = GapBuffer::from("hello world");
+
+        gb.make_contiguous();
+
+        assert!(gb.is_contiguous());
+        assert_eq!(gb.gap_start, 0);
+        assert_ne!(gb.gap_end, gb.cap);
+
+        // SAFETY: buffer is contiguous and offset is valid
+        let result = unsafe { gb.substr_from(6) };
+        assert_eq!(result, "world");
+    }
+
+    #[test]
+    fn substr_from_works_when_gap_at_end() {
+        let mut gb = GapBuffer::from("hello world");
+
+        gb.move_gap_to(gb.len());
+
+        assert!(gb.is_contiguous());
+        assert_eq!(gb.gap_end, gb.cap);
+        assert_ne!(gb.gap_start, 0);
+
+        // SAFETY: buffer is contiguous and offset is valid
+        let result = unsafe { gb.substr_from(6) };
+        assert_eq!(result, "world");
+    }
+
+    #[test]
+    fn substr_from_matches_expected_after_appending_to_end() {
+        let mut gb = GapBuffer::from("hello");
+
+        gb.insert_char(5, ' ');
+        gb.insert_char(6, 'w');
+        gb.insert_char(7, 'o');
+        gb.insert_char(8, 'r');
+        gb.insert_char(9, 'l');
+        gb.insert_char(10, 'd');
+
+        assert!(gb.is_contiguous());
+        assert_eq!(gb.gap_end, gb.cap);
+        assert_ne!(gb.gap_start, 0);
+
+        // SAFETY: buffer is contiguous and offset is valid
+        let result = unsafe { gb.substr_from(6) };
+        assert_eq!(result, "world");
     }
 }

--- a/src/buffer/internal.rs
+++ b/src/buffer/internal.rs
@@ -311,7 +311,7 @@ impl GapBuffer {
     /// You must call [GapBuffer::make_contiguous] before calling this method.
     pub unsafe fn substr_from(&self, byte_offset: usize) -> &str {
         // SAFETY: See above
-        unsafe { std::str::from_utf8_unchecked(&self.data[self.gap_end + byte_offset..]) }
+        unsafe { std::str::from_utf8_unchecked(&self.data[byte_offset..]) }
     }
 
     /// Assume that the gap is at 0 and return the full contents of the inner buffer as a slice of

--- a/src/exec/addr.rs
+++ b/src/exec/addr.rs
@@ -181,7 +181,7 @@ impl<'a> Parser<'a> {
     fn parse(&self) -> Result<Addr, Error> {
         let start = match self.parse_simple() {
             Ok(addr) => Some(addr),
-            Err(e) if self.input.at_bof() && self.input.try_char() == Some(',') => None,
+            Err(_) if self.input.at_bof() && self.input.try_char() == Some(',') => None,
             Err(e) => return Err(e),
         };
 


### PR DESCRIPTION
How to reproduce:

open ad, move cursor to line 8 Word `property`

```
+---------------------------------------------------------------------------+
| > Welcome to the ad text editor!                                          |
| This is a temporary buffer where you can make notes and execute commands. |
| You can press the '-' key to open a file from the current directory, or   |
| type :help to view the in-editor help documentation.                      |
|                                                                           |
| To prevent this message being shown at startup, set the 'show_splash'     |
| property to false in your config file.                                    |
+---------------------------------------------------------------------------+
              \  ,,  __
                ("\ ( (
                -)>\ )/
                ('( )'
                -'-'
```

Then `.`

Edit> /To/

Here is the panic stack:

```
Fatal error:
panicked at src/buffer/internal.rs:314:58:
range start index 2453 out of range for slice of length 1905
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
   2: std::backtrace::Backtrace::create
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/backtrace.rs:331:13
   3: <ad_editor::ui::tui::GenericTui<W> as ad_editor::ui::UserInterface>::init::{{closure}}
             at /Users/genius/project/ad/src/ui/tui.rs:195:22
   4: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/alloc/src/boxed.rs:1985:9
   5: std::panicking::rust_panic_with_hook
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:841:13
   6: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:706:13
   7: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/backtrace.rs:174:18
   8: __rustc::rust_begin_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:697:5
   9: core::panicking::panic_fmt
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:75:14
  10: core::slice::index::slice_start_index_len_fail::do_panic::runtime
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panic.rs:218:21
  11: core::slice::index::slice_start_index_len_fail::do_panic
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/intrinsics/mod.rs:2367:9
  12: core::slice::index::slice_start_index_len_fail
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panic.rs:223:9
  13: <core::ops::range::RangeFrom<usize> as core::slice::index::SliceIndex<[T]>>::index
             at /Users/genius/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/slice/index.rs:570:13
  14: core::slice::index::<impl core::ops::index::Index<I> for [T]>::index
             at /Users/genius/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/slice/index.rs:18:15
  15: ad_editor::buffer::internal::GapBuffer::substr_from
             at /Users/genius/project/ad/src/buffer/internal.rs:314:58
  16: <ad_editor::buffer::Buffer as ad_editor::regex::haystack::Haystack>::substr_from
             at /Users/genius/project/ad/src/regex/haystack.rs:191:50
  17: ad_editor::regex::vm::RegexInner::fast_update_byte_offset
             at /Users/genius/project/ad/src/regex/vm.rs:323:43
  18: ad_editor::regex::vm::RegexInner::match_from_byte_offset
             at /Users/genius/project/ad/src/regex/vm.rs:342:18
  19: ad_editor::regex::vm::Regex::find_from
             at /Users/genius/project/ad/src/regex/vm.rs:199:15
  20: ad_editor::exec::addr::Address::map_addr_base
             at /Users/genius/project/ad/src/exec/addr.rs:469:28
  21: ad_editor::exec::addr::Address::map_simple_addr
             at /Users/genius/project/ad/src/exec/addr.rs:492:28
  22: ad_editor::exec::addr::Address::map_addr
             at /Users/genius/project/ad/src/exec/addr.rs:404:37
  23: ad_editor::exec::Program::execute
             at /Users/genius/project/ad/src/exec/mod.rs:230:30
  24: ad_editor::editor::actions::<impl ad_editor::editor::Editor<S>>::execute_edit_command
             at /Users/genius/project/ad/src/editor/actions.rs:828:20
  25: ad_editor::editor::actions::<impl ad_editor::editor::Editor<S>>::sam_mode
             at /Users/genius/project/ad/src/editor/actions.rs:875:18
  26: ad_editor::editor::Editor<S>::handle_action
             at /Users/genius/project/ad/src/editor/mod.rs:699:29
  27: ad_editor::editor::Editor<S>::handle_actions
             at /Users/genius/project/ad/src/editor/mod.rs:547:45
  28: ad_editor::editor::Editor<S>::handle_input
             at /Users/genius/project/ad/src/editor/mod.rs:535:18
  29: ad_editor::editor::Editor<S>::handle_event
             at /Users/genius/project/ad/src/editor/mod.rs:346:37
  30: ad_editor::editor::Editor<S>::run_event_loop
             at /Users/genius/project/ad/src/editor/mod.rs:326:40
  31: ad_editor::editor::Editor<S>::run
             at /Users/genius/project/ad/src/editor/mod.rs:297:14
  32: ad::main
             at /Users/genius/project/ad/src/main.rs:68:7
  33: core::ops::function::FnOnce::call_once
             at /Users/genius/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:253:5
  34: std::sys::backtrace::__rust_begin_short_backtrace
             at /Users/genius/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:158:18
  35: std::rt::lang_start::{{closure}}
             at /Users/genius/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:206:18
  36: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/ops/function.rs:290:21
  37: std::panicking::catch_unwind::do_call
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:589:40
  38: std::panicking::catch_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:552:19
  39: std::panic::catch_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panic.rs:359:14
  40: std::rt::lang_start_internal::{{closure}}
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/rt.rs:175:24
  41: std::panicking::catch_unwind::do_call
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:589:40
  42: std::panicking::catch_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:552:19
  43: std::panic::catch_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panic.rs:359:14
  44: std::rt::lang_start_internal
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/rt.rs:171:5
  45: std::rt::lang_start
             at /Users/genius/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:205:5
  46: _main
```

I use ad in my daily work now, to some extend. Sometime it panics and that is really annoying.
And sometimes the panic is not so easy to reproduce.

This one I found it's easy to reproduce, so I try to solve it.
It seems to be a silly mistake, `offset` is compared with `self.txt.len()`, but `self.txt.substr_from` is checking from `gap+end + byte_offset`, that is out of range:

https://github.com/sminez/ad/blob/2a8737cce194cc2d400a37cfa85d8fd69113eb0e/src/regex/haystack.rs#L187-L191

