### PR TITLE
fix a panic caused by buffer slicing at the middle of UTF8 character

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -455,7 +455,18 @@ impl Buffer {
     pub fn display_name(&self) -> String {
         let s = self.kind.display_name();
 
-        s[0..min(MAX_NAME_LEN, s.len())].to_string()
+        if s.len() <= MAX_NAME_LEN {
+            s.to_string()
+        } else {
+            // Find the last character boundary at or before MAX_NAME_LEN bytes
+            // to avoid slicing in the middle of a multi-byte UTF-8 character
+            let boundary = s.char_indices()
+                .map(|(i, _)| i)
+                .take_while(|&i| i < MAX_NAME_LEN)
+                .last()
+                .unwrap_or(0);
+            s[..boundary].to_string()
+        }
     }
 
     /// Absolute path of full name of a virtual buffer
@@ -1436,6 +1447,84 @@ pub(crate) mod tests {
     #[test]
     fn n_digits_works(n: usize, digits: usize) {
         assert_eq!(n_digits(n), digits);
+    }
+
+    #[test]
+    fn display_name_short_path_returns_full() {
+        // Short path (< MAX_NAME_LEN) should return full path
+        let short_path = PathBuf::from("/home/user/file.txt");
+        let b = Buffer::new_from_canonical_file_path(0, short_path, Default::default())
+            .expect("create buffer");
+
+        assert_eq!(b.display_name(), "/home/user/file.txt");
+    }
+
+    #[test]
+    fn display_name_long_path_is_truncated() {
+        // Long path (> MAX_NAME_LEN) should be truncated
+        // Create a path with 60+ ASCII characters
+        let long_path = PathBuf::from("/a/very/long/path/that/exceeds/the/maximum/name/length/limit.txt");
+        let b = Buffer::new_from_canonical_file_path(0, long_path, Default::default())
+            .expect("create buffer");
+
+        let result = b.display_name();
+        // For ASCII, should be 49 bytes because char_indices gives starting positions
+        // [0, 1, ..., 49] and we take the last one < MAX_NAME_LEN (50)
+        assert_eq!(result.len(), 49);
+        // The path returned by Path::display() might differ slightly
+        assert!(result.ends_with("ximum/name/l"));
+    }
+
+    #[test]
+    fn display_name_multibyte_utf8_does_not_panic() {
+        // This is the regression test for the original bug
+        // The path "ai_coding_能力边界探索.md" has a multi-byte character
+        // '索' at bytes 49-52, and the old code tried to slice at byte 50,
+        // which is in the middle of that character
+        let path_with_multibyte = PathBuf::from("/Users/genius/Downloads/ai_coding_能力边界探索.md");
+        let b = Buffer::new_from_canonical_file_path(0, path_with_multibyte, Default::default())
+            .expect("create buffer");
+
+        // This should not panic
+        let result = b.display_name();
+
+        // The result should be a valid string (not panic when checking)
+        assert!(result.is_char_boundary(result.len()));
+
+        // Result should be <= MAX_NAME_LEN bytes and end at a char boundary
+        assert!(result.len() <= MAX_NAME_LEN);
+        // The truncated version ends before '索' which starts at byte 49
+        assert!(result.ends_with("能力边界探"));
+    }
+
+    #[test]
+    fn display_name_multibyte_at_exact_boundary() {
+        // Test when multibyte character starts exactly at MAX_NAME_LEN
+        // "测试" (test in Chinese) = 6 bytes total
+        let path = format!("/home/user/测试文件.md");
+        // /home/user/ = 11 bytes, 测试 = 6 bytes, 文件.md = 8 bytes
+        // Total = 25 bytes (well under MAX_NAME_LEN)
+
+        let b = Buffer::new_from_canonical_file_path(0, PathBuf::from(&path), Default::default())
+            .expect("create buffer");
+
+        let result = b.display_name();
+        assert_eq!(result, path);
+    }
+
+    #[test]
+    fn display_name_multibyte_sequence() {
+        // Test path with consecutive multibyte characters
+        let path = PathBuf::from("/a/b/c/文件名包含中文字符很长需要截断.md");
+        let b = Buffer::new_from_canonical_file_path(0, path, Default::default())
+            .expect("create buffer");
+
+        // Should not panic even when truncation point is in middle of multibyte char
+        let result = b.display_name();
+
+        // Verify the result is valid UTF-8
+        assert!(result.is_char_boundary(result.len()));
+        assert!(result.len() <= MAX_NAME_LEN);
     }
 
     #[test]

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -460,7 +460,8 @@ impl Buffer {
         } else {
             // Find the last character boundary at or before MAX_NAME_LEN bytes
             // to avoid slicing in the middle of a multi-byte UTF-8 character
-            let boundary = s.char_indices()
+            let boundary = s
+                .char_indices()
                 .map(|(i, _)| i)
                 .take_while(|&i| i < MAX_NAME_LEN)
                 .last()
@@ -1463,7 +1464,8 @@ pub(crate) mod tests {
     fn display_name_long_path_is_truncated() {
         // Long path (> MAX_NAME_LEN) should be truncated
         // Create a path with 60+ ASCII characters
-        let long_path = PathBuf::from("/a/very/long/path/that/exceeds/the/maximum/name/length/limit.txt");
+        let long_path =
+            PathBuf::from("/a/very/long/path/that/exceeds/the/maximum/name/length/limit.txt");
         let b = Buffer::new_from_canonical_file_path(0, long_path, Default::default())
             .expect("create buffer");
 
@@ -1481,7 +1483,8 @@ pub(crate) mod tests {
         // The path "ai_coding_能力边界探索.md" has a multi-byte character
         // '索' at bytes 49-52, and the old code tried to slice at byte 50,
         // which is in the middle of that character
-        let path_with_multibyte = PathBuf::from("/Users/genius/Downloads/ai_coding_能力边界探索.md");
+        let path_with_multibyte =
+            PathBuf::from("/Users/genius/Downloads/ai_coding_能力边界探索.md");
         let b = Buffer::new_from_canonical_file_path(0, path_with_multibyte, Default::default())
             .expect("create buffer");
 


### PR DESCRIPTION
How to reproduce:

```
% pwd
/Users/genius/Downloads

% touch ai_coding_能力边界探索.md

% ad ai_coding_能力边界探索.md
Fatal error:
panicked at src/buffer/mod.rs:458:10:
byte index 50 is not a char boundary; it is inside '索' (bytes 49..52) of `/Users/genius/Downloads/ai_coding_能力边界探索.md`
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
   2: std::backtrace::Backtrace::create
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/backtrace.rs:331:13
   3: <ad_editor::ui::tui::GenericTui<W> as ad_editor::ui::UserInterface>::init::{{closure}}
   4: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/alloc/src/boxed.rs:1985:9
   5: std::panicking::rust_panic_with_hook
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:841:13
   6: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:706:13
   7: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/backtrace.rs:174:18
   8: __rustc::rust_begin_unwind
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:697:5
   9: core::panicking::panic_fmt
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:75:14
  10: core::str::slice_error_fail_rt
  11: core::str::slice_error_fail
             at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/str/mod.rs:69:5
  12: core::str::traits::<impl core::slice::index::SliceIndex<str> for core::ops::range::Range<usize>>::index
             at /Users/genius/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/str/traits.rs:247:21
  13: <alloc::string::String as core::ops::index::Index<I>>::index
             at /Users/genius/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/string.rs:2717:15
  14: ad_editor::buffer::Buffer::display_name
  15: ad_editor::ui::tui::Frame::render_status_bar
  16: ad_editor::ui::tui::GenericTui<W>::render
  17: <ad_editor::ui::tui::GenericTui<W> as ad_editor::ui::UserInterface>::refresh
  18: <ad_editor::ui::Ui as ad_editor::ui::UserInterface>::refresh
  19: ad_editor::editor::Editor<S>::refresh_screen_w_minibuffer
             at /Users/genius/project/ad/src/editor/mod.rs:355:17
```

`display_name()` uses MAX_NAME_LEN to truncate the string, but when it's at the middle of UTF8 character, it would cause panic.