### PR TITLE
Support unbinding keys from user config

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -266,21 +266,32 @@ impl LspConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
 pub struct KeyBindings {
-    #[serde(default, deserialize_with = "de_serde_trie")]
-    pub normal: Trie<Input, Actions>,
-    #[serde(default, deserialize_with = "de_serde_trie")]
-    pub insert: Trie<Input, Actions>,
+    #[serde(default, deserialize_with = "de_serde_keymap_overrides")]
+    pub normal: KeymapOverrides,
+    #[serde(default, deserialize_with = "de_serde_keymap_overrides")]
+    pub insert: KeymapOverrides,
 }
 
-impl Default for KeyBindings {
-    fn default() -> Self {
-        KeyBindings {
-            normal: Trie::try_from_iter(Vec::new()).unwrap(),
-            insert: Trie::try_from_iter(Vec::new()).unwrap(),
-        }
-    }
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct KeymapOverrides {
+    pub additional: Trie<Input, Actions>,
+    pub removed: Vec<Vec<Input>>,
+}
+
+// The deny_unknown_fields is loadbearing here: we need this to ONLY deserialize from an empty TOML
+// table in order to correctly fall through to KeyAction when attempting to deserialize
+// KeyBindingItem below.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Unbind {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+enum KeybindingItem {
+    Unbind(Unbind),
+    Bind(KeyAction),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -371,25 +382,34 @@ fn try_input_from_str_template(s: &str) -> Result<Input, String> {
     }
 }
 
-fn de_serde_trie<'de, D>(deserializer: D) -> Result<Trie<Input, Actions>, D::Error>
+fn de_serde_keymap_overrides<'de, D>(deserializer: D) -> Result<KeymapOverrides, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let raw_map: HashMap<String, KeyAction> = Deserialize::deserialize(deserializer)?;
+    let raw_map: HashMap<String, KeybindingItem> = Deserialize::deserialize(deserializer)?;
     if raw_map.is_empty() {
         return Err(de::Error::custom("empty key map"));
     }
 
-    let raw = raw_map
-        .into_iter()
-        .map(|(k, action)| {
-            Inputs::try_from(k)
-                .map(|Inputs(keys)| (keys, action.into_actions()))
-                .map_err(de::Error::custom)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut additional = Vec::new();
+    let mut removed = Vec::new();
 
-    Trie::try_from_iter(raw).map_err(de::Error::custom)
+    for (k, item) in raw_map {
+        let keys = Inputs::try_from(k).map_err(de::Error::custom)?.0;
+        match item {
+            KeybindingItem::Unbind(_) => removed.push(keys),
+            KeybindingItem::Bind(action) => additional.push((keys, action.into_actions())),
+        }
+    }
+
+    if additional.is_empty() && removed.is_empty() {
+        return Err(de::Error::custom("empty key map"));
+    }
+
+    Ok(KeymapOverrides {
+        additional: Trie::try_from_iter(additional).map_err(de::Error::custom)?,
+        removed,
+    })
 }
 
 #[cfg(test)]
@@ -442,5 +462,51 @@ mod tests {
     fn parsing_an_empty_keymap_errors() {
         let res: Result<KeyBindings, _> = toml::from_str("[normal]");
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn parsing_unbind_action_works() {
+        let toml = r#"
+[normal]
+"<space> b" = {}
+"a" = { run = "test" }
+"#;
+        let keys: KeyBindings = toml::from_str(toml).unwrap();
+
+        assert_eq!(
+            keys.normal.removed,
+            vec![vec![Input::Char(' '), Input::Char('b')]]
+        );
+        assert_eq!(keys.normal.additional.len(), 1);
+    }
+
+    #[test]
+    fn parsing_unbind_only_keymap_works() {
+        let toml = r#"
+[normal]
+"<space> b" = {}
+"<space> l" = {}
+"#;
+        let keys: KeyBindings = toml::from_str(toml).unwrap();
+
+        assert_eq!(keys.normal.removed.len(), 2);
+        assert!(keys.normal.additional.is_empty());
+    }
+
+    #[test]
+    fn parsing_mixed_bindings_and_unbinds_works() {
+        let toml = r#"
+[normal]
+"<space> b" = {}
+"<space> b n" = { run = "next-buffer" }
+"<space> b p" = { run = "prev-buffer" }
+"#;
+        let keys: KeyBindings = toml::from_str(toml).unwrap();
+
+        assert_eq!(
+            keys.normal.removed,
+            vec![vec![Input::Char(' '), Input::Char('b')]]
+        );
+        assert_eq!(keys.normal.additional.len(), 2);
     }
 }

--- a/src/mode/insert.rs
+++ b/src/mode/insert.rs
@@ -88,7 +88,10 @@ mod tests {
         let default_actions = mode.handle_keys(&mut keys);
         assert_eq!(default_actions, expected_default_actions, "default");
 
-        mode.keymap = mode.keymap.merge_overriding(overrides.insert).unwrap();
+        mode.keymap = mode
+            .keymap
+            .merge_overriding(overrides.insert.additional)
+            .unwrap();
 
         // With the overrides we should see the send_keys action
         let Inputs(mut keys) = Inputs::try_from(binding.to_owned()).unwrap();

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -1,6 +1,6 @@
 //! Modal editing support.
 use crate::{
-    config::KeyBindings,
+    config::{KeyBindings, KeymapOverrides},
     editor::Actions,
     key::Input,
     term::CurShape,
@@ -59,8 +59,12 @@ impl Mode {
         }
     }
 
-    fn with_overrides(&mut self, overrides: Trie<Input, Actions>) -> Result<(), &'static str> {
-        self.keymap = self.keymap.clone().merge_overriding(overrides)?;
+    fn with_overrides(&mut self, parsed: KeymapOverrides) -> Result<(), &'static str> {
+        self.keymap = self
+            .keymap
+            .clone()
+            .without_prefixes(&parsed.removed)
+            .merge_overriding(parsed.additional)?;
 
         Ok(())
     }

--- a/src/mode/normal.rs
+++ b/src/mode/normal.rs
@@ -287,7 +287,10 @@ mod tests {
         let default_actions = mode.handle_keys(&mut keys);
         assert_eq!(default_actions, expected_default_actions, "default");
 
-        mode.keymap = mode.keymap.merge_overriding(overrides.normal).unwrap();
+        mode.keymap = mode
+            .keymap
+            .merge_overriding(overrides.normal.additional)
+            .unwrap();
 
         // With the overrides we should see the send_keys action
         let Inputs(mut keys) = Inputs::try_from(binding.to_owned()).unwrap();

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -96,6 +96,25 @@ where
         Self::try_from_iter(pairs)
     }
 
+    /// Remove all keys that match or are prefixed by any of the given prefixes.
+    ///
+    /// This performs subtree removal: if a prefix matches an internal node, all keys
+    /// under that node are removed. If it matches a leaf exactly, just that leaf is removed.
+    pub fn without_prefixes(self, prefixes: &[Vec<K>]) -> Self {
+        if self.is_empty() || prefixes.is_empty() {
+            return self;
+        }
+
+        let mut pairs = Vec::with_capacity(self.len());
+        self.extract_pairs(&mut pairs, Vec::new(), 0..self.n_roots);
+
+        let filtered = pairs
+            .into_iter()
+            .filter(|(k, _)| !prefixes.iter().any(|p| k.starts_with(p)));
+
+        Self::try_from_iter(filtered).expect("all remaining keys are valid")
+    }
+
     /// Merge two Tries preferring keys from `other` in the case of collisions.
     ///
     /// If the resulting Trie would be invalid to construct directly, an error is returned.
@@ -526,5 +545,41 @@ mod tests {
         let t2 = Trie::from_str_keys(vec![("foo", 2)]).unwrap();
 
         assert!(t1.merge_overriding(t2).is_ok());
+    }
+
+    #[test]
+    fn without_prefixes_on_empty_trie_returns_empty() {
+        let t: Trie<char, usize> = Trie::default();
+
+        assert!(t.without_prefixes(&[vec!['a', 'b']]).is_empty());
+    }
+
+    #[test_case(&["foo"], &["bar", "baz", "qxa", "qxb"]; "exact match single leaf")]
+    #[test_case(&["bar", "qxb"], &["foo", "baz", "qxa"]; "exact match multiple leaves")]
+    #[test_case(&["ba"], &["foo", "qxa", "qxb"]; "prefix removes subtree")] // typos:ignore
+    #[test_case(&["ba", "qx"], &["foo"]; "multiple prefixes remove multiple subtrees")] // typos:ignore
+    #[test_case(&["xy"], &["foo", "bar", "baz", "qxa", "qxb"]; "no match")]
+    #[test_case(&[], &["foo", "bar", "baz", "qxa", "qxb"]; "empty prefixes")]
+    #[test]
+    fn without_prefixes_works(prefixes: &[&str], expected_keys: &[&str]) {
+        let t = Trie::from_str_keys(vec![
+            ("foo", 1),
+            ("bar", 2),
+            ("baz", 3),
+            ("qxa", 4),
+            ("qxb", 5),
+        ])
+        .unwrap();
+
+        let prefixes: Vec<Vec<char>> = prefixes.iter().map(|s| s.chars().collect()).collect();
+        let result = t.without_prefixes(&prefixes);
+
+        assert_eq!(result.len(), expected_keys.len());
+        for key in expected_keys {
+            assert!(
+                result.get_str_exact(key).is_some(),
+                "expected key '{key}' to be present"
+            );
+        }
     }
 }

--- a/tests/data/config/with-unbindings.toml
+++ b/tests/data/config/with-unbindings.toml
@@ -1,0 +1,20 @@
+[editor]
+show_splash = true
+expand_tab = true
+tabstop = 4
+match_indent = true
+status_timeout = 3
+double_click_ms = 200
+minibuffer_lines = 8
+find_command = "fd -t f"
+
+[filesystem]
+enabled = false
+auto_mount = false
+
+[keys.normal]
+# Unbind <space> b (normally SelectBuffer) to free the prefix
+"<space> b" = {}
+# Now we can bind sequences under that prefix
+"<space> b n" = { send_keys = "i N <esc>" }
+"<space> b p" = { send_keys = "i P <esc>" }

--- a/tests/data/editor-scenarios/general/unbind_keybindings_normal.txtar
+++ b/tests/data/editor-scenarios/general/unbind_keybindings_normal.txtar
@@ -1,0 +1,19 @@
+Test that unbinding a key sequence frees up the prefix for new bindings.
+The default <space> b binding (SelectBuffer) is removed, allowing
+<space> b n and <space> b p to be bound as new sequences.
+
+-- config --
+path: tests/data/config/with-unbindings.toml
+-- file-new.txt --
+-- actions --
+# Type <space> b n - should insert N (not trigger SelectBuffer)
+type:  bn
+
+# Type <space> b p - should insert P
+type:  bp
+-- buffer-list --
+1    * new.txt
+-- expected-windows --
+1
+-- expected-buffer-1 --
+NP


### PR DESCRIPTION
Addresses the feature request from #172.

See the new scenario test added as part of this PR for what this looks like in practice:

```toml
[keys.normal]
# Unbind <space> b (normally SelectBuffer) to free the prefix
"<space> b" = {}
# Now we can bind sequences under that prefix
"<space> b n" = { send_keys = "i N <esc>" }
"<space> b p" = { send_keys = "i P <esc>" }
```