### PR TITLE
Handle "don't touch" values in 9p wstat messages

### DIFF
--- a/crates/ninep/README.md
+++ b/crates/ninep/README.md
@@ -8,6 +8,8 @@ transparent and language agnostic ‘API’.
 
 The section 5 man pages from plan 9 cover the [protocol](http://man.cat-v.org/plan_9/5/).
 
+The 9fans man pages also cover the [protocol](https://9fans.github.io/plan9port/man/man9/).
+
 
 ## A simple demo
 

--- a/crates/ninep/examples/async_server.rs
+++ b/crates/ninep/examples/async_server.rs
@@ -24,7 +24,7 @@
 //! ```
 use ninep::{
     Result,
-    fs::{FileMeta, IoUnit, Mode, Perm, Stat},
+    fs::{FileMeta, IoUnit, Mode, Perm, Stat, WStat},
     tokio::server::{AsyncServe9p, ClientId, ReadOutcome, Server},
 };
 use std::{
@@ -103,7 +103,7 @@ impl AsyncServe9p for EchoServer {
     }
 
     #[allow(unused_variables)]
-    async fn write_stat(&self, cid: ClientId, qid: u64, stat: Stat, uname: &str) -> Result<()> {
+    async fn write_stat(&self, cid: ClientId, qid: u64, wstat: WStat, uname: &str) -> Result<()> {
         Err("write_stat not supported".to_string())
     }
 

--- a/crates/ninep/examples/server.rs
+++ b/crates/ninep/examples/server.rs
@@ -24,7 +24,7 @@
 //! ```
 use ninep::{
     Result,
-    fs::{FileMeta, IoUnit, Mode, Perm, Stat},
+    fs::{FileMeta, IoUnit, Mode, Perm, Stat, WStat},
     sync::server::{ClientId, ReadOutcome, Serve9p, Server},
 };
 use std::{
@@ -102,7 +102,7 @@ impl Serve9p for EchoServer {
     }
 
     #[allow(unused_variables)]
-    fn write_stat(&self, cid: ClientId, qid: u64, stat: Stat, uname: &str) -> Result<()> {
+    fn write_stat(&self, cid: ClientId, qid: u64, wstat: WStat, uname: &str) -> Result<()> {
         Err("write_stat not supported".to_string())
     }
 

--- a/crates/ninep/src/fs.rs
+++ b/crates/ninep/src/fs.rs
@@ -423,7 +423,7 @@ fn systime_from_u32(t: u32) -> SystemTime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sansio::protocol::Qid;
+    use crate::sansio::protocol::{Qid, RawStat};
     use simple_test_case::test_case;
     use std::time::{Duration, UNIX_EPOCH};
 
@@ -520,5 +520,60 @@ mod tests {
     #[test]
     fn try_apply_updated_expected_fields(wstat: WStat, expected: Stat) {
         assert_eq!(wstat.try_apply(&stat()), Ok(expected));
+    }
+
+    #[test]
+    fn wstat_sentinel_values_are_correctly_handled() {
+        let raw = RawStat {
+            name: String::new(),
+            mode: u32::MAX,
+            length: u64::MAX,
+            atime: u32::MAX,
+            mtime: u32::MAX,
+            gid: String::new(),
+            muid: String::new(),
+            ..Default::default()
+        };
+
+        let wstat = WStat::from(raw);
+
+        assert!(wstat.name.is_none(), "name");
+        assert!(wstat.perms.is_none(), "perms");
+        assert!(wstat.n_bytes.is_none(), "n_bytes");
+        assert!(wstat.last_accesses.is_none(), "last_accessed");
+        assert!(wstat.last_modified.is_none(), "last_modified");
+        assert!(wstat.group.is_none(), "group");
+        assert!(wstat.last_modified_by.is_none(), "last_modified_by");
+    }
+
+    #[test]
+    fn rawstat_to_stat_strips_filetype_bits_from_perms() {
+        let raw = RawStat {
+            qid: Qid {
+                ty: Mode::FILE.bits(),
+                ..Qid::default()
+            },
+            mode: (Perm::DIR | Perm::OWNER_READ | Perm::OWNER_WRITE).bits(),
+            ..RawStat::default()
+        };
+        let s = Stat::try_from(raw).unwrap();
+        assert_eq!(s.perms, Perm::OWNER_READ | Perm::OWNER_WRITE);
+    }
+
+    #[test_case(FileType::Regular; "regular file")]
+    #[test_case(FileType::Directory; "directory")]
+    #[test_case(FileType::AppendOnly; "append only")]
+    #[test_case(FileType::Exclusive; "exclusive")]
+    #[test]
+    fn stat_to_rawstat_file_type_encoding_works(ty: FileType) {
+        let user_perms = Perm::OWNER_READ | Perm::OWNER_WRITE;
+        let mut s = stat();
+        s.fm.ty = ty;
+        s.perms = user_perms;
+
+        let raw = RawStat::from(s);
+
+        assert_eq!(raw.qid.ty, Mode::from(ty).bits());
+        assert_eq!(raw.mode, (Perm::from(ty) | user_perms).bits());
     }
 }

--- a/crates/ninep/src/fs.rs
+++ b/crates/ninep/src/fs.rs
@@ -205,6 +205,104 @@ impl TryFrom<RawStat> for Stat {
     }
 }
 
+/// An update to a known [Stat].
+///
+/// Optional fields with a [None] value denote leaving the field in the existing [Stat] unchanged.
+/// The [WStat::try_apply] method can be used to update the existing stat with the corresponding
+/// `qid`.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct WStat {
+    /// The server Qid for this entry
+    pub qid: Qid,
+    /// The name of the entry
+    pub name: Option<String>,
+    /// Permissions
+    pub perms: Option<Perm>,
+    /// Size in bytes
+    pub n_bytes: Option<u64>,
+    /// Timestamp of last access
+    pub last_accesses: Option<SystemTime>,
+    /// Timestamp of last modification
+    pub last_modified: Option<SystemTime>,
+    /// Group
+    pub group: Option<String>,
+    /// User who last modified this entry
+    pub last_modified_by: Option<String>,
+}
+
+impl WStat {
+    /// Try to apply this wstat update to an existing [Stat].
+    ///
+    /// Returns `Ok` after applying set fields if the [Qid] of this update and the provided stat
+    /// are equal, otherwise `Err`.
+    pub fn try_apply(self, stat: &Stat) -> Result<Stat, Box<WStat>> {
+        let mode = Mode::new(self.qid.ty);
+        if (self.qid.path != stat.fm.qid) || (mode != Mode::from(stat.fm.ty)) {
+            return Err(Box::new(self));
+        }
+
+        let mut stat = stat.clone();
+
+        stat.fm.name = self.name.unwrap_or(stat.fm.name);
+        stat.perms = self.perms.unwrap_or(stat.perms);
+        stat.n_bytes = self.n_bytes.unwrap_or(stat.n_bytes);
+        stat.last_accesses = self.last_accesses.unwrap_or(stat.last_accesses);
+        stat.last_modified = self.last_modified.unwrap_or(stat.last_modified);
+        stat.group = self.group.unwrap_or(stat.group);
+        stat.last_modified_by = self.last_modified_by.unwrap_or(stat.last_modified_by);
+
+        Ok(stat)
+    }
+}
+
+// From the spec: https://9fans.github.io/plan9port/man/man9/stat.html
+//
+// A wstat request can avoid modifying some properties of the file by providing explicit “don’t
+// touch” values in the stat data that is sent: zero-length strings for text values and the maximum
+// unsigned value of appropriate size for integral values. As a special case, if all the elements
+// of the directory entry in a Twstat message are “don’t touch” values, the server may interpret it
+// as a request to guarantee that the contents of the associated file are committed to stable
+// storage before the Rwstat message is returned. (Consider the message to mean, “make the state of
+// the file exactly what it claims to be.”)
+impl From<RawStat> for WStat {
+    fn from(r: RawStat) -> Self {
+        Self {
+            qid: r.qid,
+            name: if r.name.is_empty() {
+                None
+            } else {
+                Some(r.name)
+            },
+            perms: if r.mode == u32::MAX {
+                None
+            } else {
+                Some(Perm::new(r.mode & 0x0000FFFF))
+            },
+            n_bytes: if r.length == u64::MAX {
+                None
+            } else {
+                Some(r.length)
+            },
+            last_accesses: if r.atime == u32::MAX {
+                None
+            } else {
+                Some(systime_from_u32(r.atime))
+            },
+            last_modified: if r.mtime == u32::MAX {
+                None
+            } else {
+                Some(systime_from_u32(r.mtime))
+            },
+            group: if r.gid.is_empty() { None } else { Some(r.gid) },
+            last_modified_by: if r.muid.is_empty() {
+                None
+            } else {
+                Some(r.muid)
+            },
+        }
+    }
+}
+
 /// Supported filetypes
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileType {
@@ -320,4 +418,107 @@ fn systime_as_u32(t: SystemTime) -> u32 {
 
 fn systime_from_u32(t: u32) -> SystemTime {
     UNIX_EPOCH + Duration::from_secs(t as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sansio::protocol::Qid;
+    use simple_test_case::test_case;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    const TEST_QID: u64 = 42;
+    const TEST_MODE: Mode = Mode::FILE;
+
+    fn stat() -> Stat {
+        Stat {
+            fm: FileMeta {
+                name: "test".to_string(),
+                ty: FileType::Regular,
+                qid: TEST_QID,
+            },
+            perms: Perm::OWNER_READ | Perm::OWNER_WRITE,
+            n_bytes: 100,
+            last_accesses: UNIX_EPOCH,
+            last_modified: UNIX_EPOCH,
+            owner: "owner".to_string(),
+            group: "group".to_string(),
+            last_modified_by: "modifier".to_string(),
+        }
+    }
+
+    fn wstat() -> WStat {
+        WStat {
+            qid: Qid {
+                ty: TEST_MODE.bits(),
+                version: 0,
+                path: TEST_QID,
+            },
+            name: None,
+            perms: None,
+            n_bytes: None,
+            last_accesses: None,
+            last_modified: None,
+            group: None,
+            last_modified_by: None,
+        }
+    }
+
+    #[test_case(99, Mode::FILE; "path mismatch")]
+    #[test_case(42, Mode::DIR; "type mismatch")]
+    #[test_case(99, Mode::DIR; "path and type mismatch")]
+    #[test]
+    fn try_apply_qid_mismatch_returns_err(path: u64, mode: Mode) {
+        let wstat = WStat {
+            qid: Qid {
+                ty: mode.bits(),
+                version: 0,
+                path,
+            },
+            ..Default::default()
+        };
+
+        assert!(wstat.try_apply(&stat()).is_err());
+    }
+
+    #[test_case(wstat(), stat(); "unchanged")]
+    #[test_case(
+        WStat { name: Some("foo".into()), ..wstat() },
+        { let mut s = stat(); s.fm.name = "foo".into(); s };
+        "name"
+    )]
+    #[test_case(
+        WStat { perms: Some(Perm::OWNER_READ), ..wstat() },
+        Stat { perms: Perm::OWNER_READ, ..stat() };
+        "perms"
+    )]
+    #[test_case(
+        WStat { n_bytes: Some(200), ..wstat() },
+        Stat { n_bytes: 200, ..stat() };
+        "n_bytes"
+    )]
+    #[test_case(
+        WStat { last_accesses: Some(UNIX_EPOCH + Duration::from_secs(1)), ..wstat() },
+        Stat { last_accesses: UNIX_EPOCH + Duration::from_secs(1), ..stat() };
+        "last_accesses"
+    )]
+    #[test_case(
+        WStat { last_modified: Some(UNIX_EPOCH + Duration::from_secs(1)), ..wstat() },
+        Stat { last_modified: UNIX_EPOCH + Duration::from_secs(1), ..stat() };
+        "last_modified"
+    )]
+    #[test_case(
+        WStat { last_modified_by: Some("new_modifier".into()), ..wstat() },
+        Stat { last_modified_by: "new_modifier".into(), ..stat() };
+        "last_modified_by"
+    )]
+    #[test_case(
+        WStat { group: Some("new_group".into()), ..wstat() },
+        Stat { group: "new_group".into(), ..stat() };
+        "group"
+    )]
+    #[test]
+    fn try_apply_updated_expected_fields(wstat: WStat, expected: Stat) {
+        assert_eq!(wstat.try_apply(&stat()), Ok(expected));
+    }
 }

--- a/crates/ninep/src/sansio/protocol.rs
+++ b/crates/ninep/src/sansio/protocol.rs
@@ -307,15 +307,13 @@ impl TryFrom<Data> for Vec<RawStat> {
 
     fn try_from(Data(bytes): Data) -> Result<Self, io::Error> {
         let mut buf = Vec::new();
-        let mut bytes = bytes.as_slice();
-        let n = size_of::<RawStat>();
+        let mut bytes = io::Cursor::new(bytes);
         let sb = SharedBuf::default();
 
         loop {
             match RawStat::read_from(&sb, &mut bytes) {
                 Ok(rs) => {
                     buf.push(rs);
-                    bytes = &bytes[n..];
                 }
                 Err(e) if e.kind() == ErrorKind::UnexpectedEof => break,
                 Err(e) => return Err(e),
@@ -362,7 +360,7 @@ impl NineP for Data {
 
 /// A machine-independent directory entry
 /// <http://man.cat-v.org/plan_9/5/stat>
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct RawStat {
     /// `size[2]`      total byte count of the following data
     pub size: u16,
@@ -456,7 +454,7 @@ impl NineP for RawStat {
 
 /// A qid represents the server's unique identification for the file being accessed: two files
 /// on the same server hierarchy are the same if and only if their qids are the same.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct Qid {
     /// `qid.type[1]` the type of the file (directory, etc.), represented as a bit vector
     /// corresponding to the high 8 bits of the file's mode word.
@@ -1104,5 +1102,25 @@ mod tests {
                 },
             }),
         }
+    }
+
+    #[test]
+    fn raw_stats_from_data_works() {
+        let mut bytes = Vec::new();
+
+        for name in ["a", "bb", "ccc"] {
+            let rs = RawStat {
+                name: name.to_string(),
+                ..Default::default()
+            };
+            bytes.extend(rs.write_9p_bytes().unwrap());
+        }
+
+        let stats = Vec::<RawStat>::try_from(Data(bytes)).unwrap();
+
+        assert_eq!(stats.len(), 3);
+        assert_eq!(stats[0].name, "a");
+        assert_eq!(stats[1].name, "bb");
+        assert_eq!(stats[2].name, "ccc");
     }
 }

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -4,7 +4,7 @@
 //!  [1]: std::io::Write
 use crate::{
     Result,
-    fs::{FileMeta, FileType, IoUnit, Mode, Perm, Stat},
+    fs::{FileMeta, FileType, IoUnit, Mode, Perm, Stat, WStat},
     sansio::{
         protocol::{Data, RawStat, Rdata, Rmessage, Tdata, Tmessage},
         server::{
@@ -157,7 +157,7 @@ pub trait Serve9p: Send + Sync + 'static {
     fn stat(&self, cid: ClientId, qid: u64, uname: &str) -> Result<Stat>;
 
     /// Attempt to set the machine independent "directory entry" for the given resource.
-    fn write_stat(&self, cid: ClientId, qid: u64, stat: Stat, uname: &str) -> Result<()>;
+    fn write_stat(&self, cid: ClientId, qid: u64, wstat: WStat, uname: &str) -> Result<()>;
 }
 
 impl<S> Server<S>
@@ -384,10 +384,10 @@ where
     }
 
     fn handle_wstat(&mut self, fid: u32, raw_stat: RawStat) -> Result<Rdata> {
-        let stat: Stat = raw_stat.try_into()?;
+        let wstat: WStat = raw_stat.into();
         let fm = self.try_file_meta(fid)?;
         self.s
-            .write_stat(self.client_id, fm.qid, stat, &self.state.uname)?;
+            .write_stat(self.client_id, fm.qid, wstat, &self.state.uname)?;
 
         Ok(Rdata::Wstat {})
     }

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -4,7 +4,7 @@
 //!  [1]: tokio::io::AsyncWrite
 use crate::{
     Result,
-    fs::{FileMeta, FileType, IoUnit, Mode, Perm, Stat},
+    fs::{FileMeta, FileType, IoUnit, Mode, Perm, Stat, WStat},
     sansio::{
         protocol::{Data, RawStat, Rdata, Tdata, Tmessage},
         server::{
@@ -185,7 +185,7 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         &self,
         cid: ClientId,
         qid: u64,
-        stat: Stat,
+        wstat: WStat,
         uname: &str,
     ) -> impl Future<Output = Result<()>> + Send;
 }
@@ -435,10 +435,10 @@ where
     }
 
     async fn handle_wstat_async(&mut self, fid: u32, raw_stat: RawStat) -> Result<Rdata> {
-        let stat: Stat = raw_stat.try_into()?;
+        let wstat: WStat = raw_stat.into();
         let fm = self.try_file_meta(fid)?;
         self.s
-            .write_stat(self.client_id, fm.qid, stat, &self.state.uname)
+            .write_stat(self.client_id, fm.qid, wstat, &self.state.uname)
             .await?;
 
         Ok(Rdata::Wstat {})

--- a/src/fsys/mod.rs
+++ b/src/fsys/mod.rs
@@ -33,7 +33,7 @@
 use crate::{editor::Action, input::Event, ui::SCRATCH_ID};
 use ninep::{
     Result,
-    fs::{FileMeta, IoUnit, Mode, Perm, Stat},
+    fs::{FileMeta, IoUnit, Mode, Perm, Stat, WStat},
     sync::server::{ClientId, ReadOutcome, Serve9p, Server, socket_path},
 };
 use std::{
@@ -456,12 +456,12 @@ impl Serve9p for AdFs {
         }
     }
 
-    fn write_stat(&self, cid: ClientId, qid: u64, stat: Stat, uname: &str) -> Result<()> {
+    fn write_stat(&self, cid: ClientId, qid: u64, wstat: WStat, uname: &str) -> Result<()> {
         trace!(?cid, %qid, %uname, "handling write stat request");
         let mut s = self.state.lock().unwrap();
         s.buffer_nodes.update();
 
-        if stat.n_bytes == 0 {
+        if wstat.n_bytes == Some(0) {
             trace!(%qid, %uname, "stat n_bytes=0, truncating file");
             match qid {
                 MOUNT_ROOT_QID | CONTROL_FILE_QID | MINIBUFFER_QID | LOG_FILE_QID => (),


### PR DESCRIPTION
Fixes #178

Details of the bug are given in the issue for this. The assumption that the issue was down to incorrect parsing of the "don't touch" sentinel values was correct, but this amounts to a breaking change to the public API of the traits for writing servers as we now need to correctly support these sentinel values.

In looking into this I've also spotted a couple of other breaking changes (including a typo in one of the `Stat` field names...) which I will be addressing after this PR merges.

> The Client implementations currently don't support sending `wstat` messages directly, so I'll add support for that in a follow on PR as well.