### PR TITLE
Ninep v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,9 +969,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simple_coro"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92802be477870645da846efac4217346cb92b80e1bad2b71ad73da2c156a6f7c"
+checksum = "1158d11ccd4ddeebe545d676d7356f677d3737172550bdf2a12a7ae3a1229d99"
 
 [[package]]
 name = "simple_test_case"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "ninep"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.10.0",
  "simple_coro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ lexopt = "0.3.1"
 libc = "0.2.178"
 libloading = "0.9.0"
 lsp-types = "0.97.0"
-ninep = { version = "0.5", path = "crates/ninep", default-features = false }
+ninep = { version = "0.6", path = "crates/ninep", default-features = false }
 serde = "1.0.228"
 serde_json = "1.0.145"
 structex = { version = "0.6", default-features = false }

--- a/crates/ad_client/Cargo.toml
+++ b/crates/ad_client/Cargo.toml
@@ -19,4 +19,4 @@ categories = [ "development-tools", "text-editors", "command-line-utilities" ]
 
 [dependencies]
 ad_event = { version = "0.4", path = "../ad_event" }
-ninep = { version = "0.5", path = "../ninep" }
+ninep = { version = "0.6", path = "../ninep" }

--- a/crates/ninep/Cargo.toml
+++ b/crates/ninep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninep"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["sminez <innes.andersonmorrison@gmail.com>"]
 license = "MIT"

--- a/crates/ninep/Cargo.toml
+++ b/crates/ninep/Cargo.toml
@@ -20,7 +20,7 @@ tokio = ["dep:tokio"]
 [dependencies]
 bitflags = "2"
 tokio =  { version = "1", features = ["macros", "net", "io-util", "rt", "sync"], optional = true }
-simple_coro = "0.1"
+simple_coro = "0.1.5"
 
 [dev-dependencies]
 simple_test_case = "1"

--- a/crates/ninep/examples/async_server.rs
+++ b/crates/ninep/examples/async_server.rs
@@ -107,7 +107,7 @@ impl AsyncServe9p for EchoServer {
         Err("write_stat not supported".to_string())
     }
 
-    async fn walk(
+    async fn walk_one(
         &self,
         _cid: ClientId,
         parent_qid: u64,

--- a/crates/ninep/examples/server.rs
+++ b/crates/ninep/examples/server.rs
@@ -106,7 +106,13 @@ impl Serve9p for EchoServer {
         Err("write_stat not supported".to_string())
     }
 
-    fn walk(&self, _cid: ClientId, parent_qid: u64, child: &str, _uname: &str) -> Result<FileMeta> {
+    fn walk_one(
+        &self,
+        _cid: ClientId,
+        parent_qid: u64,
+        child: &str,
+        _uname: &str,
+    ) -> Result<FileMeta> {
         println!("handling walk request: parent={parent_qid} child={child}");
         match (parent_qid, child) {
             (ROOT, "bar") => Ok(FileMeta::dir("bar", BAR)),

--- a/crates/ninep/src/fs.rs
+++ b/crates/ninep/src/fs.rs
@@ -119,6 +119,30 @@ impl Perm {
     pub fn new(bits: u32) -> Self {
         Perm::from_bits_truncate(bits)
     }
+
+    /// Apply the appropriate 9P create permission mask based on the parent directory's
+    /// permissions:
+    ///
+    /// The create request asks the file server to create a new file with the name supplied, in the
+    /// directory (dir) represented by fid, and requires write permission in the directory. The
+    /// owner of the file is the implied user id of the request, the group of the file is the same
+    /// as dir, and the permissions are the value of
+    ///   perm & (~0666 | (dir.perm & 0666))
+    /// if a regular file is being created and
+    ///   perm & (~0777 | (dir.perm & 0777))
+    /// if a directory is being created. This means, for example, that if the create allows read
+    /// permission to others, but the containing directory does not, then the created file will not
+    /// allow others to read the file.
+    pub fn apply_create_mask(&self, parent_perms: Perm) -> Perm {
+        let mask = if self.contains(Perm::DIR) {
+            0o777
+        } else {
+            0o666
+        };
+        let bits = self.bits() & (!mask | (parent_perms.bits() & mask));
+
+        Perm::new(bits)
+    }
 }
 
 /// <http://p9f.org/magic/man2html/2/iounit>

--- a/crates/ninep/src/lib.rs
+++ b/crates/ninep/src/lib.rs
@@ -18,5 +18,8 @@ pub mod sync;
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
+#[cfg(test)]
+pub(crate) mod test_utils;
+
 /// A simple result type for errors returned from this crate
 pub type Result<T> = std::result::Result<T, String>;

--- a/crates/ninep/src/sansio/client.rs
+++ b/crates/ninep/src/sansio/client.rs
@@ -1,7 +1,7 @@
 //! Traits and structs for implementing a 9p client
 use crate::{
     fs::{Mode, Perm, Stat},
-    sansio::protocol::{Data, RawStat, Rdata, Rmessage, SharedBuf, Tdata, Tmessage},
+    sansio::protocol::{Data, MAXWELEM, RawStat, Rdata, Rmessage, SharedBuf, Tdata, Tmessage},
     sync::SyncNineP,
 };
 use simple_coro::{Coro, Handle, ReadyCoro};
@@ -102,28 +102,61 @@ impl State {
         path: String,
     ) -> Coro9p<u32, impl Future<Output = io::Result<u32>> + use<'_>> {
         Coro::from(move |handle: Handle<Tmessage, Rmessage>| async move {
-            let new_fid = {
-                if let Some(fid) = self.fids.get(&path) {
-                    return Ok(*fid);
+            if let Some(fid) = self.fids.get(&path) {
+                return Ok(*fid);
+            }
+
+            let wnames: Vec<String> = path
+                .split('/')
+                .filter(|name| !name.is_empty())
+                .map(Into::into)
+                .collect();
+
+            if wnames.is_empty() {
+                // walk to root
+                self.fids.insert(path, 0);
+                return Ok(0);
+            }
+
+            let mut intermediate_fids = Vec::new();
+            let mut fid = 0;
+
+            for chunk in wnames.chunks(MAXWELEM) {
+                let new_fid = self.next_fid();
+                let rmessage = handle
+                    .yield_value(Tmessage::new(
+                        0,
+                        Tdata::Walk {
+                            fid,
+                            new_fid,
+                            wnames: chunk.to_vec(),
+                        },
+                    ))
+                    .await;
+                let wqids = expect_rmessage!(rmessage, Walk { wqids });
+
+                if wqids.len() != chunk.len() {
+                    for fid in intermediate_fids.into_iter().rev() {
+                        _ = handle
+                            .yield_value(Tmessage::new(0, Tdata::Clunk { fid }))
+                            .await;
+                    }
+
+                    return err("walk failed before reaching full path");
                 }
 
-                self.next_fid()
-            };
+                intermediate_fids.push(new_fid);
+                fid = new_fid;
+            }
 
-            // If the walk succeeds then we've successfully associated our new fid with this path
-            // and we don't currently do anything with the qids for each of the path elements
-            handle
-                .yield_value(Tmessage::new(
-                    0,
-                    Tdata::Walk {
-                        fid: 0,
-                        new_fid,
-                        wnames: path.split('/').map(Into::into).collect(),
-                    },
-                ))
-                .await;
-
+            let new_fid = intermediate_fids.pop().unwrap();
             self.fids.insert(path, new_fid);
+
+            for fid in intermediate_fids {
+                _ = handle
+                    .yield_value(Tmessage::new(0, Tdata::Clunk { fid }))
+                    .await;
+            }
 
             Ok(new_fid)
         })
@@ -309,5 +342,89 @@ impl State {
 
             Ok(())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sansio::protocol::Qid;
+    use std::collections::HashMap;
+
+    #[test]
+    fn handle_walk_chunks_requests_to_maxwelem() {
+        let parts: Vec<String> = (0..=MAXWELEM).map(|i| format!("n{i}")).collect();
+        let full_path = parts.join("/");
+
+        let mut state = State {
+            msize: MSIZE,
+            fids: HashMap::new(),
+            next_fid: 1,
+        };
+
+        let mut coro = state.handle_walk(full_path.clone());
+
+        // first walk should be MAXWELEM elements
+        coro = coro.resume().unwrap_pending(|Tmessage { tag, content }| {
+            assert_eq!(
+                content,
+                Tdata::Walk {
+                    fid: 0,
+                    new_fid: 1,
+                    wnames: parts[0..MAXWELEM].to_vec()
+                }
+            );
+
+            Rmessage::new(
+                tag,
+                Rdata::Walk {
+                    wqids: vec![Qid::default(); MAXWELEM],
+                },
+            )
+        });
+
+        // second walk should contain the 17th element only
+        coro = coro.resume().unwrap_pending(|Tmessage { tag, content }| {
+            assert_eq!(
+                content,
+                Tdata::Walk {
+                    fid: 1,
+                    new_fid: 2,
+                    wnames: parts[MAXWELEM..].to_vec()
+                }
+            );
+
+            Rmessage::new(
+                tag,
+                Rdata::Walk {
+                    wqids: vec![Qid::default()],
+                },
+            )
+        });
+
+        // after the walks we should clunk the intermediate fid
+        coro = coro.resume().unwrap_pending(|Tmessage { tag, content }| {
+            assert_eq!(content, Tdata::Clunk { fid: 1 });
+            Rmessage::new(tag, Rdata::Clunk {})
+        });
+
+        // the provided fid for the walk should now be bound to the full path
+        let fid = coro.resume().unwrap().unwrap();
+        assert_eq!(fid, 2);
+        assert_eq!(state.fids.get(&full_path), Some(&2));
+    }
+
+    #[test]
+    fn handle_walk_empty_path_returns_root_without_messages() {
+        let mut state = State {
+            msize: MSIZE,
+            fids: HashMap::from([("/".to_string(), 0)]),
+            next_fid: 1,
+        };
+
+        let coro = state.handle_walk(String::new());
+        let fid = coro.resume().unwrap().unwrap();
+
+        assert_eq!(fid, 0);
     }
 }

--- a/crates/ninep/src/sansio/client.rs
+++ b/crates/ninep/src/sansio/client.rs
@@ -214,7 +214,7 @@ impl State {
             let sb = SharedBuf::default();
 
             loop {
-                match RawStat::read_from(&sb, &mut buf) {
+                match RawStat::read_from(self.msize, &sb, &mut buf) {
                     Ok(rs) => match rs.try_into() {
                         Ok(s) => stats.push(s),
                         Err(e) => return err(e),

--- a/crates/ninep/src/sansio/protocol.rs
+++ b/crates/ninep/src/sansio/protocol.rs
@@ -16,14 +16,13 @@ use std::{
 pub const MAX_SIZE_FIELD: usize = u16::MAX as usize;
 /// For data fields in read/write messages the size field is 32bits not 16
 pub const MAX_DATA_SIZE_FIELD: usize = u32::MAX as usize;
-/// The maximum number of bytes we allow in a Data buffer: a client attempting
-/// to use more than this is an error.
-pub const MAX_DATA_LEN: usize = 32 * 1024 * 1024;
+/// The default message size supported
+pub const DEFAULT_MSIZE: u32 = 32 * 1024 * 1024;
 
 /// Non IO related errors that can occur when attempting to serialize a [NineP] type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WriteError {
-    /// The maximum number of bytes we allow in a Data buffer is [MAX_DATA_LEN]: a client
+    /// The maximum number of bytes we allow in a Data buffer is [MAX_DATA_SIZE_FIELD]: a client
     /// attempting to use more than this is an error.
     DataLength(usize),
     /// The size of variable length data is denoted using a u16 so anything longer
@@ -40,6 +39,18 @@ impl fmt::Display for WriteError {
             ),
             Self::FieldLength(len) => write!(f, "string too long: max={MAX_SIZE_FIELD} len={len}"),
         }
+    }
+}
+
+#[inline(always)]
+pub(crate) fn validate_msize(requested: u32, msize: u32) -> io::Result<()> {
+    if requested > msize {
+        Err(io::Error::new(
+            io::ErrorKind::FileTooLarge,
+            format!("requested data ({requested}) is larger than msize ({msize})"),
+        ))
+    } else {
+        Ok(())
     }
 }
 
@@ -107,18 +118,34 @@ impl SharedBuf {
         }
     }
 
+    unsafe fn remaining(&self) -> usize {
+        // SAFETY: the caller must guarantee that no concurrent access takes place
+        let inner = unsafe { &*self.0.get() };
+        inner.buf.len() - inner.pos
+    }
+
     /// Helper for reading a single [NineP] value from a [SharedBuf] that has already been filled with
     /// the correct number of bytes for parsing the entire message without any further IO.
     ///
     /// # Safety
     /// The caller must guarantee that no concurrent access to the inner buffer takes place while
     /// this reference is held.
-    unsafe fn parse_from_buffer<T: NineP>(&self) -> io::Result<T> {
-        let mut coro = T::read_9p_coro(self);
+    unsafe fn parse_from_buffer<T: NineP>(&self, msize: u32) -> io::Result<T> {
+        let mut coro = T::read_9p_coro(msize, self);
 
         loop {
             coro = match coro.resume() {
-                CoroState::Pending(c, _) => c.send(()),
+                CoroState::Pending(c, n) => {
+                    // SAFETY: the caller must guarantee that no concurrent access takes place
+                    if n > unsafe { self.remaining() } {
+                        return Err(io::Error::new(
+                            ErrorKind::UnexpectedEof,
+                            "message content shorter than declared field lengths",
+                        ));
+                    }
+
+                    c.send(())
+                }
                 CoroState::Complete(res) => return res,
             };
         }
@@ -149,6 +176,7 @@ pub trait NineP: Sized {
     /// This is not a normal async function. It is used to set up a sans-io state machine that
     /// can be driven by a concrete implementation.
     fn read_9p(
+        msize: u32,
         buf: &SharedBuf,
         handle: Handle<usize>,
     ) -> impl Future<Output = io::Result<Self>> + Send;
@@ -156,9 +184,10 @@ pub trait NineP: Sized {
     /// Create a new [Coro] that reads from a [SharedBuf] to parse 9p protocol messages with
     /// minimal allocation.
     fn read_9p_coro(
+        msize: u32,
         buf: &SharedBuf,
     ) -> ReadyCoro<usize, (), io::Result<Self>, impl Future<Output = io::Result<Self>> + Send> {
-        Coro::from(async move |handle: Handle<usize>| Self::read_9p(buf, handle).await)
+        Coro::from(async move |handle: Handle<usize>| Self::read_9p(msize, buf, handle).await)
     }
 }
 
@@ -185,7 +214,7 @@ macro_rules! impl_u {
                     Ok(())
                 }
 
-                async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<$ty> {
+                async fn read_9p(_msize: u32, buf: &SharedBuf, handle: Handle<usize>) -> io::Result<$ty> {
                     let n = size_of::<$ty>();
                     handle.yield_value(n).await;
 
@@ -225,12 +254,13 @@ impl NineP for String {
         Ok(())
     }
 
-    async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
-        let len = u16::read_9p(buf, handle).await? as usize;
-        handle.yield_value(len).await;
+    async fn read_9p(msize: u32, buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+        let n = u16::read_9p(msize, buf, handle).await? as usize;
+        validate_msize(n as u32, msize)?;
+        handle.yield_value(n).await;
 
         // SAFETY: this is the only read we are doing and it matches the data we requested
-        let data = unsafe { buf.as_slice_to(len).to_vec() };
+        let data = unsafe { buf.as_slice_to(n).to_vec() };
 
         String::from_utf8(data).map_err(|e| io::Error::new(ErrorKind::InvalidData, e.to_string()))
     }
@@ -263,11 +293,11 @@ impl<T: NineP + fmt::Debug + Send> NineP for Vec<T> {
         Ok(())
     }
 
-    async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
-        let len = u16::read_9p(buf, handle).await? as usize;
+    async fn read_9p(msize: u32, buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+        let len = u16::read_9p(msize, buf, handle).await? as usize;
         let mut elems = Vec::with_capacity(len);
         for _ in 0..len {
-            elems.push(T::read_9p(buf, handle).await?);
+            elems.push(T::read_9p(msize, buf, handle).await?);
         }
 
         Ok(elems)
@@ -311,7 +341,7 @@ impl TryFrom<Data> for Vec<RawStat> {
         let sb = SharedBuf::default();
 
         loop {
-            match RawStat::read_from(&sb, &mut bytes) {
+            match RawStat::read_from(u32::MAX, &sb, &mut bytes) {
                 Ok(rs) => {
                     buf.push(rs);
                 }
@@ -341,18 +371,13 @@ impl NineP for Data {
         Ok(())
     }
 
-    async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
-        let len = u32::read_9p(buf, handle).await? as usize;
-        if len > MAX_DATA_LEN {
-            return Err(io::Error::new(
-                ErrorKind::InvalidData,
-                format!("data field too long: max={MAX_DATA_LEN} len={len}"),
-            ));
-        }
-        handle.yield_value(len).await;
+    async fn read_9p(msize: u32, buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+        let n = u32::read_9p(msize, buf, handle).await? as usize;
+        validate_msize(n as u32, msize)?;
+        handle.yield_value(n).await;
 
         // SAFETY: this is the only read we are doing and it matches the data we requested
-        let data = unsafe { buf.as_slice_to(len).to_vec() };
+        let data = unsafe { buf.as_slice_to(n).to_vec() };
 
         Ok(Data(data))
     }
@@ -415,8 +440,10 @@ impl NineP for RawStat {
         )
     }
 
-    async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+    async fn read_9p(msize: u32, buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
         // Request the fixed sized data before the strings in one block up front
+        // -> Strictly speaking we should validate against msize here but if msize is < 41 then we
+        //    will have already errored at the point of parsing the message
         handle.yield_value(41).await;
 
         // SAFETY: this is the only read we are doing and it matches the data we requested
@@ -430,10 +457,10 @@ impl NineP for RawStat {
         let atime = from_le_bytes!(u32, &bytes[25..]);
         let mtime = from_le_bytes!(u32, &bytes[29..]);
         let length = from_le_bytes!(u64, &bytes[33..]);
-        let name = String::read_9p(buf, handle).await?;
-        let uid = String::read_9p(buf, handle).await?;
-        let gid = String::read_9p(buf, handle).await?;
-        let muid = String::read_9p(buf, handle).await?;
+        let name = String::read_9p(msize, buf, handle).await?;
+        let uid = String::read_9p(msize, buf, handle).await?;
+        let gid = String::read_9p(msize, buf, handle).await?;
+        let muid = String::read_9p(msize, buf, handle).await?;
 
         Ok(RawStat {
             size,
@@ -485,10 +512,10 @@ impl NineP for Qid {
         write_fields!(buf, self, ty, version, path)
     }
 
-    async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
-        let ty = u8::read_9p(buf, handle).await?;
-        let version = u32::read_9p(buf, handle).await?;
-        let path = u64::read_9p(buf, handle).await?;
+    async fn read_9p(msize: u32, buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+        let ty = u8::read_9p(msize, buf, handle).await?;
+        let version = u32::read_9p(msize, buf, handle).await?;
+        let path = u64::read_9p(msize, buf, handle).await?;
 
         Ok(Qid { ty, version, path })
     }
@@ -601,9 +628,20 @@ macro_rules! impl_message_format {
             }
 
             #[allow(unused_assignments, unused_unsafe)]
-            async fn read_9p(buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
-                let len = u32::read_9p(buf, handle).await? as usize;
-                handle.yield_value(len-4).await;
+            async fn read_9p(msize: u32, buf: &SharedBuf, handle: Handle<usize>) -> io::Result<Self> {
+                let len = u32::read_9p(msize, buf, handle).await?;
+
+                // Guard against messages that are over the negotiated msize and smaller than the
+                // minimum message header size so we don't panic when we
+                validate_msize(len, msize)?;
+                if len < 7 {
+                    return Err(io::Error::new(
+                        ErrorKind::InvalidData,
+                        format!("minimum valid message size is 7 bytes, got {len}"),
+                    ));
+                }
+
+                handle.yield_value((len - 4) as usize).await;
 
                 // SAFETY: this is inside a running coro so the outer code is unable to take a
                 //         reference to buf while we update `pos` and read from the inner buffer
@@ -615,7 +653,7 @@ macro_rules! impl_message_format {
                     let content = match MessageType(ty) {
                         $(
                             MessageType::$message_variant => $enum_ty::$enum_variant {
-                                $($field: buf.parse_from_buffer::<$ty>()?),*
+                                $($field: buf.parse_from_buffer::<$ty>(msize)?),*
                             },
                         )+
 
@@ -841,6 +879,26 @@ pub struct Rmessage {
     pub content: Rdata,
 }
 
+impl Rmessage {
+    /// Construct a new [Rmessage]
+    pub const fn new(tag: u16, content: Rdata) -> Self {
+        Self { tag, content }
+    }
+
+    /// Replace `self.content` with an [Rdata::Error] this message's serialized size exceeds `msize`.
+    pub(crate) fn clamp(&mut self, msize: u32) {
+        let n = self.n_bytes() as u32;
+
+        if n > msize {
+            self.content = Rdata::Error {
+                ename: format!(
+                    "request generated a response of {n} bytes which is larger than msize ({msize})",
+                ),
+            };
+        }
+    }
+}
+
 /// Generate the Rdata enum along with the wrapped R-message types
 /// and their implementations of Format9p
 macro_rules! impl_rdata {
@@ -978,15 +1036,21 @@ mod tests {
         let buf: Vec<u8> = vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
         let sb = SharedBuf::default();
 
-        assert_eq!(0x01, u8::read_from(&sb, &mut buf.as_slice()).unwrap());
-        assert_eq!(0x2301, u16::read_from(&sb, &mut buf.as_slice()).unwrap());
+        assert_eq!(
+            0x01,
+            u8::read_from(DEFAULT_MSIZE, &sb, &mut buf.as_slice()).unwrap()
+        );
+        assert_eq!(
+            0x2301,
+            u16::read_from(DEFAULT_MSIZE, &sb, &mut buf.as_slice()).unwrap()
+        );
         assert_eq!(
             0x67452301,
-            u32::read_from(&sb, &mut buf.as_slice()).unwrap()
+            u32::read_from(DEFAULT_MSIZE, &sb, &mut buf.as_slice()).unwrap()
         );
         assert_eq!(
             0xefcdab8967452301,
-            u64::read_from(&sb, &mut buf.as_slice()).unwrap()
+            u64::read_from(DEFAULT_MSIZE, &sb, &mut buf.as_slice()).unwrap()
         );
     }
 
@@ -1027,7 +1091,7 @@ mod tests {
     {
         let buf = t1.write_9p_bytes().unwrap();
         let sb = SharedBuf::default();
-        let t2 = T::read_from(&sb, &mut buf.as_slice()).unwrap();
+        let t2 = T::read_from(DEFAULT_MSIZE, &sb, &mut buf.as_slice()).unwrap();
 
         assert_eq!(t1, t2);
     }
@@ -1104,6 +1168,112 @@ mod tests {
         }
     }
 
+    #[test_case(0, ErrorKind::InvalidData; "zero")]
+    #[test_case(4, ErrorKind::InvalidData; "just the size field itself")]
+    #[test_case(6, ErrorKind::InvalidData; "one less than valid header")]
+    #[test_case(9, ErrorKind::FileTooLarge; "valid header but larger than msize")]
+    #[test]
+    fn invalid_tmessage_size_errors(len: u32, expected_kind: ErrorKind) {
+        let bytes = len.to_le_bytes();
+        let err = Tmessage::read_from(8, &SharedBuf::default(), &mut bytes.as_slice()).unwrap_err();
+
+        assert_eq!(err.kind(), expected_kind, "size={len}");
+    }
+
+    // A well-formed 9p message header with an unrecognized type byte for both T and R messages
+    // size[4]=7, type[1]=0xFF, tag[2]=0
+    const UNKNOWN_TYPE_BYTES: [u8; 7] = [7, 0, 0, 0, 0xFF, 0, 0];
+
+    #[test]
+    fn tmessage_with_unknown_type_returns_invalid_data() {
+        let err = Tmessage::read_from(
+            DEFAULT_MSIZE,
+            &SharedBuf::default(),
+            &mut UNKNOWN_TYPE_BYTES.as_slice(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn rmessage_with_unknown_type_returns_invalid_data() {
+        let err = Rmessage::read_from(
+            DEFAULT_MSIZE,
+            &SharedBuf::default(),
+            &mut UNKNOWN_TYPE_BYTES.as_slice(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test_case(1; "one byte missing from body")]
+    #[test_case(4; "entire body missing")]
+    #[test_case(5; "body and one size byte missing")]
+    #[test_case(10; "only first size byte present")]
+    #[test]
+    fn truncated_tmessage_returns_unexpected_eof(truncate_by: usize) {
+        let msg = Tmessage::new(1, Tdata::Clunk { fid: 42 });
+        let mut bytes = msg.write_9p_bytes().unwrap();
+        bytes.truncate(bytes.len() - truncate_by);
+
+        let err = Tmessage::read_from(DEFAULT_MSIZE, &SharedBuf::default(), &mut bytes.as_slice())
+            .unwrap_err();
+
+        assert_eq!(
+            err.kind(),
+            ErrorKind::UnexpectedEof,
+            "truncate_by={truncate_by}"
+        );
+    }
+
+    #[test_case(1; "one byte missing from body")]
+    #[test_case(4; "entire body missing")]
+    #[test_case(5; "body and one size byte missing")]
+    #[test_case(10; "only first size byte present")]
+    #[test]
+    fn truncated_rmessage_returns_unexpected_eof(truncate_by: usize) {
+        let msg = Rmessage::new(1, Rdata::Write { count: 42 });
+        let mut bytes = msg.write_9p_bytes().unwrap();
+        bytes.truncate(bytes.len() - truncate_by);
+
+        let err = Rmessage::read_from(DEFAULT_MSIZE, &SharedBuf::default(), &mut bytes.as_slice())
+            .unwrap_err();
+
+        assert_eq!(
+            err.kind(),
+            ErrorKind::UnexpectedEof,
+            "truncate_by={truncate_by}"
+        );
+    }
+
+    // Exceeding both msize and the size claimed by the header should just trigger the standard
+    // error around exceeding msize.
+    #[test_case(50, ErrorKind::FileTooLarge; "larger than message size and msize")]
+    // Not requesting enough data to exceed msize but still requesting more than the size claimed
+    // by the header should result in an unexpected EOF as we should read the header stated size
+    // into a buffer and then attempt to parse the message from there.
+    #[test_case(DEFAULT_MSIZE, ErrorKind::UnexpectedEof; "larger than message size")]
+    #[test]
+    fn malicious_inner_field_size_errors(msize: u32, expected_kind: ErrorKind) {
+        // A Twalk where the outer message size correctly matches the total length of the payload
+        // but the inner string length field claims an additional 100 bytes of content will follow.
+        //
+        //   size[4]=19  type[1]=110(Twalk)  tag[2]=0
+        //   fid[4]=0  new_fid[4]=1  nwname[2]=1  str_len[2]=100
+        let malicious_bytes = [19, 0, 0, 0, 110, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 100, 0];
+
+        let err = Tmessage::read_from(
+            msize,
+            &SharedBuf::default(),
+            &mut malicious_bytes.as_slice(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), expected_kind);
+    }
+
     #[test]
     fn raw_stats_from_data_works() {
         let mut bytes = Vec::new();
@@ -1122,5 +1292,74 @@ mod tests {
         assert_eq!(stats[0].name, "a");
         assert_eq!(stats[1].name, "bb");
         assert_eq!(stats[2].name, "ccc");
+    }
+
+    #[test_case(-1, Some(ErrorKind::FileTooLarge); "msg larger than msize")]
+    #[test_case(1, None; "msg smaller than msize")]
+    #[test_case(0, None; "msg equals msize")]
+    #[test]
+    fn tmessage_read_from_respects_msize(delta: i32, expected_error: Option<ErrorKind>) {
+        let msg = Tmessage::new(1, Tdata::Clunk { fid: 42 });
+        let bytes = msg.write_9p_bytes().unwrap();
+        let msize = (bytes.len() as i32 + delta) as u32;
+
+        let res = Tmessage::read_from(msize, &SharedBuf::default(), &mut bytes.as_slice());
+
+        match expected_error {
+            Some(kind) => assert_eq!(res.unwrap_err().kind(), kind, "expected error"),
+            None => assert!(res.is_ok(), "{res:?}"),
+        }
+    }
+
+    #[test_case(-1, Some(ErrorKind::FileTooLarge); "msg larger than msize")]
+    #[test_case(1, None; "msg smaller than msize")]
+    #[test_case(0, None; "msg equals msize")]
+    #[test]
+    fn rmessage_read_from_respects_msize(delta: i32, expected_error: Option<ErrorKind>) {
+        let msg = Rmessage::new(1, Rdata::Write { count: 42 });
+        let bytes = msg.write_9p_bytes().unwrap();
+        let msize = (bytes.len() as i32 + delta) as u32;
+
+        let res = Rmessage::read_from(msize, &SharedBuf::default(), &mut bytes.as_slice());
+
+        match expected_error {
+            Some(kind) => assert_eq!(res.unwrap_err().kind(), kind, "expected error"),
+            None => assert!(res.is_ok(), "{res:?}"),
+        }
+    }
+
+    #[test]
+    fn string_read_from_errors_when_larger_than_msize() {
+        let s = "a".repeat(1024);
+        let bytes = s.write_9p_bytes().unwrap();
+
+        let err = String::read_from(512, &SharedBuf::default(), &mut bytes.as_slice()).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::FileTooLarge);
+    }
+
+    #[test]
+    fn data_read_from_errors_when_larger_than_msize() {
+        let data = Data(vec![1; 1024]);
+        let bytes = data.write_9p_bytes().unwrap();
+
+        let err = Data::read_from(512, &SharedBuf::default(), &mut bytes.as_slice()).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::FileTooLarge);
+    }
+
+    #[test_case(-1, true; "oversized reply is replaced with Rerror")]
+    #[test_case(0, false; "reply at exactly msize is sent unchanged")]
+    #[test_case(1, false; "undersized reply is sent unchanged")]
+    #[test]
+    fn rmessage_clamp_replaces_with_an_error_when_exceeding_msize(delta: i32, expect_error: bool) {
+        let mut r = Rmessage::new(1, Rdata::Write { count: 42 });
+        let msize = (r.n_bytes() as i32 + delta) as u32;
+
+        r.clamp(msize);
+
+        if expect_error {
+            assert!(matches!(r.content, Rdata::Error { .. }), "expected Error",);
+        } else {
+            assert_eq!(r.content, Rdata::Write { count: 42 }, "expected Write");
+        }
     }
 }

--- a/crates/ninep/src/sansio/protocol.rs
+++ b/crates/ninep/src/sansio/protocol.rs
@@ -634,7 +634,8 @@ macro_rules! impl_message_format {
                 let len = u32::read_9p(msize, buf, handle).await?;
 
                 // Guard against messages that are over the negotiated msize and smaller than the
-                // minimum message header size so we don't panic when we
+                // minimum message header size so we don't panic when we attempt to slice out the
+                // header below.
                 validate_msize(len, msize)?;
                 if len < 7 {
                     return Err(io::Error::new(
@@ -894,7 +895,7 @@ impl Rmessage {
         Self { tag, content }
     }
 
-    /// Replace `self.content` with an [Rdata::Error] this message's serialized size exceeds `msize`.
+    /// Replace `self.content` with an [Rdata::Error] if this message's serialized size exceeds `msize`.
     pub(crate) fn clamp(&mut self, msize: u32) {
         let n = self.n_bytes() as u32;
 

--- a/crates/ninep/src/sansio/protocol.rs
+++ b/crates/ninep/src/sansio/protocol.rs
@@ -859,6 +859,13 @@ impl_tdata! {
     }
 }
 
+impl Tdata {
+    /// Whether or not this is a flush message
+    pub fn is_flush(&self) -> bool {
+        matches!(self, Tdata::Flush { .. })
+    }
+}
+
 /// The Plan 9 File Protocol, 9P, is used for messages between clients and servers. A client
 /// transmits requests (T- messages) to a server, which subsequently returns replies (R-messages)
 /// to the client. The combined acts of transmitting (receiving) a request of a particular type,

--- a/crates/ninep/src/sansio/protocol.rs
+++ b/crates/ninep/src/sansio/protocol.rs
@@ -18,6 +18,8 @@ pub const MAX_SIZE_FIELD: usize = u16::MAX as usize;
 pub const MAX_DATA_SIZE_FIELD: usize = u32::MAX as usize;
 /// The default message size supported
 pub const DEFAULT_MSIZE: u32 = 32 * 1024 * 1024;
+/// Maximum number of walk elements in a single Twalk/Rwalk message.
+pub const MAXWELEM: usize = 16;
 
 /// Non IO related errors that can occur when attempting to serialize a [NineP] type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ninep/src/sansio/protocol.rs
+++ b/crates/ninep/src/sansio/protocol.rs
@@ -454,7 +454,7 @@ impl NineP for RawStat {
 
 /// A qid represents the server's unique identification for the file being accessed: two files
 /// on the same server hierarchy are the same if and only if their qids are the same.
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Qid {
     /// `qid.type[1]` the type of the file (directory, etc.), represented as a bit vector
     /// corresponding to the high 8 bits of the file's mode word.

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -80,7 +80,7 @@ impl<S> Server<S>
 where
     S: Send,
 {
-    /// Create a new file server with a single anonymous root (name will be "") and
+    /// Create a new file server with a single anonymous root (name will be "/") and
     /// qid of [QID_ROOT].
     pub fn new(s: S) -> Self {
         Self::new_with_roots(s, [("/".to_string(), QID_ROOT)].into_iter().collect())
@@ -536,7 +536,7 @@ mod tests {
         SessionState {
             client_id: ClientId(0),
             msize: DEFAULT_MSIZE,
-            roots: BTreeMap::from([("".to_string(), QID_ROOT)]),
+            roots: BTreeMap::from([("/".to_string(), QID_ROOT)]),
             qids: BTreeMap::from([(QID_ROOT, FileMeta::dir("", QID_ROOT))]),
             state: Attached {
                 uname: "testuser".to_string(),
@@ -610,12 +610,12 @@ mod tests {
     fn handle_attach_with_valid_root_initialises_state() {
         let mut session = Server::new(()).new_session(());
         assert!(
-            session.roots.contains_key(""),
+            session.roots.contains_key("/"),
             "expected default root is not present"
         );
 
         let (attached, qid) = session
-            .handle_attach(5, AFID_NO_AUTH, "testuser".into(), "".into())
+            .handle_attach(5, AFID_NO_AUTH, "testuser".into(), "/".into())
             .unwrap();
 
         assert_eq!(attached.fids, BTreeMap::from([(5, QID_ROOT)]));
@@ -676,7 +676,7 @@ mod tests {
                 fid: 0,
                 afid: AFID_NO_AUTH,
                 uname: "user".into(),
-                aname: "".into(),
+                aname: "/".into(),
             },
         ));
 

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -3,7 +3,7 @@ use crate::{
     Result,
     fs::{FileMeta, FileType, QID_ROOT, Stat},
     sansio::protocol::{
-        DEFAULT_MSIZE, Data, NineP, Qid, RawStat, Rdata, SharedBuf, Tdata, Tmessage,
+        DEFAULT_MSIZE, Data, MAXWELEM, NineP, Qid, RawStat, Rdata, SharedBuf, Tdata, Tmessage,
     },
 };
 use simple_coro::{Coro, Handle, ReadyCoro};
@@ -29,6 +29,7 @@ pub(crate) const E_ILLEGAL_CREATE_NAME: &str = "creating files named '.' or '..'
 pub(crate) const E_ILLEGAL_DIRECTORY_WRITE: &str = "illegal write to directory";
 pub(crate) const E_INVALID_OFFSET: &str = "invalid offset for read on directory";
 pub(crate) const E_NO_VERSION_MESSAGE: &str = "first message must be Tversion";
+pub(crate) const E_OVER_MAXWELEM: &str = "too many walk elements";
 pub(crate) const E_UNATTACHED: &str = "session is not attached";
 pub(crate) const E_UNKNOWN_FID: &str = "unknown fid";
 pub(crate) const E_UNKNOWN_FILE: &str = "unknown file";
@@ -195,7 +196,9 @@ impl SessionState<Attached> {
     > {
         Coro::from(
             move |handle: Handle<(u64, &'a str, &'a str), Result<FileMeta>>| async move {
-                if new_fid != fid && self.state.fids.contains_key(&new_fid) {
+                if wnames.len() > MAXWELEM {
+                    return Err(E_OVER_MAXWELEM.to_string());
+                } else if new_fid != fid && self.state.fids.contains_key(&new_fid) {
                     return Err(E_DUPLICATE_FID.to_string());
                 }
 
@@ -809,6 +812,19 @@ mod tests {
 
         assert_eq!(wqids.len(), 1, "expected partial qid list");
         assert_eq!(wqids[0].path, a_qid, "partial qid should be for 'a'");
+        assert_eq!(ss.state.fids.get(&1), None, "new_fid was bound");
+    }
+
+    #[test]
+    fn walk_over_maxwelem_returns_error() {
+        let mut ss = attached_session_state();
+        let wnames = (0..=MAXWELEM)
+            .map(|i| format!("n{i}"))
+            .collect::<Vec<String>>();
+
+        let res = ss.handle_attached_walk(0, 1, &wnames).resume().unwrap();
+
+        assert_eq!(res.unwrap_err(), E_OVER_MAXWELEM);
         assert_eq!(ss.state.fids.get(&1), None, "new_fid was bound");
     }
 

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -26,6 +26,7 @@ pub(crate) const E_AUTH_NOT_REQUIRED: &str = "authentication not required";
 pub(crate) const E_CREATE_NON_DIR: &str = "create in non-directory";
 pub(crate) const E_DUPLICATE_FID: &str = "duplicate fid";
 pub(crate) const E_ILLEGAL_CREATE_NAME: &str = "creating files named '.' or '..' is not allowed";
+pub(crate) const E_ILLEGAL_DIRECTORY_WRITE: &str = "illegal write to directory";
 pub(crate) const E_INVALID_OFFSET: &str = "invalid offset for read on directory";
 pub(crate) const E_NO_VERSION_MESSAGE: &str = "first message must be Tversion";
 pub(crate) const E_UNATTACHED: &str = "session is not attached";

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -121,16 +121,19 @@ where
 /// Marker trait for implementing a type state for Session
 pub(crate) trait SessionType: Send {}
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Unattached {
+    /// Whether or not we have seen a successful Version Tmessage
     pub(crate) seen_version: bool,
 }
 
 impl SessionType for Unattached {}
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Attached {
+    /// uname of the attached user
     pub(crate) uname: String,
+    /// Map of client fids to server qids
     pub(crate) fids: BTreeMap<u32, u64>,
 }
 impl SessionType for Attached {}
@@ -381,7 +384,7 @@ where
     /// Once the protocol is complete, the same afid is presented in the attach message for the
     /// user, granting entry. The same validated afid may be used for multiple attach messages with
     /// the same uname and aname.
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     pub(crate) fn handle_auth(&mut self, afid: u32, uname: String, aname: String) -> Result<Rdata> {
         // TODO: handle auth
         // let aqid = self.s.lock().unwrap().auth(afid, &uname, &aname)?;
@@ -506,5 +509,343 @@ where
         let aqid = self.qid(root_qid).expect("to have root qid");
 
         Ok((st, aqid))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::{FileMeta, Mode, Perm, Stat};
+    use crate::sansio::protocol::{MAX_DATA_LEN, NineP, RawStat, Rdata, Tdata, Tmessage};
+    use simple_coro::CoroState;
+    use simple_test_case::test_case;
+    use std::time::SystemTime;
+
+    fn attached_session_state() -> SessionState<Attached> {
+        SessionState {
+            client_id: ClientId(0),
+            msize: MAX_DATA_LEN as u32,
+            roots: BTreeMap::from([("".to_string(), QID_ROOT)]),
+            qids: BTreeMap::from([(QID_ROOT, FileMeta::dir("", QID_ROOT))]),
+            state: Attached {
+                uname: "testuser".to_string(),
+                fids: BTreeMap::from([(0, QID_ROOT)]),
+            },
+        }
+    }
+
+    fn test_stat(name: &str, qid: u64) -> Stat {
+        Stat {
+            fm: FileMeta::dir(name, qid),
+            perms: Perm::DIR,
+            n_bytes: 0,
+            last_accesses: SystemTime::UNIX_EPOCH,
+            last_modified: SystemTime::UNIX_EPOCH,
+            owner: "owner".to_string(),
+            group: "group".to_string(),
+            last_modified_by: "owner".to_string(),
+        }
+    }
+
+    #[test_case(SUPPORTED_VERSION, MAX_DATA_LEN  / 2, MAX_DATA_LEN  / 2, SUPPORTED_VERSION; "client msize smaller than server")]
+    #[test_case(SUPPORTED_VERSION, MAX_DATA_LEN  + 1, MAX_DATA_LEN , SUPPORTED_VERSION; "client msize larger than server")]
+    #[test_case("12345", MAX_DATA_LEN  / 2, MAX_DATA_LEN  / 2, UNKNOWN_VERSION; "unknown version still negotiates msize")]
+    #[test]
+    fn handle_version_returns_expected_response(
+        version: &str,
+        client_msize: usize,
+        expected_msize: usize,
+        expected_version: &str,
+    ) {
+        let mut session = Server::new(()).new_session(());
+        let resp = session.handle_version(client_msize as u32, version.into());
+
+        assert_eq!(
+            resp,
+            Rdata::Version {
+                msize: expected_msize as u32,
+                version: expected_version.into()
+            }
+        );
+    }
+
+    #[test]
+    fn unsupported_version_does_not_set_seen_version() {
+        let mut session = Server::new(()).new_session(());
+
+        session.handle_tmessage_unattached(Tmessage::new(
+            u16::MAX,
+            Tdata::Version {
+                msize: MAX_DATA_LEN as u32,
+                version: "12345".into(),
+            },
+        ));
+
+        assert!(
+            !session.state.seen_version,
+            "seen_version should not be set"
+        );
+    }
+
+    #[test]
+    fn handle_attach_with_unknown_root_returns_err() {
+        let mut session = Server::new(()).new_session(());
+        let result = session.handle_attach(0, AFID_NO_AUTH, "user".into(), "unknown aname".into());
+
+        assert_eq!(result.unwrap_err(), E_UNKNOWN_ROOT);
+    }
+
+    #[test]
+    fn handle_attach_with_valid_root_initialises_state() {
+        let mut session = Server::new(()).new_session(());
+        assert!(
+            session.roots.contains_key(""),
+            "expected default root is not present"
+        );
+
+        let (attached, qid) = session
+            .handle_attach(5, AFID_NO_AUTH, "testuser".into(), "".into())
+            .unwrap();
+
+        assert_eq!(attached.fids, BTreeMap::from([(5, QID_ROOT)]));
+        assert_eq!(attached.uname, "testuser");
+        assert_eq!(qid.ty, Mode::DIR.bits());
+        assert_eq!(qid.path, QID_ROOT);
+    }
+
+    #[test]
+    fn attach_before_version_returns_error() {
+        let mut session = Server::new(()).new_session(());
+
+        let resp = session.handle_tmessage_unattached(Tmessage::new(
+            0,
+            Tdata::Attach {
+                fid: 0,
+                afid: AFID_NO_AUTH,
+                uname: "user".into(),
+                aname: "".into(),
+            },
+        ));
+
+        match resp {
+            Either::L((_, Err(e))) => assert_eq!(e, E_NO_VERSION_MESSAGE),
+            other => panic!("expected E_NO_VERSION, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn attach_with_unknown_root_propagates_error() {
+        let mut session = Server::new(()).new_session(());
+        session.state.seen_version = true;
+
+        let resp = session.handle_tmessage_unattached(Tmessage::new(
+            0,
+            Tdata::Attach {
+                fid: 0,
+                afid: AFID_NO_AUTH,
+                uname: "user".into(),
+                aname: "unknown aname".into(),
+            },
+        ));
+
+        match resp {
+            Either::L((_, Err(e))) => assert_eq!(e, E_UNKNOWN_ROOT),
+            other => panic!("expected E_UNKNOWN_ROOT, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn valid_attach_returns_expected_qid() {
+        let mut session = Server::new(()).new_session(());
+        session.state.seen_version = true;
+
+        let resp = session.handle_tmessage_unattached(Tmessage::new(
+            0,
+            Tdata::Attach {
+                fid: 0,
+                afid: AFID_NO_AUTH,
+                uname: "user".into(),
+                aname: "".into(),
+            },
+        ));
+
+        match resp {
+            Either::R((0, _, qid)) => assert_eq!(qid.path, QID_ROOT),
+            other => panic!("expected root qid, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn walk_empty_wnames_binds_new_fid_to_root() {
+        let mut ss = attached_session_state();
+        let result = ss.handle_attached_walk(0, 1, &[]).resume().unwrap();
+
+        match result.unwrap() {
+            Rdata::Walk { wqids } => assert!(wqids.is_empty(), "expected empty wqids: {wqids:?}"),
+            other => panic!("expected Walk, got: {other:?}"),
+        }
+
+        assert_eq!(
+            ss.state.fids.get(&1),
+            Some(&QID_ROOT),
+            "new_fid should be bound to root"
+        );
+    }
+
+    #[test]
+    fn walk_duplicate_new_fid_returns_error() {
+        let mut ss = attached_session_state();
+        ss.state.fids.insert(1, 99);
+
+        let result = ss
+            .handle_attached_walk(0, 1, &["child".to_string()])
+            .resume()
+            .unwrap();
+
+        assert_eq!(result.unwrap_err(), E_DUPLICATE_FID);
+    }
+
+    #[test]
+    fn walk_unknown_fid_returns_error() {
+        let mut ss = attached_session_state();
+        let result = ss
+            .handle_attached_walk(99, 1, &["child".to_string()])
+            .resume()
+            .unwrap();
+
+        assert_eq!(result.unwrap_err(), E_UNKNOWN_FID);
+    }
+
+    #[test]
+    fn walk_non_dir_returns_error() {
+        let mut ss = attached_session_state();
+        ss.qids.insert(1, FileMeta::file("file.txt", 1));
+        ss.state.fids.insert(2, 1);
+
+        let result = ss
+            .handle_attached_walk(2, 3, &["child".to_string()])
+            .resume()
+            .unwrap();
+
+        assert_eq!(result.unwrap_err(), E_WALK_NON_DIR);
+    }
+
+    #[test]
+    fn walk_full_walk_binds_new_fid() {
+        let mut ss = attached_session_state();
+        let wnames = vec!["child".to_string()];
+        let child_qid = 42;
+
+        let mut coro = ss.handle_attached_walk(0, 1, &wnames);
+        coro = coro.resume().unwrap_pending(|(parent_qid, name, _uname)| {
+            assert_eq!(parent_qid, QID_ROOT, "should walk from root");
+            assert_eq!(name, "child", "should request child name");
+            FileMeta::file("child", child_qid)
+        });
+
+        let wqids = match coro.resume().unwrap() {
+            Ok(Rdata::Walk { wqids }) => wqids,
+            other => panic!("expected Walk, got: {other:?}"),
+        };
+
+        assert_eq!(wqids.len(), 1, "expected one wqid");
+        assert_eq!(wqids[0].path, child_qid, "wqid path should match child qid");
+        assert_eq!(
+            ss.state.fids.get(&1),
+            Some(&child_qid),
+            "new_fid should be bound to child"
+        );
+    }
+
+    #[test]
+    fn read_regular_file_yields_file_read_request() {
+        let mut ss = attached_session_state();
+        ss.qids.insert(1, FileMeta::file("file.txt", 1));
+        ss.state.fids.insert(2, 1);
+
+        let coro = ss.handle_attached_read(2, 0, 1024);
+
+        match coro.resume() {
+            CoroState::Pending(_, Either::R((qid, _))) => assert_eq!(qid, 1, "wrong qid"),
+            CoroState::Pending(_, s) => panic!("unexpected pending coro state: {s:?}"),
+            CoroState::Complete(res) => panic!("unexpected complete coro result: {res:?}"),
+        }
+    }
+
+    // Helper for readdir tests below
+    fn handle_readdir(
+        ss: &mut SessionState<Attached>,
+        stats: &[Stat],
+        offset: u64,
+        count: u32,
+    ) -> Vec<RawStat> {
+        let mut coro = ss.handle_attached_read(0, offset, count);
+        coro = coro.resume().unwrap_pending(|_| stats.to_vec());
+
+        let data = match coro.resume().unwrap() {
+            Ok(Some(Rdata::Read { data })) => data,
+            other => panic!("expected Read, got: {other:?}"),
+        };
+
+        Vec::<RawStat>::try_from(data).unwrap()
+    }
+
+    #[test]
+    fn read_dir_returns_serialized_stats() {
+        let mut ss = attached_session_state();
+        let expected = test_stat("child", 1);
+
+        let raw_stats = handle_readdir(&mut ss, std::slice::from_ref(&expected), 0, 4096);
+        let expected_raw: RawStat = expected.into();
+
+        assert_eq!(raw_stats, vec![expected_raw]);
+    }
+
+    #[test]
+    fn read_dir_valid_offset_skips_entries() {
+        let mut ss = attached_session_state();
+        let stat1 = test_stat("a", 1);
+        let stat2 = test_stat("b", 2);
+        let stat1_len = RawStat::from(stat1.clone()).n_bytes();
+
+        let raw_stats = handle_readdir(&mut ss, &[stat1, stat2.clone()], stat1_len as u64, 4096);
+        let expected_raw: RawStat = stat2.into();
+
+        assert_eq!(raw_stats, vec![expected_raw]);
+    }
+
+    #[test]
+    fn read_dir_invalid_offset_returns_error() {
+        let mut ss = attached_session_state();
+        let stat = test_stat("child", 1);
+        let stat_len = RawStat::from(stat.clone()).n_bytes();
+        let invalid_offset = (stat_len - 1) as u64; // not aligned to a stat boundary
+
+        let coro = ss.handle_attached_read(0, invalid_offset, 4096);
+        let res = match coro.resume() {
+            CoroState::Pending(c, Either::L(_)) => c.send(vec![stat]).resume().unwrap(),
+            _ => panic!("expected Pending with Either::L"),
+        };
+
+        assert_eq!(res.unwrap_err(), E_INVALID_OFFSET);
+    }
+
+    /// The user can specify a count for the number of bytes to be read back. This is almost always
+    /// not exactly aligned with the boundaries between individual stat entries, so we should
+    /// truncate to only return stats that fit within the requested number of bytes.
+    #[test]
+    fn read_dir_with_unaligned_count_truncates() {
+        let mut ss = attached_session_state();
+        let stat1 = test_stat("a", 1);
+        let stat2 = test_stat("b", 2);
+
+        // Ensure that we fit the first entry but not the second
+        let stat_len = RawStat::from(stat1.clone()).n_bytes();
+        let count = (stat_len + 1) as u32;
+
+        let raw_stats = handle_readdir(&mut ss, &[stat1.clone(), stat2], 0, count);
+        let expected_raw: RawStat = stat1.into();
+
+        assert_eq!(raw_stats, vec![expected_raw]);
     }
 }

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -21,17 +21,18 @@ use std::{
 pub const AFID_NO_AUTH: u32 = u32::MAX;
 
 // Error messages
-pub(crate) const E_NO_VERSION_MESSAGE: &str = "first message must be Tversion";
-pub(crate) const E_UNATTACHED: &str = "session is not attached";
 pub(crate) const E_ALREADY_ATTACHED: &str = "session is already attached";
 pub(crate) const E_AUTH_NOT_REQUIRED: &str = "authentication not required";
+pub(crate) const E_CREATE_NON_DIR: &str = "create in non-directory";
 pub(crate) const E_DUPLICATE_FID: &str = "duplicate fid";
+pub(crate) const E_ILLEGAL_CREATE_NAME: &str = "creating files named '.' or '..' is not allowed";
+pub(crate) const E_INVALID_OFFSET: &str = "invalid offset for read on directory";
+pub(crate) const E_NO_VERSION_MESSAGE: &str = "first message must be Tversion";
+pub(crate) const E_UNATTACHED: &str = "session is not attached";
 pub(crate) const E_UNKNOWN_FID: &str = "unknown fid";
 pub(crate) const E_UNKNOWN_FILE: &str = "unknown file";
 pub(crate) const E_UNKNOWN_ROOT: &str = "unknown root directory";
 pub(crate) const E_WALK_NON_DIR: &str = "walk in non-directory";
-pub(crate) const E_CREATE_NON_DIR: &str = "create in non-directory";
-pub(crate) const E_INVALID_OFFSET: &str = "invalid offset for read on directory";
 
 pub(crate) const UNKNOWN_VERSION: &str = "unknown";
 pub(crate) const SUPPORTED_VERSION: &str = "9P2000";

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -25,6 +25,7 @@ pub(crate) const E_ALREADY_ATTACHED: &str = "session is already attached";
 pub(crate) const E_AUTH_NOT_REQUIRED: &str = "authentication not required";
 pub(crate) const E_CREATE_NON_DIR: &str = "create in non-directory";
 pub(crate) const E_DUPLICATE_FID: &str = "duplicate fid";
+pub(crate) const E_FID_ALREADY_OPEN: &str = "fid already open";
 pub(crate) const E_ILLEGAL_CREATE_NAME: &str = "creating files named '.' or '..' is not allowed";
 pub(crate) const E_ILLEGAL_DIRECTORY_WRITE: &str = "illegal write to directory";
 pub(crate) const E_INVALID_OFFSET: &str = "invalid offset for read on directory";
@@ -34,6 +35,7 @@ pub(crate) const E_UNATTACHED: &str = "session is not attached";
 pub(crate) const E_UNKNOWN_FID: &str = "unknown fid";
 pub(crate) const E_UNKNOWN_FILE: &str = "unknown file";
 pub(crate) const E_UNKNOWN_ROOT: &str = "unknown root directory";
+pub(crate) const E_WALK_OPEN_FID: &str = "cannot clone open fid";
 pub(crate) const E_WALK_NON_DIR: &str = "walk in non-directory";
 
 pub(crate) const UNKNOWN_VERSION: &str = "unknown";
@@ -134,8 +136,8 @@ impl SessionType for Unattached {}
 pub(crate) struct Attached {
     /// uname of the attached user
     pub(crate) uname: String,
-    /// Map of client fids to server qids
-    pub(crate) fids: BTreeMap<u32, u64>,
+    /// Map of client fids to server file metadata
+    pub(crate) fids: BTreeMap<u32, FidMeta>,
 }
 impl SessionType for Attached {}
 
@@ -143,7 +145,29 @@ impl Attached {
     fn new(uname: String, root_fid: u32, root_qid: u64) -> Self {
         Self {
             uname,
-            fids: [(root_fid, root_qid)].into_iter().collect(),
+            fids: [(root_fid, FidMeta::closed(root_qid))]
+                .into_iter()
+                .collect(),
+        }
+    }
+}
+
+/// Internal metadata for known fids
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FidMeta {
+    pub(crate) qid: u64,
+    pub(crate) is_open: bool,
+}
+
+impl FidMeta {
+    pub(crate) fn open(qid: u64) -> Self {
+        Self { qid, is_open: true }
+    }
+
+    pub(crate) fn closed(qid: u64) -> Self {
+        Self {
+            qid,
+            is_open: false,
         }
     }
 }
@@ -173,9 +197,17 @@ where
 }
 
 impl SessionState<Attached> {
+    pub(crate) fn try_fid_meta(&self, fid: u32) -> Result<FidMeta> {
+        self.state
+            .fids
+            .get(&fid)
+            .copied()
+            .ok_or_else(|| E_UNKNOWN_FID.to_string())
+    }
+
     pub(crate) fn try_file_meta(&self, fid: u32) -> Result<FileMeta> {
         let opt = match self.state.fids.get(&fid) {
-            Some(&qid) => self.qids.get(&qid).cloned(),
+            Some(meta) => self.qids.get(&meta.qid).cloned(),
             None => None,
         };
 
@@ -202,10 +234,14 @@ impl SessionState<Attached> {
                     return Err(E_DUPLICATE_FID.to_string());
                 }
 
+                if self.try_fid_meta(fid)?.is_open {
+                    return Err(E_WALK_OPEN_FID.to_string());
+                }
+
                 let fm = self.try_file_meta(fid)?;
 
                 if wnames.is_empty() {
-                    self.state.fids.insert(new_fid, fm.qid);
+                    self.state.fids.insert(new_fid, FidMeta::closed(fm.qid));
                     return Ok(Rdata::Walk { wqids: vec![] });
                 } else if matches!(fm.ty, FileType::Regular) {
                     return Err(E_WALK_NON_DIR.to_string());
@@ -233,7 +269,7 @@ impl SessionState<Attached> {
                 // new_fid is only bound when all elements were walked successfully
                 if wqids.len() == wnames.len() {
                     let qid = wqids.last().expect("empty was handled above").path;
-                    self.state.fids.insert(new_fid, qid);
+                    self.state.fids.insert(new_fid, FidMeta::closed(qid));
                 }
 
                 Ok(Rdata::Walk { wqids })
@@ -544,7 +580,7 @@ mod tests {
             qids: BTreeMap::from([(QID_ROOT, FileMeta::dir("", QID_ROOT))]),
             state: Attached {
                 uname: "testuser".to_string(),
-                fids: BTreeMap::from([(0, QID_ROOT)]),
+                fids: BTreeMap::from([(0, FidMeta::closed(QID_ROOT))]),
             },
         }
     }
@@ -622,7 +658,10 @@ mod tests {
             .handle_attach(5, AFID_NO_AUTH, "testuser".into(), "/".into())
             .unwrap();
 
-        assert_eq!(attached.fids, BTreeMap::from([(5, QID_ROOT)]));
+        assert_eq!(
+            attached.fids,
+            BTreeMap::from([(5, FidMeta::closed(QID_ROOT))])
+        );
         assert_eq!(attached.uname, "testuser");
         assert_eq!(qid.ty, Mode::DIR.bits());
         assert_eq!(qid.path, QID_ROOT);
@@ -702,7 +741,7 @@ mod tests {
 
         assert_eq!(
             ss.state.fids.get(&1),
-            Some(&QID_ROOT),
+            Some(&FidMeta::closed(QID_ROOT)),
             "new_fid should be bound to root"
         );
     }
@@ -710,7 +749,7 @@ mod tests {
     #[test]
     fn walk_duplicate_new_fid_returns_error() {
         let mut ss = attached_session_state();
-        ss.state.fids.insert(1, 99);
+        ss.state.fids.insert(1, FidMeta::closed(99));
 
         let res = ss
             .handle_attached_walk(0, 1, &["child".to_string()])
@@ -735,7 +774,7 @@ mod tests {
     fn walk_non_dir_returns_error() {
         let mut ss = attached_session_state();
         ss.qids.insert(1, FileMeta::file("file.txt", 1));
-        ss.state.fids.insert(2, 1);
+        ss.state.fids.insert(2, FidMeta::closed(1));
 
         let res = ss
             .handle_attached_walk(2, 3, &["child".to_string()])
@@ -767,7 +806,7 @@ mod tests {
         assert_eq!(wqids[0].path, child_qid, "wqid path should match child qid");
         assert_eq!(
             ss.state.fids.get(&1),
-            Some(&child_qid),
+            Some(&FidMeta::closed(child_qid)),
             "new_fid should be bound to child"
         );
     }
@@ -832,7 +871,7 @@ mod tests {
     fn read_regular_file_yields_file_read_request() {
         let mut ss = attached_session_state();
         ss.qids.insert(1, FileMeta::file("file.txt", 1));
-        ss.state.fids.insert(2, 1);
+        ss.state.fids.insert(2, FidMeta::closed(1));
 
         let coro = ss.handle_attached_read(2, 0, 1024);
 

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -37,6 +37,7 @@ pub(crate) const UNKNOWN_VERSION: &str = "unknown";
 pub(crate) const SUPPORTED_VERSION: &str = "9P2000";
 
 const DEFAULT_DISPLAY_VALUE: &str = ":0";
+const DEFAULT_MSIZE: u32 = MAX_DATA_LEN as u32;
 
 /// Determine the 9p socket directory based on the USER and DISPLAY environment variables
 pub fn socket_dir() -> PathBuf {
@@ -70,7 +71,6 @@ where
     S: Send,
 {
     pub(crate) s: Arc<S>,
-    pub(crate) msize: u32,
     pub(crate) roots: BTreeMap<String, u64>,
     pub(crate) qids: BTreeMap<u64, FileMeta>,
     pub(crate) next_client_id: u64,
@@ -95,7 +95,6 @@ where
 
         Self {
             s: Arc::new(s),
-            msize: MAX_DATA_LEN as u32,
             roots,
             qids,
             next_client_id: 0,
@@ -106,7 +105,6 @@ where
     pub(crate) fn new_session<U>(&mut self, stream: U) -> Session<Unattached, S, U> {
         let session = Session::new_unattached(
             ClientId(self.next_client_id),
-            self.msize,
             self.roots.clone(),
             self.s.clone(),
             self.qids.clone(),
@@ -378,8 +376,10 @@ where
             SUPPORTED_VERSION
         };
 
+        self.msize = min(DEFAULT_MSIZE, msize);
+
         Rdata::Version {
-            msize: min(self.msize, msize),
+            msize: self.msize,
             version: server_version.to_string(),
         }
     }
@@ -412,7 +412,6 @@ where
 {
     fn new_unattached(
         client_id: ClientId,
-        msize: u32,
         roots: BTreeMap<String, u64>,
         s: Arc<S>,
         qids: BTreeMap<u64, FileMeta>,
@@ -425,7 +424,7 @@ where
             session_state: SessionState {
                 client_id,
                 state: Unattached::default(),
-                msize,
+                msize: DEFAULT_MSIZE,
                 roots,
                 qids,
             },
@@ -528,7 +527,7 @@ where
 mod tests {
     use super::*;
     use crate::fs::{FileMeta, Mode, Perm, Stat};
-    use crate::sansio::protocol::{MAX_DATA_LEN, NineP, RawStat, Rdata, Tdata, Tmessage};
+    use crate::sansio::protocol::{NineP, RawStat, Rdata, Tdata, Tmessage};
     use simple_coro::CoroState;
     use simple_test_case::test_case;
     use std::time::SystemTime;
@@ -536,7 +535,7 @@ mod tests {
     fn attached_session_state() -> SessionState<Attached> {
         SessionState {
             client_id: ClientId(0),
-            msize: MAX_DATA_LEN as u32,
+            msize: DEFAULT_MSIZE,
             roots: BTreeMap::from([("".to_string(), QID_ROOT)]),
             qids: BTreeMap::from([(QID_ROOT, FileMeta::dir("", QID_ROOT))]),
             state: Attached {
@@ -559,23 +558,23 @@ mod tests {
         }
     }
 
-    #[test_case(SUPPORTED_VERSION, MAX_DATA_LEN  / 2, MAX_DATA_LEN  / 2, SUPPORTED_VERSION; "client msize smaller than server")]
-    #[test_case(SUPPORTED_VERSION, MAX_DATA_LEN  + 1, MAX_DATA_LEN , SUPPORTED_VERSION; "client msize larger than server")]
-    #[test_case("12345", MAX_DATA_LEN  / 2, MAX_DATA_LEN  / 2, UNKNOWN_VERSION; "unknown version still negotiates msize")]
+    #[test_case(SUPPORTED_VERSION, DEFAULT_MSIZE  / 2, DEFAULT_MSIZE  / 2, SUPPORTED_VERSION; "client msize smaller than server")]
+    #[test_case(SUPPORTED_VERSION, DEFAULT_MSIZE  + 1, DEFAULT_MSIZE , SUPPORTED_VERSION; "client msize larger than server")]
+    #[test_case("12345", DEFAULT_MSIZE  / 2, DEFAULT_MSIZE  / 2, UNKNOWN_VERSION; "unknown version still negotiates msize")]
     #[test]
     fn handle_version_returns_expected_response(
         version: &str,
-        client_msize: usize,
-        expected_msize: usize,
+        client_msize: u32,
+        expected_msize: u32,
         expected_version: &str,
     ) {
         let mut session = Server::new(()).new_session(());
-        let resp = session.handle_version(client_msize as u32, version.into());
+        let resp = session.handle_version(client_msize, version.into());
 
         assert_eq!(
             resp,
             Rdata::Version {
-                msize: expected_msize as u32,
+                msize: expected_msize,
                 version: expected_version.into()
             }
         );
@@ -588,7 +587,7 @@ mod tests {
         session.handle_tmessage_unattached(Tmessage::new(
             u16::MAX,
             Tdata::Version {
-                msize: MAX_DATA_LEN as u32,
+                msize: DEFAULT_MSIZE,
                 version: "12345".into(),
             },
         ));

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -27,6 +27,7 @@ pub(crate) const E_ALREADY_ATTACHED: &str = "session is already attached";
 pub(crate) const E_AUTH_NOT_REQUIRED: &str = "authentication not required";
 pub(crate) const E_DUPLICATE_FID: &str = "duplicate fid";
 pub(crate) const E_UNKNOWN_FID: &str = "unknown fid";
+pub(crate) const E_UNKNOWN_FILE: &str = "unknown file";
 pub(crate) const E_UNKNOWN_ROOT: &str = "unknown root directory";
 pub(crate) const E_WALK_NON_DIR: &str = "walk in non-directory";
 pub(crate) const E_CREATE_NON_DIR: &str = "create in non-directory";
@@ -181,6 +182,7 @@ impl SessionState<Attached> {
         opt.ok_or_else(|| E_UNKNOWN_FID.to_string())
     }
 
+    #[expect(clippy::type_complexity)]
     pub(crate) fn handle_attached_walk<'a, 's: 'a>(
         &'s mut self,
         fid: u32,
@@ -188,12 +190,12 @@ impl SessionState<Attached> {
         wnames: &'a [String],
     ) -> ReadyCoro<
         (u64, &'a str, &'a str),
-        FileMeta,
+        Result<FileMeta>,
         Result<Rdata>,
         impl Future<Output = Result<Rdata>> + use<'s, 'a>,
     > {
         Coro::from(
-            move |handle: Handle<(u64, &'a str, &'a str), FileMeta>| async move {
+            move |handle: Handle<(u64, &'a str, &'a str), Result<FileMeta>>| async move {
                 if new_fid != fid && self.state.fids.contains_key(&new_fid) {
                     return Err(E_DUPLICATE_FID.to_string());
                 }
@@ -211,12 +213,22 @@ impl SessionState<Attached> {
                 let mut qid = fm.qid;
 
                 for name in wnames.iter() {
-                    let fm = handle.yield_value((qid, name, &self.state.uname)).await;
-                    qid = fm.qid;
-                    wqids.push(fm.as_qid());
-                    self.qids.insert(qid, fm);
+                    match handle.yield_value((qid, name, &self.state.uname)).await {
+                        Ok(fm) => {
+                            qid = fm.qid;
+                            wqids.push(fm.as_qid());
+                            self.qids.insert(qid, fm);
+                        }
+                        Err(_) => break,
+                    }
                 }
 
+                // Spec: first element failure must be Rerror, not Rwalk with zero qids
+                if wqids.is_empty() {
+                    return Err(E_UNKNOWN_FILE.to_string());
+                }
+
+                // new_fid is only bound when all elements were walked successfully
                 if wqids.len() == wnames.len() {
                     let qid = wqids.last().expect("empty was handled above").path;
                     self.state.fids.insert(new_fid, qid);
@@ -227,7 +239,7 @@ impl SessionState<Attached> {
         )
     }
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub(crate) fn handle_attached_read<'a, 's: 'a>(
         &'s mut self,
         fid: u32,
@@ -590,9 +602,9 @@ mod tests {
     #[test]
     fn handle_attach_with_unknown_root_returns_err() {
         let mut session = Server::new(()).new_session(());
-        let result = session.handle_attach(0, AFID_NO_AUTH, "user".into(), "unknown aname".into());
+        let res = session.handle_attach(0, AFID_NO_AUTH, "user".into(), "unknown aname".into());
 
-        assert_eq!(result.unwrap_err(), E_UNKNOWN_ROOT);
+        assert_eq!(res.unwrap_err(), E_UNKNOWN_ROOT);
     }
 
     #[test]
@@ -678,9 +690,9 @@ mod tests {
     #[test]
     fn walk_empty_wnames_binds_new_fid_to_root() {
         let mut ss = attached_session_state();
-        let result = ss.handle_attached_walk(0, 1, &[]).resume().unwrap();
+        let res = ss.handle_attached_walk(0, 1, &[]).resume().unwrap();
 
-        match result.unwrap() {
+        match res.unwrap() {
             Rdata::Walk { wqids } => assert!(wqids.is_empty(), "expected empty wqids: {wqids:?}"),
             other => panic!("expected Walk, got: {other:?}"),
         }
@@ -697,23 +709,23 @@ mod tests {
         let mut ss = attached_session_state();
         ss.state.fids.insert(1, 99);
 
-        let result = ss
+        let res = ss
             .handle_attached_walk(0, 1, &["child".to_string()])
             .resume()
             .unwrap();
 
-        assert_eq!(result.unwrap_err(), E_DUPLICATE_FID);
+        assert_eq!(res.unwrap_err(), E_DUPLICATE_FID);
     }
 
     #[test]
     fn walk_unknown_fid_returns_error() {
         let mut ss = attached_session_state();
-        let result = ss
+        let res = ss
             .handle_attached_walk(99, 1, &["child".to_string()])
             .resume()
             .unwrap();
 
-        assert_eq!(result.unwrap_err(), E_UNKNOWN_FID);
+        assert_eq!(res.unwrap_err(), E_UNKNOWN_FID);
     }
 
     #[test]
@@ -722,12 +734,12 @@ mod tests {
         ss.qids.insert(1, FileMeta::file("file.txt", 1));
         ss.state.fids.insert(2, 1);
 
-        let result = ss
+        let res = ss
             .handle_attached_walk(2, 3, &["child".to_string()])
             .resume()
             .unwrap();
 
-        assert_eq!(result.unwrap_err(), E_WALK_NON_DIR);
+        assert_eq!(res.unwrap_err(), E_WALK_NON_DIR);
     }
 
     #[test]
@@ -740,7 +752,7 @@ mod tests {
         coro = coro.resume().unwrap_pending(|(parent_qid, name, _uname)| {
             assert_eq!(parent_qid, QID_ROOT, "should walk from root");
             assert_eq!(name, "child", "should request child name");
-            FileMeta::file("child", child_qid)
+            Ok(FileMeta::file("child", child_qid))
         });
 
         let wqids = match coro.resume().unwrap() {
@@ -755,6 +767,49 @@ mod tests {
             Some(&child_qid),
             "new_fid should be bound to child"
         );
+    }
+
+    #[test]
+    fn walk_first_element_failure_returns_error() {
+        let mut ss = attached_session_state();
+        let wnames = &["missing".to_string()];
+
+        let mut coro = ss.handle_attached_walk(0, 1, wnames);
+        coro = coro
+            .resume()
+            .unwrap_pending(|_| Err("not found".to_string()));
+
+        let res = coro.resume().unwrap();
+        assert!(res.is_err(), "expected Rerror");
+        assert_eq!(ss.state.fids.get(&1), None, "new_fid was bound");
+    }
+
+    #[test]
+    fn walk_partial_walk_returns_partial_qids_and_does_not_bind_new_fid() {
+        let mut ss = attached_session_state();
+        let wnames = &["a".to_string(), "b".to_string()];
+        let a_qid = 10;
+
+        let mut coro = ss.handle_attached_walk(0, 1, wnames);
+
+        // First step of the walk succeeds
+        coro = coro
+            .resume()
+            .unwrap_pending(|(_, _, _)| Ok(FileMeta::dir("a", a_qid)));
+
+        // Second step fails
+        coro = coro
+            .resume()
+            .unwrap_pending(|(_, _, _)| Err("not found".to_string()));
+
+        let wqids = match coro.resume().unwrap() {
+            Ok(Rdata::Walk { wqids }) => wqids,
+            other => panic!("expected partial Walk, got: {other:?}"),
+        };
+
+        assert_eq!(wqids.len(), 1, "expected partial qid list");
+        assert_eq!(wqids[0].path, a_qid, "partial qid should be for 'a'");
+        assert_eq!(ss.state.fids.get(&1), None, "new_fid was bound");
     }
 
     #[test]

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -3,7 +3,7 @@ use crate::{
     Result,
     fs::{FileMeta, FileType, QID_ROOT, Stat},
     sansio::protocol::{
-        Data, MAX_DATA_LEN, NineP, Qid, RawStat, Rdata, SharedBuf, Tdata, Tmessage,
+        DEFAULT_MSIZE, Data, NineP, Qid, RawStat, Rdata, SharedBuf, Tdata, Tmessage,
     },
 };
 use simple_coro::{Coro, Handle, ReadyCoro};
@@ -37,7 +37,6 @@ pub(crate) const UNKNOWN_VERSION: &str = "unknown";
 pub(crate) const SUPPORTED_VERSION: &str = "9P2000";
 
 const DEFAULT_DISPLAY_VALUE: &str = ":0";
-const DEFAULT_MSIZE: u32 = MAX_DATA_LEN as u32;
 
 /// Determine the 9p socket directory based on the USER and DISPLAY environment variables
 pub fn socket_dir() -> PathBuf {

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -82,7 +82,7 @@ where
     /// Create a new file server with a single anonymous root (name will be "") and
     /// qid of [QID_ROOT].
     pub fn new(s: S) -> Self {
-        Self::new_with_roots(s, [("".to_string(), QID_ROOT)].into_iter().collect())
+        Self::new_with_roots(s, [("/".to_string(), QID_ROOT)].into_iter().collect())
     }
 
     /// Create a new file server with the given roots for clients to attach to.

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -9,7 +9,7 @@ use crate::{
 use simple_coro::{Coro, Handle, ReadyCoro};
 use std::{
     cmp::min,
-    collections::btree_map::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     env,
     future::Future,
     ops::{Deref, DerefMut},
@@ -152,26 +152,6 @@ impl Attached {
     }
 }
 
-/// Internal metadata for known fids
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct FidMeta {
-    pub(crate) qid: u64,
-    pub(crate) is_open: bool,
-}
-
-impl FidMeta {
-    pub(crate) fn open(qid: u64) -> Self {
-        Self { qid, is_open: true }
-    }
-
-    pub(crate) fn closed(qid: u64) -> Self {
-        Self {
-            qid,
-            is_open: false,
-        }
-    }
-}
-
 /// Internal state for a running client session other than the user provided filesystem
 /// implementation. We keep this separate in order to allow for splitting borrows between this
 /// state and the filesystem impl when creating coroutine based helper methods.
@@ -215,19 +195,19 @@ impl SessionState<Attached> {
     }
 
     #[expect(clippy::type_complexity)]
-    pub(crate) fn handle_attached_walk<'a, 's: 'a>(
+    pub(crate) fn handle_attached_walk<'s>(
         &'s mut self,
         fid: u32,
         new_fid: u32,
-        wnames: &'a [String],
+        wnames: Vec<String>,
     ) -> ReadyCoro<
-        (u64, &'a str, &'a str),
+        (u64, String, String),
         Result<FileMeta>,
         Result<Rdata>,
-        impl Future<Output = Result<Rdata>> + use<'s, 'a>,
+        impl Future<Output = Result<Rdata>> + use<'s>,
     > {
         Coro::from(
-            move |handle: Handle<(u64, &'a str, &'a str), Result<FileMeta>>| async move {
+            move |handle: Handle<(u64, String, String), Result<FileMeta>>| async move {
                 if wnames.len() > MAXWELEM {
                     return Err(E_OVER_MAXWELEM.to_string());
                 } else if new_fid != fid && self.state.fids.contains_key(&new_fid) {
@@ -249,9 +229,10 @@ impl SessionState<Attached> {
 
                 let mut wqids = Vec::with_capacity(wnames.len());
                 let mut qid = fm.qid;
+                let uname = self.state.uname.clone();
 
                 for name in wnames.iter() {
-                    match handle.yield_value((qid, name, &self.state.uname)).await {
+                    match handle.yield_value((qid, name.clone(), uname.clone())).await {
                         Ok(fm) => {
                             qid = fm.qid;
                             wqids.push(fm.as_qid());
@@ -278,19 +259,19 @@ impl SessionState<Attached> {
     }
 
     #[expect(clippy::type_complexity)]
-    pub(crate) fn handle_attached_read<'a, 's: 'a>(
+    pub(crate) fn handle_attached_read<'s>(
         &'s mut self,
         fid: u32,
         offset: u64,
         count: u32,
     ) -> ReadyCoro<
-        Either<(u64, &'a str), (u64, &'a str)>, // L=read_dir R=read
+        Either<(u64, String), (u64, String)>, // L=read_dir R=read
         Vec<Stat>, // we never send or use a value in response to a read, only read-dir
         Result<Option<Rdata>>,
-        impl Future<Output = Result<Option<Rdata>>> + use<'s, 'a>,
+        impl Future<Output = Result<Option<Rdata>>> + use<'s>,
     > {
         Coro::from(
-            move |handle: Handle<Either<(u64, &'a str), (u64, &'a str)>, Vec<Stat>>| async move {
+            move |handle: Handle<Either<(u64, String), (u64, String)>, Vec<Stat>>| async move {
                 use FileType::*;
 
                 let fm = self.try_file_meta(fid)?;
@@ -301,14 +282,14 @@ impl SessionState<Attached> {
                 let stats = match fm.ty {
                     Regular | AppendOnly | Exclusive => {
                         handle
-                            .yield_value(Either::R((fm.qid, &self.state.uname)))
+                            .yield_value(Either::R((fm.qid, self.state.uname.clone())))
                             .await;
                         return Ok(None); // processing of the ReadOutcome is handled by the caller
                     }
 
                     Directory => {
                         handle
-                            .yield_value(Either::L((fm.qid, &self.state.uname)))
+                            .yield_value(Either::L((fm.qid, self.state.uname.clone())))
                             .await
                     }
                 };
@@ -563,6 +544,78 @@ where
     }
 }
 
+/// Internal metadata for known fids
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FidMeta {
+    pub(crate) qid: u64,
+    pub(crate) is_open: bool,
+}
+
+impl FidMeta {
+    pub(crate) fn open(qid: u64) -> Self {
+        Self { qid, is_open: true }
+    }
+
+    pub(crate) fn closed(qid: u64) -> Self {
+        Self {
+            qid,
+            is_open: false,
+        }
+    }
+}
+
+/// We track in-flight messages so we can associate flush messages against their target `old_tag`.
+/// https://9fans.github.io/plan9port/man/man9/flush.html
+#[derive(Debug, Default)]
+pub(crate) struct FlushHandle {
+    /// Map of message tag to queued flush tags that came in while that message was being processed
+    pending_flushes: BTreeMap<u16, Vec<u16>>,
+}
+
+impl FlushHandle {
+    /// Mark `tag` as being pending so we are able to associate future flush messages with it.
+    pub(crate) fn mark_pending(&mut self, tag: u16) {
+        self.pending_flushes.entry(tag).or_default();
+    }
+
+    /// Build a coroutine that will either request that the caller immediately respond to the
+    /// provided flush tag or chain it behind an existing flush.
+    pub(crate) fn flush_or_chain<'s>(
+        &'s mut self,
+        flush_tag: u16,
+        old_tag: u16,
+    ) -> ReadyCoro<(), (), (), impl Future<Output = ()> + use<'s>> {
+        Coro::from(move |handle: Handle<(), ()>| async move {
+            let should_flush_now =
+                flush_tag == old_tag || !self.pending_flushes.contains_key(&old_tag);
+
+            if should_flush_now {
+                handle.yield_value(()).await;
+            } else {
+                self.mark_pending(flush_tag);
+                if let Some(pending) = self.pending_flushes.get_mut(&old_tag) {
+                    pending.push(flush_tag);
+                }
+            }
+        })
+    }
+
+    /// Collapse any chained flushes for this tag into the complete list of all outstanding flush
+    /// messages that now need to have their responses sent.
+    pub(crate) fn pending_flush_tags(&mut self, tag: u16) -> Vec<u16> {
+        let mut flushed = Vec::new();
+        let mut to_flush: VecDeque<u16> =
+            self.pending_flushes.remove(&tag).unwrap_or_default().into();
+
+        while let Some(flush_tag) = to_flush.pop_front() {
+            flushed.push(flush_tag);
+            to_flush.extend(self.pending_flushes.remove(&flush_tag).unwrap_or_default());
+        }
+
+        flushed
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -732,7 +785,7 @@ mod tests {
     #[test]
     fn walk_empty_wnames_binds_new_fid_to_root() {
         let mut ss = attached_session_state();
-        let res = ss.handle_attached_walk(0, 1, &[]).resume().unwrap();
+        let res = ss.handle_attached_walk(0, 1, vec![]).resume().unwrap();
 
         match res.unwrap() {
             Rdata::Walk { wqids } => assert!(wqids.is_empty(), "expected empty wqids: {wqids:?}"),
@@ -752,7 +805,7 @@ mod tests {
         ss.state.fids.insert(1, FidMeta::closed(99));
 
         let res = ss
-            .handle_attached_walk(0, 1, &["child".to_string()])
+            .handle_attached_walk(0, 1, vec!["child".to_string()])
             .resume()
             .unwrap();
 
@@ -763,7 +816,7 @@ mod tests {
     fn walk_unknown_fid_returns_error() {
         let mut ss = attached_session_state();
         let res = ss
-            .handle_attached_walk(99, 1, &["child".to_string()])
+            .handle_attached_walk(99, 1, vec!["child".to_string()])
             .resume()
             .unwrap();
 
@@ -777,7 +830,7 @@ mod tests {
         ss.state.fids.insert(2, FidMeta::closed(1));
 
         let res = ss
-            .handle_attached_walk(2, 3, &["child".to_string()])
+            .handle_attached_walk(2, 3, vec!["child".to_string()])
             .resume()
             .unwrap();
 
@@ -790,7 +843,7 @@ mod tests {
         let wnames = vec!["child".to_string()];
         let child_qid = 42;
 
-        let mut coro = ss.handle_attached_walk(0, 1, &wnames);
+        let mut coro = ss.handle_attached_walk(0, 1, wnames);
         coro = coro.resume().unwrap_pending(|(parent_qid, name, _uname)| {
             assert_eq!(parent_qid, QID_ROOT, "should walk from root");
             assert_eq!(name, "child", "should request child name");
@@ -814,7 +867,7 @@ mod tests {
     #[test]
     fn walk_first_element_failure_returns_error() {
         let mut ss = attached_session_state();
-        let wnames = &["missing".to_string()];
+        let wnames = vec!["missing".to_string()];
 
         let mut coro = ss.handle_attached_walk(0, 1, wnames);
         coro = coro
@@ -829,7 +882,7 @@ mod tests {
     #[test]
     fn walk_partial_walk_returns_partial_qids_and_does_not_bind_new_fid() {
         let mut ss = attached_session_state();
-        let wnames = &["a".to_string(), "b".to_string()];
+        let wnames = vec!["a".to_string(), "b".to_string()];
         let a_qid = 10;
 
         let mut coro = ss.handle_attached_walk(0, 1, wnames);
@@ -861,7 +914,7 @@ mod tests {
             .map(|i| format!("n{i}"))
             .collect::<Vec<String>>();
 
-        let res = ss.handle_attached_walk(0, 1, &wnames).resume().unwrap();
+        let res = ss.handle_attached_walk(0, 1, wnames).resume().unwrap();
 
         assert_eq!(res.unwrap_err(), E_OVER_MAXWELEM);
         assert_eq!(ss.state.fids.get(&1), None, "new_fid was bound");

--- a/crates/ninep/src/sansio/server.rs
+++ b/crates/ninep/src/sansio/server.rs
@@ -584,18 +584,20 @@ impl FlushHandle {
         &'s mut self,
         flush_tag: u16,
         old_tag: u16,
-    ) -> ReadyCoro<(), (), (), impl Future<Output = ()> + use<'s>> {
+    ) -> ReadyCoro<(), (), bool, impl Future<Output = bool> + use<'s>> {
         Coro::from(move |handle: Handle<(), ()>| async move {
             let should_flush_now =
                 flush_tag == old_tag || !self.pending_flushes.contains_key(&old_tag);
 
             if should_flush_now {
                 handle.yield_value(()).await;
+                true
             } else {
                 self.mark_pending(flush_tag);
                 if let Some(pending) = self.pending_flushes.get_mut(&old_tag) {
                     pending.push(flush_tag);
                 }
+                false
             }
         })
     }

--- a/crates/ninep/src/sync/client.rs
+++ b/crates/ninep/src/sync/client.rs
@@ -26,6 +26,7 @@ pub struct Client<S> {
     state: Arc<Mutex<State>>,
     stream: Arc<Mutex<S>>,
     buf: SharedBuf,
+    msize: u32,
 }
 
 impl<S> Clone for Client<S> {
@@ -34,6 +35,7 @@ impl<S> Clone for Client<S> {
             state: Arc::clone(&self.state),
             stream: Arc::clone(&self.stream),
             buf: SharedBuf::default(),
+            msize: self.msize,
         }
     }
 }
@@ -48,6 +50,7 @@ impl<S> Client<S> {
             })),
             stream: Arc::new(Mutex::new(stream)),
             buf: SharedBuf::default(),
+            msize: MSIZE,
         }
     }
 
@@ -125,6 +128,7 @@ impl Client<TcpStream> {
 macro_rules! run_9p_coro {
     ($self:ident, $method:ident, $($arg:expr),*) => {{
         let mut state = $self.state();
+        let msize = state.msize;
         let mut coro = state.$method($($arg),*);
         loop {
             coro = match coro.resume() {
@@ -133,7 +137,7 @@ macro_rules! run_9p_coro {
                     let mut stream = $self.stream();
                     t.write_to(&mut *stream)?;
 
-                    match Rmessage::read_from(&$self.buf, &mut *stream)? {
+                    match Rmessage::read_from(msize, &$self.buf, &mut *stream)? {
                         Rmessage {
                             content: Rdata::Error { ename },
                             ..
@@ -154,7 +158,7 @@ where
         let mut stream = self.stream();
         Tmessage { tag, content }.write_to(&mut *stream)?;
 
-        match Rmessage::read_from(&self.buf, &mut *stream)? {
+        match Rmessage::read_from(self.msize, &self.buf, &mut *stream)? {
             Rmessage {
                 content: Rdata::Error { ename },
                 ..
@@ -165,7 +169,11 @@ where
 
     /// Establish our connection to the target 9p server and begin the session.
     fn connect(&mut self, uname: impl Into<String>, aname: impl Into<String>) -> io::Result<()> {
-        run_9p_coro!(self, handle_connect, uname.into(), aname.into())
+        run_9p_coro!(self, handle_connect, uname.into(), aname.into())?;
+        let msize = self.state().msize;
+        self.msize = msize;
+
+        Ok(())
     }
 
     /// Associate the given path with a new fid.

--- a/crates/ninep/src/sync/client.rs
+++ b/crates/ninep/src/sync/client.rs
@@ -45,7 +45,7 @@ impl<S> Client<S> {
         Self {
             state: Arc::new(Mutex::new(State {
                 msize: MSIZE,
-                fids: HashMap::from([(String::new(), 0)]),
+                fids: HashMap::from([("/".into(), 0)]),
                 next_fid: 1,
             })),
             stream: Arc::new(Mutex::new(stream)),

--- a/crates/ninep/src/sync/mod.rs
+++ b/crates/ninep/src/sync/mod.rs
@@ -1,7 +1,7 @@
 //! A synchronous implementation of 9p Servers and Clients
 use crate::{
     Result,
-    sansio::protocol::{NineP, SharedBuf},
+    sansio::protocol::{NineP, SharedBuf, validate_msize},
 };
 use simple_coro::CoroState;
 use std::{
@@ -25,11 +25,16 @@ pub trait SyncNineP: NineP {
     }
 
     /// Decode self from 9p protocol bytes coming from the given [SyncStream].
-    fn read_from<R: Read>(buf: &SharedBuf, r: &mut R) -> io::Result<Self> {
-        let mut coro = Self::read_9p_coro(buf);
+    fn read_from<R: Read>(msize: u32, buf: &SharedBuf, r: &mut R) -> io::Result<Self> {
+        let mut coro = Self::read_9p_coro(msize, buf);
+        let mut total_bytes: u32 = 0;
+
         loop {
             coro = match coro.resume() {
                 CoroState::Pending(c, n) => {
+                    total_bytes = total_bytes.saturating_add(n as u32);
+                    validate_msize(total_bytes, msize)?;
+
                     // SAFETY: coro is currently suspended and unable to take a reference to buf
                     let mut_buf = unsafe { buf.as_inner_mut() };
                     mut_buf.resize(n, 0);

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -6,7 +6,7 @@ use crate::{
     Result,
     fs::{FileMeta, FileType, IoUnit, Mode, Perm, Stat, WStat},
     sansio::{
-        protocol::{Data, RawStat, Rdata, Rmessage, Tdata, Tmessage},
+        protocol::{DEFAULT_MSIZE, Data, RawStat, Rdata, Rmessage, Tdata, Tmessage},
         server::{
             Attached, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_UNKNOWN_FID, Either, Session,
             SessionType, Unattached,
@@ -211,7 +211,8 @@ where
     U: SyncStream,
 {
     fn reply(&mut self, tag: u16, resp: Result<Rdata>) {
-        let r: Rmessage = (tag, resp).into();
+        let mut r: Rmessage = (tag, resp).into();
+        r.clamp(self.msize);
         let _ = r.write_to(&mut self.stream);
     }
 }
@@ -223,7 +224,7 @@ where
 {
     fn handle_connection(mut self) {
         loop {
-            let t = match Tmessage::read_from(&self.buf, &mut self.stream) {
+            let t = match Tmessage::read_from(DEFAULT_MSIZE, &self.buf, &mut self.stream) {
                 Ok(t) => t,
                 Err(_) => return,
             };
@@ -256,7 +257,7 @@ where
         use Tdata::*;
 
         loop {
-            let t = match Tmessage::read_from(&self.buf, &mut self.stream) {
+            let t = match Tmessage::read_from(self.msize, &self.buf, &mut self.stream) {
                 Ok(t) => t,
                 Err(_) => return self.clunk_and_clear(),
             };

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -518,9 +518,9 @@ mod tests {
             let mut client = SyncTestClient::new(client_stream);
             let mut server = Server::new(fs);
 
-            let handle = thread::spawn(move || {
+            let mut handle = Some(thread::spawn(move || {
                 server.new_session(server_stream).handle_connection();
-            });
+            }));
 
             // Run the test case
             let mut next_tag = 0;
@@ -540,6 +540,9 @@ mod tests {
 
                     Step::CloseStream => {
                         let _ = client.stream.shutdown(Shutdown::Both);
+                        if let Some(h) = handle.take() {
+                            h.join().expect("server thread join failed");
+                        }
                         did_shutdown = true;
                     }
                 }
@@ -550,7 +553,9 @@ mod tests {
             }
 
             // wait for the server to shutdown
-            handle.join().expect("server thread join failed");
+            if let Some(h) = handle.take() {
+                h.join().expect("server thread join failed");
+            }
         };
     }
 

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -355,8 +355,8 @@ where
             coro = match coro.resume() {
                 CoroState::Complete(res) => return res,
                 CoroState::Pending(c, (qid, name, uname)) => {
-                    let fm = self.s.walk(client_id, qid, name, uname)?;
-                    c.send(fm)
+                    let res = self.s.walk(client_id, qid, name, uname);
+                    c.send(res)
                 }
             };
         }

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -124,8 +124,20 @@ pub trait Serve9p: Send + Sync + 'static {
     fn open(&self, cid: ClientId, qid: u64, mode: Mode, uname: &str) -> Result<IoUnit>;
 
     /// Clunk a currently open file.
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn clunk(&self, cid: ClientId, qid: u64) {}
+
+    /// Handle "best effort" cancellation of an in-flight message identified by `old_tag`.
+    ///
+    /// Invoked when the server receives a flush message for a message that is still pending. As
+    /// per the 9p spec, this is a hint _only_: the server is still permitted to complete any
+    /// outstanding work and send a response to the original message being flushed.
+    ///
+    /// Clients are permitted to send multiple flush messages for the same tag. As such,
+    /// implementations of this method should be resilient to being called multiple times with the
+    /// same arguments. (The default implementation is a no-op.)
+    #[expect(unused_variables)]
+    fn flush(&self, cid: ClientId, old_tag: u16) {}
 
     /// Create a new file in the given parent directory.
     fn create(
@@ -359,9 +371,13 @@ where
                 Remove { fid } => self.handle_remove(fid),
                 Wstat { fid, stat, .. } => self.handle_wstat(fid, stat),
                 Flush { old_tag } => {
-                    flush_handle
-                        .flush_or_chain(tag, old_tag)
-                        .run_sync(|_| self.reply(tag, Ok(Rdata::Flush {})));
+                    let sent_flush = flush_handle.flush_or_chain(tag, old_tag).run_sync(|_| {
+                        self.reply(tag, Ok(Rdata::Flush {}));
+                    });
+
+                    if !sent_flush {
+                        self.s.flush(self.client_id, old_tag);
+                    }
 
                     continue;
                 }
@@ -596,6 +612,7 @@ mod tests {
     use super::*;
     use crate::{
         generate_test_suite,
+        sansio::protocol::Tmessage,
         test_utils::{SyncTestClient, TestFs, cases::Step},
     };
     use std::{net::Shutdown, os::unix::net::UnixStream, thread};
@@ -614,17 +631,29 @@ mod tests {
             }));
 
             // Run the test case
-            let mut next_tag = 0;
             let mut did_shutdown = false;
 
             for step in $case {
                 match step {
-                    Step::Request { req, resp } => {
-                        let tag = next_tag;
-                        next_tag += 1;
-
+                    Step::Request { tag, req, resp } => {
                         let rmsg = client.send_sync(tag, req).unwrap();
                         assert_eq!(rmsg, Rmessage { tag, content: resp });
+                    }
+
+                    Step::Send { tag, req } => {
+                        Tmessage::new(tag, req)
+                            .write_to(&mut client.stream)
+                            .unwrap();
+                    }
+
+                    Step::Receive { tag, resp } => {
+                        let rmsg = <Rmessage as SyncNineP>::read_from(
+                            client.msize,
+                            &client.buf,
+                            &mut client.stream,
+                        )
+                        .unwrap();
+                        assert_eq!(rmsg, Rmessage::new(tag, resp));
                     }
 
                     Step::AssertCalls { calls } => assert_eq!(recorded.take(), calls),

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -8,8 +8,8 @@ use crate::{
     sansio::{
         protocol::{DEFAULT_MSIZE, Data, RawStat, Rdata, Rmessage, Tdata, Tmessage},
         server::{
-            Attached, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_UNKNOWN_FID, Either, Session,
-            SessionType, Unattached,
+            Attached, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_ILLEGAL_CREATE_NAME, E_UNKNOWN_FID,
+            Either, Session, SessionType, Unattached,
         },
     },
     sync::{SyncNineP, SyncServerStream, SyncStream},
@@ -406,6 +406,10 @@ where
     }
 
     fn handle_create(&mut self, fid: u32, name: String, perm: Perm, mode: Mode) -> Result<Rdata> {
+        if name == "." || name == ".." {
+            return Err(E_ILLEGAL_CREATE_NAME.to_string());
+        }
+
         let fm = self.try_file_meta(fid)?;
         if fm.ty != FileType::Directory {
             return Err(E_CREATE_NON_DIR.to_string());

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -426,9 +426,15 @@ where
             return Err(E_CREATE_NON_DIR.to_string());
         }
 
-        let (fm, iounit) =
-            self.s
-                .create(self.client_id, fm.qid, &name, perm, mode, &self.state.uname)?;
+        let parent = self.s.stat(self.client_id, fm.qid, &self.state.uname)?;
+        let (fm, iounit) = self.s.create(
+            self.client_id,
+            fm.qid,
+            &name,
+            perm.apply_create_mask(parent.perms),
+            mode,
+            &self.state.uname,
+        )?;
 
         // fid is now changed to point to the newly created file rather than the parent
         let qid = fm.as_qid();

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -8,8 +8,8 @@ use crate::{
     sansio::{
         protocol::{DEFAULT_MSIZE, Data, RawStat, Rdata, Rmessage, Tdata, Tmessage},
         server::{
-            Attached, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_ILLEGAL_CREATE_NAME, E_UNKNOWN_FID,
-            Either, Session, SessionType, Unattached,
+            Attached, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_ILLEGAL_CREATE_NAME,
+            E_ILLEGAL_DIRECTORY_WRITE, E_UNKNOWN_FID, Either, Session, SessionType, Unattached,
         },
     },
     sync::{SyncNineP, SyncServerStream, SyncStream},
@@ -477,7 +477,10 @@ where
 
     fn handle_write(&mut self, fid: u32, offset: u64, data: Vec<u8>) -> Result<Rdata> {
         let fm = self.try_file_meta(fid)?;
-        if offset > u32::MAX as u64 {
+
+        if fm.ty == FileType::Directory {
+            return Err(E_ILLEGAL_DIRECTORY_WRITE.to_string());
+        } else if offset > u32::MAX as u64 {
             return Err(format!("offset too large: {offset} > {}", u32::MAX));
         }
 
@@ -494,7 +497,11 @@ where
 
     fn handle_remove(&mut self, fid: u32) -> Result<Rdata> {
         let fm = self.try_file_meta(fid)?;
-        self.s.remove(self.client_id, fm.qid, &self.state.uname)?;
+        let res = self.s.remove(self.client_id, fm.qid, &self.state.uname);
+
+        // ensure that we clunk before erroring
+        self.s.clunk(self.client_id, fm.qid);
+        res?;
 
         Ok(Rdata::Remove {})
     }

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -8,8 +8,9 @@ use crate::{
     sansio::{
         protocol::{DEFAULT_MSIZE, Data, RawStat, Rdata, Rmessage, Tdata, Tmessage},
         server::{
-            Attached, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_ILLEGAL_CREATE_NAME,
-            E_ILLEGAL_DIRECTORY_WRITE, E_UNKNOWN_FID, Either, Session, SessionType, Unattached,
+            Attached, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_FID_ALREADY_OPEN,
+            E_ILLEGAL_CREATE_NAME, E_ILLEGAL_DIRECTORY_WRITE, E_UNKNOWN_FID, Either, FidMeta,
+            Session, SessionType, Unattached,
         },
     },
     sync::{SyncNineP, SyncServerStream, SyncStream},
@@ -247,8 +248,8 @@ where
 {
     /// Explicitly clunk all
     fn clunk_and_clear(&mut self) {
-        for &qid in self.state.fids.values() {
-            self.s.clunk(self.client_id, qid);
+        for meta in self.state.fids.values() {
+            self.s.clunk(self.client_id, meta.qid);
         }
         self.state.fids.clear();
     }
@@ -366,8 +367,8 @@ where
     fn handle_clunk(&mut self, fid: u32) -> Result<Rdata> {
         match self.state.fids.entry(fid) {
             Entry::Occupied(ent) => {
-                let qid = ent.remove();
-                self.s.clunk(self.client_id, qid);
+                let meta = ent.remove();
+                self.s.clunk(self.client_id, meta.qid);
 
                 Ok(Rdata::Clunk {})
             }
@@ -394,10 +395,20 @@ where
     }
 
     fn handle_open(&mut self, fid: u32, mode: Mode) -> Result<Rdata> {
+        if self.try_fid_meta(fid)?.is_open {
+            return Err(E_FID_ALREADY_OPEN.to_string());
+        }
+
         let fm = self.try_file_meta(fid)?;
         let iounit = self
             .s
             .open(self.client_id, fm.qid, mode, &self.state.uname)?;
+
+        self.state
+            .fids
+            .get_mut(&fid)
+            .expect("known fid after try_file_meta")
+            .is_open = true;
 
         Ok(Rdata::Open {
             qid: fm.as_qid(),
@@ -421,7 +432,7 @@ where
 
         // fid is now changed to point to the newly created file rather than the parent
         let qid = fm.as_qid();
-        self.state.fids.insert(fid, fm.qid);
+        self.state.fids.insert(fid, FidMeta::open(fm.qid));
         self.qids.entry(fm.qid).or_insert(fm);
 
         Ok(Rdata::Create { qid, iounit })

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -6,7 +6,7 @@ use crate::{
     Result,
     fs::{FileMeta, FileType, IoUnit, Mode, Perm, Stat, WStat},
     sansio::{
-        protocol::{DEFAULT_MSIZE, Data, RawStat, Rdata, Rmessage, Tdata, Tmessage},
+        protocol::{DEFAULT_MSIZE, Data, RawStat, Rdata, Rmessage, SharedBuf, Tdata, Tmessage},
         server::{
             Attached, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_FID_ALREADY_OPEN,
             E_ILLEGAL_CREATE_NAME, E_ILLEGAL_DIRECTORY_WRITE, E_UNKNOWN_FID, Either, FidMeta,
@@ -23,7 +23,11 @@ use std::{
     net::TcpListener,
     os::unix::net::UnixListener,
     path::PathBuf,
-    sync::mpsc::Receiver,
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+        mpsc::{Receiver, Sender, channel},
+    },
     thread::{JoinHandle, spawn},
 };
 
@@ -38,6 +42,13 @@ pub enum ReadOutcome {
     /// No response should be sent until data is received on the provided channel
     Blocked(Receiver<Vec<u8>>),
 }
+
+/// Tri-state of the three cases we need to process in the event loop for handling an ongoing
+/// connection:
+/// 1. Tmessage from the client
+/// 2. Blocked read resolving
+/// 3. Error on the client stream (None)
+type Event = Option<Either<Tmessage, (u16, Vec<u8>)>>;
 
 #[derive(Debug)]
 struct Socket {
@@ -254,22 +265,59 @@ where
         self.state.fids.clear();
     }
 
+    fn spawn_reader(&self, tx: Sender<Event>, msize: Arc<AtomicU32>) -> Option<JoinHandle<()>>
+    where
+        U: SyncServerStream,
+    {
+        let mut stream = self.stream.try_clone().ok()?;
+        let h = spawn(move || {
+            let buf = SharedBuf::default();
+            loop {
+                let msize = msize.load(Ordering::Relaxed);
+                let t = match Tmessage::read_from(msize, &buf, &mut stream) {
+                    Ok(t) => t,
+                    Err(_) => {
+                        _ = tx.send(None);
+                        return;
+                    }
+                };
+
+                if tx.send(Some(Either::L(t))).is_err() {
+                    return;
+                }
+            }
+        });
+
+        Some(h)
+    }
+
     fn handle_connection(mut self) {
         use Tdata::*;
 
-        loop {
-            let t = match Tmessage::read_from(self.msize, &self.buf, &mut self.stream) {
-                Ok(t) => t,
-                Err(_) => return self.clunk_and_clear(),
-            };
+        let current_msize = Arc::new(AtomicU32::new(self.msize));
+        let (tx, rx) = channel();
 
-            let Tmessage { tag, content } = t;
+        let _handle = match self.spawn_reader(tx.clone(), current_msize.clone()) {
+            None => return self.clunk_and_clear(),
+            Some(h) => h,
+        };
+
+        loop {
+            let (tag, content) = match rx.recv() {
+                Ok(Some(Either::L(Tmessage { tag, content }))) => (tag, content),
+                Ok(Some(Either::R((tag, data)))) => {
+                    self.reply(tag, Ok(Rdata::Read { data: Data(data) }));
+                    continue;
+                }
+                Ok(None) | Err(_) => return self.clunk_and_clear(),
+            };
 
             let resp = match content {
                 Auth { .. } | Attach { .. } => Err(E_ALREADY_ATTACHED.into()),
                 Flush { .. } => Ok(Rdata::Flush {}),
                 Version { msize, version } => {
                     let rdata = self.handle_version(msize, version);
+                    current_msize.store(self.msize, Ordering::Relaxed);
                     self.clunk_and_clear();
 
                     Ok(rdata)
@@ -289,11 +337,14 @@ where
                     perm,
                     mode,
                 } => self.handle_create(fid, name, Perm::new(perm), Mode::new(mode)),
-                Read { fid, offset, count } => match self.handle_read(tag, fid, offset, count) {
-                    Ok(Some(resp)) => Ok(resp),
-                    Err(err) => Err(err),
-                    Ok(None) => continue,
-                },
+                Read { fid, offset, count } => {
+                    let res = self.handle_read(tag, fid, offset, count, &tx);
+                    match res {
+                        Ok(Some(resp)) => Ok(resp),
+                        Err(err) => Err(err),
+                        Ok(None) => continue,
+                    }
+                }
                 Write { fid, offset, data } => self.handle_write(fid, offset, data.0),
                 Remove { fid } => self.handle_remove(fid),
                 Wstat { fid, stat, .. } => self.handle_wstat(fid, stat),
@@ -461,6 +512,7 @@ where
         fid: u32,
         offset: u64,
         count: u32,
+        tx: &Sender<Event>,
     ) -> Result<Option<Rdata>> {
         let cid = self.client_id;
         let coro = self.session_state.handle_attached_read(fid, offset, count);
@@ -477,12 +529,10 @@ where
                 match outcome {
                     ReadOutcome::Immediate(data) => Ok(Some(Rdata::Read { data: Data(data) })),
                     ReadOutcome::Blocked(chan) => {
-                        let mut stream = self.stream.try_clone()?;
+                        let tx = tx.clone();
                         spawn(move || {
                             let data = chan.recv().unwrap_or_default();
-                            let resp = Ok(Rdata::Read { data: Data(data) });
-                            let r: Rmessage = (tag, resp).into();
-                            let _ = r.write_to(&mut stream);
+                            _ = tx.send(Some(Either::R((tag, data))));
                         });
 
                         Ok(None)

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -112,7 +112,13 @@ pub trait Serve9p: Send + Sync + 'static {
     /// (of file type [Directory][FileType::Directory]) to a target `child`. This method is called
     /// for each element of that path in order, stopping either when the target is reached or some
     /// element of the path returns an error.
-    fn walk(&self, cid: ClientId, parent_qid: u64, child: &str, uname: &str) -> Result<FileMeta>;
+    fn walk_one(
+        &self,
+        cid: ClientId,
+        parent_qid: u64,
+        child: &str,
+        uname: &str,
+    ) -> Result<FileMeta>;
 
     /// Open an existing file for subsequent I/O via [read](Serve9p::read) and
     /// [write](Serve9p::write) messages.
@@ -496,7 +502,7 @@ where
             coro = match coro.resume() {
                 CoroState::Complete(res) => return res,
                 CoroState::Pending(c, (qid, name, uname)) => {
-                    let res = self.s.walk(client_id, qid, &name, &uname);
+                    let res = self.s.walk_one(client_id, qid, &name, &uname);
                     c.send(res)
                 }
             };

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -106,40 +106,60 @@ pub trait Serve9p: Send + Sync + 'static {
     //     Err("authentication not required".to_string())
     // }
 
-    /// Lookup a child node under a known parent directory by name.
+    /// Lookup the [FileMeta] for `child` under the directory represented by `parent_qid`.
     ///
-    /// `9p` Twalk messages received by the server will specify a full path from a known parent
-    /// to a target child. This method is called for each element of that path in sequence in order,
-    /// stopping either when the target is reached or some element of the path returns an error.
-    ///
-    /// [Server] will ensure that this method is only called for known parents who have previously
-    /// been identified has having [FileType::Directory].
+    /// `9p` walk messages received by the [Server] will specify a full path from a known parent
+    /// (of file type [Directory][FileType::Directory]) to a target `child`. This method is called
+    /// for each element of that path in order, stopping either when the target is reached or some
+    /// element of the path returns an error.
     fn walk(&self, cid: ClientId, parent_qid: u64, child: &str, uname: &str) -> Result<FileMeta>;
 
-    /// Open an existing file in the requested mode for subsequent I/O via [read](Serve9p::read) and
-    /// [write](Serve9p::write) calls.
+    /// Open an existing file for subsequent I/O via [read](Serve9p::read) and
+    /// [write](Serve9p::write) messages.
+    ///
+    /// [Server] calls this only for known, currently-closed fids. On success, [Server] marks the
+    /// fid as open with further `walk`, `open` and `create` messages using that fid being rejected
+    /// until the fid is clunked (either [explicitly](Serve9p::clunk) or via session reset).
     ///
     /// The return of this method is an [IoUnit] used to inform the client of the maximum number of
-    /// bytes that will be supported per read/write call on this resource.
+    /// bytes that will be supported per read/write call on this resource. An `Err` should be
+    /// returned if access is denied, mode is unsupported, or the target cannot be opened.
     fn open(&self, cid: ClientId, qid: u64, mode: Mode, uname: &str) -> Result<IoUnit>;
 
-    /// Clunk a currently open file.
+    /// Release client specific server-side resources associated with with provided qid.
+    ///
+    /// [Server] calls this when a fid is discarded (i.e. [clunk](Serve9p::clunk), successful or
+    /// failed [remove](Serve9p::remove), `version` session reset, or connection close). It is
+    /// possible that the provided qid may represent a file that was never opened for I/O in this
+    /// session.
+    ///
+    /// Implementations should be resilient to repeated calls for the same qid. (The default
+    /// implementation is a no-op.)
     #[expect(unused_variables)]
     fn clunk(&self, cid: ClientId, qid: u64) {}
 
     /// Handle "best effort" cancellation of an in-flight message identified by `old_tag`.
     ///
-    /// Invoked when the server receives a flush message for a message that is still pending. As
-    /// per the 9p spec, this is a hint _only_: the server is still permitted to complete any
+    /// Invoked when the server receives a `flush` message for a message that is still pending. As
+    /// per the `9p` spec, this is a hint _only_: the server is still permitted to complete any
     /// outstanding work and send a response to the original message being flushed.
     ///
-    /// Clients are permitted to send multiple flush messages for the same tag. As such,
+    /// Clients are permitted to send multiple `flush` messages for the same tag. As such,
     /// implementations of this method should be resilient to being called multiple times with the
     /// same arguments. (The default implementation is a no-op.)
     #[expect(unused_variables)]
     fn flush(&self, cid: ClientId, old_tag: u16) {}
 
-    /// Create a new file in the given parent directory.
+    /// Create a new entry in `parent`, returning its [metadata][FileMeta] and [IoUnit].
+    ///
+    /// [Server] ensures that this method is only called when the target fid is known, pointing to
+    /// a directory and not currently open for I/O. [Server] also handles rejecting `.` and `..` as
+    /// invalid entry names, and applying `9p` permission masking before this call, meaning `perm`
+    /// is already normalized against the parent directory's permissions.
+    ///
+    /// On success, [Server] rebinds the creating fid to the qid found in the returned [FileMeta]
+    /// and marks it as open for I/O. Implementations should return `Err` if `name` already exists
+    /// or creation cannot be completed for any reason.
     fn create(
         &self,
         cid: ClientId,
@@ -150,7 +170,16 @@ pub trait Serve9p: Send + Sync + 'static {
         uname: &str,
     ) -> Result<(FileMeta, IoUnit)>;
 
-    /// Read `count` bytes from the requested file starting from the given `offset`.
+    /// Read up to `count` bytes from `qid` starting at `offset`.
+    ///
+    /// [Server] calls this for non-directory files only; directory reads are routed through
+    /// [read_dir](Serve9p::read_dir). The returned [ReadOutcome] controls how the response is sent
+    /// to the client: [Immediate][ReadOutcome::Immediate] is send directly to the client on
+    /// completion of this method, while [blocked][ReadOutcome::Blocked] spawns a background task
+    /// to wait for data to become available before responding.
+    ///
+    /// Implementations should tolerate flush hints while blocked (see [flush](Serve9p::flush)) and
+    /// must respect client specified byte `count` limit.
     fn read(
         &self,
         cid: ClientId,
@@ -160,10 +189,24 @@ pub trait Serve9p: Send + Sync + 'static {
         uname: &str,
     ) -> Result<ReadOutcome>;
 
-    /// List the contents of the given directory.
+    /// List [Stat] entries for a given client's view of a directory.
+    ///
+    /// [Server] calls this for `read` requests on a directory, handling read offsets and count
+    /// limits automatically (unlike [read][Serve9p::read]). Implementations should return the full
+    /// logical entry list in stable order for the client's view of the directory (as identified by
+    /// `cid`).
     fn read_dir(&self, cid: ClientId, qid: u64, uname: &str) -> Result<Vec<Stat>>;
 
-    /// Write the given `data` to the requested file starting at `offset`
+    /// Write the provided `data` to the file denoted by `qid` starting at the provided byte
+    /// `offset`.
+    ///
+    /// [Server] ensures that this is only called for entries of type [file][FileType::Regular].
+    ///
+    /// Returns the number of bytes written. Returning `n < data.len()` is permitted and is treated
+    /// as a short write which may result in further `write` messages from the client.
+    ///
+    /// Implementations are required to enforce mode/permission rules and return `Err` when writes
+    /// are not permitted.
     fn write(
         &self,
         cid: ClientId,
@@ -173,13 +216,24 @@ pub trait Serve9p: Send + Sync + 'static {
         uname: &str,
     ) -> Result<usize>;
 
-    /// Remove the requested file from the filesystem.
+    /// Remove the entry identified by `qid` from the filesystem.
+    ///
+    /// [Server] calls this for each `remove` request received from the client followed by
+    /// [clunking][Serve9p::clunk] the `qid` regardless of success. Implementations should return
+    /// `Err` when removal is not permitted or fails.
     fn remove(&self, cid: ClientId, qid: u64, uname: &str) -> Result<()>;
 
-    /// Request a machine independent "directory entry" for the given resource.
+    /// Fetch the current [Stat] metadata for the filesystem entry identified by `qid`.
+    ///
+    /// [Server] uses this for client `stat` messages and internally for [create][Serve9p::create]
+    /// permission masking against parent directories.
     fn stat(&self, cid: ClientId, qid: u64, uname: &str) -> Result<Stat>;
 
-    /// Attempt to set the machine independent "directory entry" for the given resource.
+    /// Apply a [WStat] update to the [Stat] of the filesystem entry identified by `qid`.
+    ///
+    /// [Server] validates fid/qid identity before calling this and passes a [WStat] containing
+    /// only caller-requested field changes. Implementations must enforce authorization and
+    /// supported field semantics, returning `Err` for invalid or disallowed changes.
     fn write_stat(&self, cid: ClientId, qid: u64, wstat: WStat, uname: &str) -> Result<()>;
 }
 

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -499,3 +499,60 @@ where
         Ok(Rdata::Remove {})
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        generate_test_suite,
+        test_utils::{SyncTestClient, TestFs, cases::Step},
+    };
+    use std::{net::Shutdown, os::unix::net::UnixStream, thread};
+
+    macro_rules! run_one {
+        ($case:expr) => {
+            // Setup the client and server
+            let fs = TestFs::default();
+            let recorded = fs.calls();
+            let (client_stream, server_stream) = UnixStream::pair().unwrap();
+            let mut client = SyncTestClient::new(client_stream);
+            let mut server = Server::new(fs);
+
+            let handle = thread::spawn(move || {
+                server.new_session(server_stream).handle_connection();
+            });
+
+            // Run the test case
+            let mut next_tag = 0;
+            let mut did_shutdown = false;
+
+            for step in $case {
+                match step {
+                    Step::Request { req, resp } => {
+                        let tag = next_tag;
+                        next_tag += 1;
+
+                        let rmsg = client.send_sync(tag, req).unwrap();
+                        assert_eq!(rmsg, Rmessage { tag, content: resp });
+                    }
+
+                    Step::AssertCalls { calls } => assert_eq!(recorded.take(), calls),
+
+                    Step::CloseStream => {
+                        let _ = client.stream.shutdown(Shutdown::Both);
+                        did_shutdown = true;
+                    }
+                }
+            }
+
+            if !did_shutdown {
+                let _ = client.stream.shutdown(Shutdown::Both);
+            }
+
+            // wait for the server to shutdown
+            handle.join().expect("server thread join failed");
+        };
+    }
+
+    generate_test_suite!(sync, run_one);
+}

--- a/crates/ninep/src/sync/server.rs
+++ b/crates/ninep/src/sync/server.rs
@@ -10,14 +10,13 @@ use crate::{
         server::{
             Attached, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_FID_ALREADY_OPEN,
             E_ILLEGAL_CREATE_NAME, E_ILLEGAL_DIRECTORY_WRITE, E_UNKNOWN_FID, Either, FidMeta,
-            Session, SessionType, Unattached,
+            FlushHandle, Session, SessionType, Unattached,
         },
     },
     sync::{SyncNineP, SyncServerStream, SyncStream},
 };
 use simple_coro::CoroState;
 use std::{
-    collections::btree_map::Entry,
     fs,
     mem::size_of,
     net::TcpListener,
@@ -265,6 +264,12 @@ where
         self.state.fids.clear();
     }
 
+    fn flush_waiters(&mut self, flush_handle: &mut FlushHandle, tag: u16) {
+        for tag in flush_handle.pending_flush_tags(tag) {
+            self.reply(tag, Ok(Rdata::Flush {}));
+        }
+    }
+
     fn spawn_reader(&self, tx: Sender<Event>, msize: Arc<AtomicU32>) -> Option<JoinHandle<()>>
     where
         U: SyncServerStream,
@@ -296,6 +301,7 @@ where
 
         let current_msize = Arc::new(AtomicU32::new(self.msize));
         let (tx, rx) = channel();
+        let mut flush_handle = FlushHandle::default();
 
         let _handle = match self.spawn_reader(tx.clone(), current_msize.clone()) {
             None => return self.clunk_and_clear(),
@@ -307,14 +313,18 @@ where
                 Ok(Some(Either::L(Tmessage { tag, content }))) => (tag, content),
                 Ok(Some(Either::R((tag, data)))) => {
                     self.reply(tag, Ok(Rdata::Read { data: Data(data) }));
+                    self.flush_waiters(&mut flush_handle, tag);
                     continue;
                 }
                 Ok(None) | Err(_) => return self.clunk_and_clear(),
             };
 
+            if !matches!(content, Flush { .. }) {
+                flush_handle.mark_pending(tag);
+            }
+
             let resp = match content {
                 Auth { .. } | Attach { .. } => Err(E_ALREADY_ATTACHED.into()),
-                Flush { .. } => Ok(Rdata::Flush {}),
                 Version { msize, version } => {
                     let rdata = self.handle_version(msize, version);
                     current_msize.store(self.msize, Ordering::Relaxed);
@@ -348,9 +358,17 @@ where
                 Write { fid, offset, data } => self.handle_write(fid, offset, data.0),
                 Remove { fid } => self.handle_remove(fid),
                 Wstat { fid, stat, .. } => self.handle_wstat(fid, stat),
+                Flush { old_tag } => {
+                    flush_handle
+                        .flush_or_chain(tag, old_tag)
+                        .run_sync(|_| self.reply(tag, Ok(Rdata::Flush {})));
+
+                    continue;
+                }
             };
 
             self.reply(tag, resp);
+            self.flush_waiters(&mut flush_handle, tag);
         }
     }
 
@@ -402,13 +420,13 @@ where
         let client_id = self.client_id;
         let mut coro = self
             .session_state
-            .handle_attached_walk(fid, new_fid, &wnames);
+            .handle_attached_walk(fid, new_fid, wnames);
 
         loop {
             coro = match coro.resume() {
                 CoroState::Complete(res) => return res,
                 CoroState::Pending(c, (qid, name, uname)) => {
-                    let res = self.s.walk(client_id, qid, name, uname);
+                    let res = self.s.walk(client_id, qid, &name, &uname);
                     c.send(res)
                 }
             };
@@ -416,14 +434,13 @@ where
     }
 
     fn handle_clunk(&mut self, fid: u32) -> Result<Rdata> {
-        match self.state.fids.entry(fid) {
-            Entry::Occupied(ent) => {
-                let meta = ent.remove();
+        match self.state.fids.remove(&fid) {
+            Some(meta) => {
                 self.s.clunk(self.client_id, meta.qid);
 
                 Ok(Rdata::Clunk {})
             }
-            Entry::Vacant(_) => Err(E_UNKNOWN_FID.to_string()),
+            None => Err(E_UNKNOWN_FID.to_string()),
         }
     }
 
@@ -521,11 +538,11 @@ where
         match coro.resume() {
             CoroState::Complete(res) => res,
             CoroState::Pending(c, Either::L((qid, uname))) => {
-                let stats = self.s.read_dir(cid, qid, uname)?;
+                let stats = self.s.read_dir(cid, qid, &uname)?;
                 c.send(stats).resume().unwrap()
             }
             CoroState::Pending(_, Either::R((qid, uname))) => {
-                let outcome = self.s.read(cid, qid, offset, count, uname)?;
+                let outcome = self.s.read(cid, qid, offset, count, &uname)?;
                 match outcome {
                     ReadOutcome::Immediate(data) => Ok(Some(Rdata::Read { data: Data(data) })),
                     ReadOutcome::Blocked(chan) => {

--- a/crates/ninep/src/test_utils/cases.rs
+++ b/crates/ninep/src/test_utils/cases.rs
@@ -131,6 +131,7 @@ macro_rules! generate_test_suite {
             stat_unknown_fid_returns_error,
             create_in_directory_returns_rcreate,
             create_with_dot_name_returns_error,
+            create_with_double_dot_name_returns_error,
             create_on_non_directory_returns_error,
             remove_known_fid_returns_rremove,
             blocked_read_delivers_response_later,
@@ -552,6 +553,25 @@ pub(crate) fn create_with_dot_name_returns_error() -> TestCase {
             Tdata::Create {
                 fid: 0,
                 name: ".".to_string(),
+                perm: perm.bits(),
+                mode: 0,
+            },
+            E_ILLEGAL_CREATE_NAME,
+        ),
+        Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn create_with_double_dot_name_returns_error() -> TestCase {
+    let perm = Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ;
+
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::err(
+            Tdata::Create {
+                fid: 0,
+                name: "..".to_string(),
                 perm: perm.bits(),
                 mode: 0,
             },

--- a/crates/ninep/src/test_utils/cases.rs
+++ b/crates/ninep/src/test_utils/cases.rs
@@ -1,0 +1,18 @@
+use crate::{
+    sansio::protocol::{Rdata, Tdata},
+    test_utils::Call,
+};
+
+/// A test case to be run against a 9p server.
+pub(crate) type TestCase = Vec<Step>;
+
+/// A single step within a larger test case.
+///
+/// Corresponds to an action to take and possibly a paired assertion.
+#[derive(Debug)]
+#[expect(clippy::large_enum_variant)]
+pub(crate) enum Step {
+    Request { req: Tdata, resp: Rdata },
+    AssertCalls { calls: Vec<Call> },
+    CloseStream,
+}

--- a/crates/ninep/src/test_utils/cases.rs
+++ b/crates/ninep/src/test_utils/cases.rs
@@ -1,6 +1,10 @@
 use crate::{
-    sansio::protocol::{Rdata, Tdata},
-    test_utils::Call,
+    fs::Mode,
+    sansio::{
+        protocol::{DEFAULT_MSIZE, Qid, Rdata, Tdata},
+        server::{AFID_NO_AUTH, E_NO_VERSION_MESSAGE, SUPPORTED_VERSION},
+    },
+    test_utils::{Call, ROOT_QID},
 };
 
 /// A test case to be run against a 9p server.
@@ -15,4 +19,103 @@ pub(crate) enum Step {
     Request { req: Tdata, resp: Rdata },
     AssertCalls { calls: Vec<Call> },
     CloseStream,
+}
+
+impl Step {
+    fn version_req(msize: u32) -> Step {
+        Step::Request {
+            req: Tdata::Version {
+                msize,
+                version: SUPPORTED_VERSION.to_string(),
+            },
+            resp: Rdata::Version {
+                msize,
+                version: SUPPORTED_VERSION.to_string(),
+            },
+        }
+    }
+
+    fn attach_req() -> Step {
+        Step::Request {
+            req: Tdata::Attach {
+                fid: 0,
+                afid: AFID_NO_AUTH,
+                uname: "user".to_string(),
+                aname: "/".to_string(),
+            },
+            resp: Rdata::Attach {
+                aqid: Qid {
+                    ty: Mode::DIR.bits(),
+                    version: 0,
+                    path: ROOT_QID,
+                },
+            },
+        }
+    }
+}
+
+/// Helper for generating shared behavioural tests of both the sync and tokio server
+/// implementations.
+#[macro_export]
+macro_rules! generate_test_suite {
+    // Public entrypoint used by sync/tokio test modules.
+    //
+    // As new cases are added to the suite below, they MUST be added here in order to actually be
+    // run as part of the sync/tokio test suites.
+    ($mode:ident, $run_one:ident) => {
+        generate_test_suite!(
+            @cases $mode, $run_one;
+            // Test cases
+            version_sets_negotiated_msize,
+            attach_before_version_returns_error,
+            attach_after_version_succeeds,
+        );
+    };
+
+    // generate sync test suite
+    (@cases sync, $run_one:ident; $($case:ident),+ $(,)?) => {
+        $(
+            #[test]
+            fn $case() { $run_one!($crate::test_utils::cases::$case()); }
+        )+
+    };
+
+    // generate tokio test suite
+    (@cases tokio, $run_one:ident; $($case:ident),+ $(,)?) => {
+        $(
+            #[tokio::test]
+            async fn $case() { $run_one!($crate::test_utils::cases::$case()); }
+        )+
+    };
+}
+
+// Test cases for use with the generate_test_suite macro above
+
+pub(crate) fn version_sets_negotiated_msize() -> TestCase {
+    vec![Step::version_req(DEFAULT_MSIZE / 2)]
+}
+
+pub(crate) fn attach_before_version_returns_error() -> TestCase {
+    vec![
+        Step::Request {
+            req: Tdata::Attach {
+                fid: 0,
+                afid: AFID_NO_AUTH,
+                uname: "user".to_string(),
+                aname: "/".to_string(),
+            },
+            resp: Rdata::Error {
+                ename: E_NO_VERSION_MESSAGE.to_string(),
+            },
+        },
+        Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn attach_after_version_succeeds() -> TestCase {
+    vec![
+        Step::version_req(DEFAULT_MSIZE / 2),
+        Step::attach_req(),
+        Step::AssertCalls { calls: vec![] },
+    ]
 }

--- a/crates/ninep/src/test_utils/cases.rs
+++ b/crates/ninep/src/test_utils/cases.rs
@@ -70,12 +70,10 @@ impl Step {
         }
     }
 
-    fn err(req: Tdata, msg: &str) -> Step {
+    fn err(req: Tdata, msg: impl Into<String>) -> Step {
         Step::Request {
             req,
-            resp: Rdata::Error {
-                ename: msg.to_string(),
-            },
+            resp: Rdata::Error { ename: msg.into() },
         }
     }
 }
@@ -108,33 +106,34 @@ macro_rules! generate_test_suite {
         generate_test_suite!(
             @cases $mode, $run_one;
             // Test cases
-            version_sets_negotiated_msize,
-            attach_before_version_returns_error,
             attach_after_version_succeeds,
-            duplicate_attach_returns_error,
-            version_while_attached_clunks_all_open_fids,
-            connection_close_clunks_all_open_fids,
-            flush_returns_rflush,
-            walk_to_known_child_returns_qids,
-            walk_first_element_missing_returns_error,
-            walk_partial_returns_partial_qids,
-            walk_unknown_fid_returns_error,
+            attach_before_version_returns_error,
+            blocked_read_delivers_response_later,
             clunk_known_fid_returns_rclunk_and_calls_serve9p,
             clunk_unknown_fid_returns_error,
-            open_known_fid_returns_ropen,
-            open_unknown_fid_returns_error,
-            read_file_returns_data,
-            read_dir_returns_serialized_stats,
-            write_to_file_returns_byte_count,
-            write_with_oversized_offset_returns_error,
-            stat_known_fid_returns_rstat,
-            stat_unknown_fid_returns_error,
+            connection_close_clunks_all_open_fids,
             create_in_directory_returns_rcreate,
+            create_on_non_directory_returns_error,
             create_with_dot_name_returns_error,
             create_with_double_dot_name_returns_error,
-            create_on_non_directory_returns_error,
+            duplicate_attach_returns_error,
+            flush_returns_rflush,
+            open_known_fid_returns_ropen,
+            open_unknown_fid_returns_error,
+            read_dir_returns_serialized_stats,
+            read_file_returns_data,
             remove_known_fid_returns_rremove,
-            blocked_read_delivers_response_later,
+            stat_known_fid_returns_rstat,
+            stat_unknown_fid_returns_error,
+            version_sets_negotiated_msize,
+            version_while_attached_clunks_all_open_fids,
+            walk_first_element_missing_returns_error,
+            walk_partial_returns_partial_qids,
+            walk_to_known_child_returns_qids,
+            walk_unknown_fid_returns_error,
+            write_to_directory_returns_error,
+            write_to_file_returns_byte_count,
+            write_with_oversized_offset_returns_error,
         );
     };
 
@@ -172,17 +171,15 @@ pub(crate) fn version_sets_negotiated_msize() -> TestCase {
 
 pub(crate) fn attach_before_version_returns_error() -> TestCase {
     vec![
-        Step::Request {
-            req: Tdata::Attach {
+        Step::err(
+            Tdata::Attach {
                 fid: 0,
                 afid: AFID_NO_AUTH,
                 uname: "user".to_string(),
                 aname: "/".to_string(),
             },
-            resp: Rdata::Error {
-                ename: E_NO_VERSION_MESSAGE.to_string(),
-            },
-        },
+            E_NO_VERSION_MESSAGE,
+        ),
         Step::AssertCalls { calls: vec![] },
     ]
 }
@@ -466,16 +463,14 @@ pub(crate) fn write_with_oversized_offset_returns_error() -> TestCase {
         Step::version_req(),
         Step::attach_req(),
         Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
-        Step::Request {
-            req: Tdata::Write {
+        Step::err(
+            Tdata::Write {
                 fid: 1,
                 offset,
                 data: Data(vec![1]),
             },
-            resp: Rdata::Error {
-                ename: format!("offset too large: {offset} > {}", u32::MAX),
-            },
-        },
+            format!("offset too large: {offset} > {}", u32::MAX),
+        ),
         Step::AssertCalls {
             calls: vec![Call::walk(ClientId(0), ROOT_QID, "hello", "user")],
         },
@@ -616,6 +611,7 @@ pub(crate) fn remove_known_fid_returns_rremove() -> TestCase {
             calls: vec![
                 Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
                 Call::remove(ClientId(0), HELLO_QID, "user"),
+                Call::clunk(ClientId(0), HELLO_QID),
             ],
         },
     ]
@@ -642,5 +638,21 @@ pub(crate) fn blocked_read_delivers_response_later() -> TestCase {
                 Call::read(ClientId(0), BLOCKED_QID, 0, 4096, "user"),
             ],
         },
+    ]
+}
+
+pub(crate) fn write_to_directory_returns_error() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::err(
+            Tdata::Write {
+                fid: 0,
+                offset: 0,
+                data: Data(vec![1]),
+            },
+            "illegal write to directory",
+        ),
+        Step::AssertCalls { calls: vec![] },
     ]
 }

--- a/crates/ninep/src/test_utils/cases.rs
+++ b/crates/ninep/src/test_utils/cases.rs
@@ -21,16 +21,23 @@ pub(crate) type TestCase = Vec<Step>;
 ///
 /// Corresponds to an action to take and possibly a paired assertion.
 #[derive(Debug)]
-#[expect(clippy::large_enum_variant)]
 pub(crate) enum Step {
-    Request { req: Tdata, resp: Rdata },
+    /// Blocking request -> assert expected response
+    Request { tag: u16, req: Tdata, resp: Rdata },
+    /// Submit request without waiting for response
+    Send { tag: u16, req: Tdata },
+    /// Assert expected response
+    Receive { tag: u16, resp: Rdata },
+    /// Assert state of TestFs method calls
     AssertCalls { calls: Vec<Call> },
+    /// Close client connection stream
     CloseStream,
 }
 
 impl Step {
-    fn version_req() -> Step {
+    fn version_req(tag: u16) -> Step {
         Step::Request {
+            tag,
             req: Tdata::Version {
                 msize: DEFAULT_MSIZE,
                 version: SUPPORTED_VERSION.to_string(),
@@ -42,8 +49,9 @@ impl Step {
         }
     }
 
-    fn attach_req() -> Step {
+    fn attach_req(tag: u16) -> Step {
         Step::Request {
+            tag,
             req: Tdata::Attach {
                 fid: 0,
                 afid: AFID_NO_AUTH,
@@ -60,8 +68,9 @@ impl Step {
         }
     }
 
-    fn walk_req(fid: u32, new_fid: u32, wnames: Vec<&str>, wqids: Vec<Qid>) -> Step {
+    fn walk_req(tag: u16, fid: u32, new_fid: u32, wnames: Vec<&str>, wqids: Vec<Qid>) -> Step {
         Step::Request {
+            tag,
             req: Tdata::Walk {
                 fid,
                 new_fid,
@@ -71,8 +80,9 @@ impl Step {
         }
     }
 
-    fn err(req: Tdata, msg: impl Into<String>) -> Step {
+    fn err(tag: u16, req: Tdata, msg: impl Into<String>) -> Step {
         Step::Request {
+            tag,
             req,
             resp: Rdata::Error { ename: msg.into() },
         }
@@ -120,6 +130,7 @@ macro_rules! generate_test_suite {
             create_with_double_dot_name_returns_error,
             duplicate_attach_returns_error,
             flush_returns_rflush,
+            flush_pending_request_calls_filesystem_flush,
             flush_waits_for_blocked_read,
             open_known_fid_returns_ropen,
             open_open_fid_returns_error,
@@ -164,6 +175,7 @@ macro_rules! generate_test_suite {
 
 pub(crate) fn version_sets_negotiated_msize() -> TestCase {
     vec![Step::Request {
+        tag: 0,
         req: Tdata::Version {
             msize: DEFAULT_MSIZE / 2,
             version: SUPPORTED_VERSION.to_string(),
@@ -178,6 +190,7 @@ pub(crate) fn version_sets_negotiated_msize() -> TestCase {
 pub(crate) fn attach_before_version_returns_error() -> TestCase {
     vec![
         Step::err(
+            0,
             Tdata::Attach {
                 fid: 0,
                 afid: AFID_NO_AUTH,
@@ -192,17 +205,18 @@ pub(crate) fn attach_before_version_returns_error() -> TestCase {
 
 pub(crate) fn attach_after_version_succeeds() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::AssertCalls { calls: vec![] },
     ]
 }
 
 pub(crate) fn duplicate_attach_returns_error() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::err(
+            2,
             Tdata::Attach {
                 fid: 1,
                 afid: AFID_NO_AUTH,
@@ -217,17 +231,18 @@ pub(crate) fn duplicate_attach_returns_error() -> TestCase {
 
 pub(crate) fn version_while_attached_clunks_all_open_fids() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Open { fid: 1, mode: 0 },
             resp: Rdata::Open {
                 qid: file_qid(HELLO_QID),
                 iounit: TEST_IOUNIT,
             },
         },
-        Step::version_req(),
+        Step::version_req(4),
         Step::AssertCalls {
             calls: vec![
                 Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
@@ -241,10 +256,11 @@ pub(crate) fn version_while_attached_clunks_all_open_fids() -> TestCase {
 
 pub(crate) fn connection_close_clunks_all_open_fids() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Open { fid: 1, mode: 0 },
             resp: Rdata::Open {
                 qid: file_qid(HELLO_QID),
@@ -265,9 +281,10 @@ pub(crate) fn connection_close_clunks_all_open_fids() -> TestCase {
 
 pub(crate) fn flush_returns_rflush() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::Request {
+            tag: 2,
             req: Tdata::Flush { old_tag: 123 },
             resp: Rdata::Flush {},
         },
@@ -277,10 +294,11 @@ pub(crate) fn flush_returns_rflush() -> TestCase {
 
 pub(crate) fn flush_waits_for_blocked_read() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["blocked"], vec![file_qid(BLOCKED_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["blocked"], vec![file_qid(BLOCKED_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Read {
                 fid: 1,
                 offset: 0,
@@ -291,6 +309,7 @@ pub(crate) fn flush_waits_for_blocked_read() -> TestCase {
             },
         },
         Step::Request {
+            tag: 4,
             req: Tdata::Flush { old_tag: 3 },
             resp: Rdata::Flush {},
         },
@@ -303,11 +322,48 @@ pub(crate) fn flush_waits_for_blocked_read() -> TestCase {
     ]
 }
 
+pub(crate) fn flush_pending_request_calls_filesystem_flush() -> TestCase {
+    vec![
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["blocked"], vec![file_qid(BLOCKED_QID)]),
+        Step::Send {
+            tag: 3,
+            req: Tdata::Read {
+                fid: 1,
+                offset: 0,
+                count: 4096,
+            },
+        },
+        Step::Send {
+            tag: 4,
+            req: Tdata::Flush { old_tag: 3 },
+        },
+        Step::Receive {
+            tag: 3,
+            resp: Rdata::Read {
+                data: Data(BLOCKED_CONTENT.to_vec()),
+            },
+        },
+        Step::Receive {
+            tag: 4,
+            resp: Rdata::Flush {},
+        },
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "blocked", "user"),
+                Call::read(ClientId(0), BLOCKED_QID, 0, 4096, "user"),
+                Call::flush(ClientId(0), 3),
+            ],
+        },
+    ]
+}
+
 pub(crate) fn walk_to_known_child_returns_qids() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::AssertCalls {
             calls: vec![Call::walk(ClientId(0), ROOT_QID, "hello", "user")],
         },
@@ -316,9 +372,10 @@ pub(crate) fn walk_to_known_child_returns_qids() -> TestCase {
 
 pub(crate) fn walk_first_element_missing_returns_error() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::err(
+            2,
             Tdata::Walk {
                 fid: 0,
                 new_fid: 1,
@@ -334,9 +391,15 @@ pub(crate) fn walk_first_element_missing_returns_error() -> TestCase {
 
 pub(crate) fn walk_partial_returns_partial_qids() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["subdir", "missing"], vec![dir_qid(SUBDIR_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(
+            2,
+            0,
+            1,
+            vec!["subdir", "missing"],
+            vec![dir_qid(SUBDIR_QID)],
+        ),
         Step::AssertCalls {
             calls: vec![
                 Call::walk(ClientId(0), ROOT_QID, "subdir", "user"),
@@ -348,10 +411,11 @@ pub(crate) fn walk_partial_returns_partial_qids() -> TestCase {
 
 pub(crate) fn walk_open_fid_returns_error_after_open() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Open { fid: 1, mode: 0 },
             resp: Rdata::Open {
                 qid: file_qid(HELLO_QID),
@@ -359,6 +423,7 @@ pub(crate) fn walk_open_fid_returns_error_after_open() -> TestCase {
             },
         },
         Step::err(
+            4,
             Tdata::Walk {
                 fid: 1,
                 new_fid: 2,
@@ -379,9 +444,10 @@ pub(crate) fn walk_open_fid_returns_error_after_create() -> TestCase {
     let perm = Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ;
 
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::Request {
+            tag: 2,
             req: Tdata::Create {
                 fid: 0,
                 name: "new.txt".to_string(),
@@ -394,6 +460,7 @@ pub(crate) fn walk_open_fid_returns_error_after_create() -> TestCase {
             },
         },
         Step::err(
+            3,
             Tdata::Walk {
                 fid: 0,
                 new_fid: 1,
@@ -419,9 +486,10 @@ pub(crate) fn walk_open_fid_returns_error_after_create() -> TestCase {
 
 pub(crate) fn walk_unknown_fid_returns_error() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::err(
+            2,
             Tdata::Walk {
                 fid: 99,
                 new_fid: 1,
@@ -435,10 +503,11 @@ pub(crate) fn walk_unknown_fid_returns_error() -> TestCase {
 
 pub(crate) fn clunk_known_fid_returns_rclunk_and_calls_serve9p() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Clunk { fid: 1 },
             resp: Rdata::Clunk {},
         },
@@ -453,19 +522,20 @@ pub(crate) fn clunk_known_fid_returns_rclunk_and_calls_serve9p() -> TestCase {
 
 pub(crate) fn clunk_unknown_fid_returns_error() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::err(Tdata::Clunk { fid: 99 }, E_UNKNOWN_FID),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::err(2, Tdata::Clunk { fid: 99 }, E_UNKNOWN_FID),
         Step::AssertCalls { calls: vec![] },
     ]
 }
 
 pub(crate) fn open_known_fid_returns_ropen() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Open { fid: 1, mode: 0 },
             resp: Rdata::Open {
                 qid: file_qid(HELLO_QID),
@@ -483,17 +553,18 @@ pub(crate) fn open_known_fid_returns_ropen() -> TestCase {
 
 pub(crate) fn open_open_fid_returns_error() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Open { fid: 1, mode: 0 },
             resp: Rdata::Open {
                 qid: file_qid(HELLO_QID),
                 iounit: TEST_IOUNIT,
             },
         },
-        Step::err(Tdata::Open { fid: 1, mode: 0 }, E_FID_ALREADY_OPEN),
+        Step::err(4, Tdata::Open { fid: 1, mode: 0 }, E_FID_ALREADY_OPEN),
         Step::AssertCalls {
             calls: vec![
                 Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
@@ -505,19 +576,20 @@ pub(crate) fn open_open_fid_returns_error() -> TestCase {
 
 pub(crate) fn open_unknown_fid_returns_error() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::err(Tdata::Open { fid: 99, mode: 0 }, E_UNKNOWN_FID),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::err(2, Tdata::Open { fid: 99, mode: 0 }, E_UNKNOWN_FID),
         Step::AssertCalls { calls: vec![] },
     ]
 }
 
 pub(crate) fn read_file_returns_data() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Read {
                 fid: 1,
                 offset: 0,
@@ -543,9 +615,10 @@ pub(crate) fn read_dir_returns_serialized_stats() -> TestCase {
     buf.extend(s2.write_9p_bytes().unwrap());
 
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::Request {
+            tag: 2,
             req: Tdata::Read {
                 fid: 0,
                 offset: 0,
@@ -563,10 +636,11 @@ pub(crate) fn write_to_file_returns_byte_count() -> TestCase {
     let payload = b"abc".to_vec();
 
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Write {
                 fid: 1,
                 offset: 0,
@@ -587,10 +661,11 @@ pub(crate) fn write_with_oversized_offset_returns_error() -> TestCase {
     let offset = u64::from(u32::MAX) + 1;
 
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::err(
+            3,
             Tdata::Write {
                 fid: 1,
                 offset,
@@ -609,10 +684,11 @@ pub(crate) fn stat_known_fid_returns_rstat() -> TestCase {
     let size = stat.n_bytes() as u16;
 
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Stat { fid: 1 },
             resp: Rdata::Stat { size, stat },
         },
@@ -627,9 +703,9 @@ pub(crate) fn stat_known_fid_returns_rstat() -> TestCase {
 
 pub(crate) fn stat_unknown_fid_returns_error() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::err(Tdata::Stat { fid: 99 }, E_UNKNOWN_FID),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::err(2, Tdata::Stat { fid: 99 }, E_UNKNOWN_FID),
         Step::AssertCalls { calls: vec![] },
     ]
 }
@@ -638,9 +714,10 @@ pub(crate) fn create_in_directory_returns_rcreate() -> TestCase {
     let perm = Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ;
 
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::Request {
+            tag: 2,
             req: Tdata::Create {
                 fid: 0,
                 name: "new.txt".to_string(),
@@ -677,9 +754,10 @@ pub(crate) fn create_masks_permissions_before_call() -> TestCase {
         | Perm::OTHER_WRITE;
 
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::Request {
+            tag: 2,
             req: Tdata::Create {
                 fid: 0,
                 name: "masked.txt".to_string(),
@@ -711,9 +789,10 @@ pub(crate) fn create_with_dot_name_returns_error() -> TestCase {
     let perm = Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ;
 
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::err(
+            2,
             Tdata::Create {
                 fid: 0,
                 name: ".".to_string(),
@@ -730,9 +809,10 @@ pub(crate) fn create_with_double_dot_name_returns_error() -> TestCase {
     let perm = Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ;
 
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::err(
+            2,
             Tdata::Create {
                 fid: 0,
                 name: "..".to_string(),
@@ -749,10 +829,11 @@ pub(crate) fn create_on_non_directory_returns_error() -> TestCase {
     let perm = Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ;
 
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::err(
+            3,
             Tdata::Create {
                 fid: 1,
                 name: "child".to_string(),
@@ -769,10 +850,11 @@ pub(crate) fn create_on_non_directory_returns_error() -> TestCase {
 
 pub(crate) fn remove_known_fid_returns_rremove() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Remove { fid: 1 },
             resp: Rdata::Remove {},
         },
@@ -788,10 +870,11 @@ pub(crate) fn remove_known_fid_returns_rremove() -> TestCase {
 
 pub(crate) fn blocked_read_delivers_response_later() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
-        Step::walk_req(0, 1, vec!["blocked"], vec![file_qid(BLOCKED_QID)]),
+        Step::version_req(0),
+        Step::attach_req(1),
+        Step::walk_req(2, 0, 1, vec!["blocked"], vec![file_qid(BLOCKED_QID)]),
         Step::Request {
+            tag: 3,
             req: Tdata::Read {
                 fid: 1,
                 offset: 0,
@@ -812,9 +895,10 @@ pub(crate) fn blocked_read_delivers_response_later() -> TestCase {
 
 pub(crate) fn write_to_directory_returns_error() -> TestCase {
     vec![
-        Step::version_req(),
-        Step::attach_req(),
+        Step::version_req(0),
+        Step::attach_req(1),
         Step::err(
+            2,
             Tdata::Write {
                 fid: 0,
                 offset: 0,

--- a/crates/ninep/src/test_utils/cases.rs
+++ b/crates/ninep/src/test_utils/cases.rs
@@ -114,6 +114,7 @@ macro_rules! generate_test_suite {
             clunk_unknown_fid_returns_error,
             connection_close_clunks_all_open_fids,
             create_in_directory_returns_rcreate,
+            create_masks_permissions_before_call,
             create_on_non_directory_returns_error,
             create_with_dot_name_returns_error,
             create_with_double_dot_name_returns_error,
@@ -372,14 +373,17 @@ pub(crate) fn walk_open_fid_returns_error_after_create() -> TestCase {
             E_WALK_OPEN_FID,
         ),
         Step::AssertCalls {
-            calls: vec![Call::create(
-                ClientId(0),
-                ROOT_QID,
-                "new.txt",
-                perm,
-                Mode::new(0),
-                "user",
-            )],
+            calls: vec![
+                Call::stat(ClientId(0), ROOT_QID, "user"),
+                Call::create(
+                    ClientId(0),
+                    ROOT_QID,
+                    "new.txt",
+                    Perm::OWNER_READ,
+                    Mode::new(0),
+                    "user",
+                ),
+            ],
         },
     ]
 }
@@ -620,14 +624,56 @@ pub(crate) fn create_in_directory_returns_rcreate() -> TestCase {
             },
         },
         Step::AssertCalls {
-            calls: vec![Call::create(
-                ClientId(0),
-                ROOT_QID,
-                "new.txt",
-                perm,
-                Mode::new(0),
-                "user",
-            )],
+            calls: vec![
+                Call::stat(ClientId(0), ROOT_QID, "user"),
+                Call::create(
+                    ClientId(0),
+                    ROOT_QID,
+                    "new.txt",
+                    Perm::OWNER_READ,
+                    Mode::new(0),
+                    "user",
+                ),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn create_masks_permissions_before_call() -> TestCase {
+    let requested = Perm::OWNER_READ
+        | Perm::OWNER_WRITE
+        | Perm::GROUP_READ
+        | Perm::GROUP_WRITE
+        | Perm::OTHER_READ
+        | Perm::OTHER_WRITE;
+
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::Request {
+            req: Tdata::Create {
+                fid: 0,
+                name: "masked.txt".to_string(),
+                perm: requested.bits(),
+                mode: 0,
+            },
+            resp: Rdata::Create {
+                qid: file_qid(CREATED_QID),
+                iounit: TEST_IOUNIT,
+            },
+        },
+        Step::AssertCalls {
+            calls: vec![
+                Call::stat(ClientId(0), ROOT_QID, "user"),
+                Call::create(
+                    ClientId(0),
+                    ROOT_QID,
+                    "masked.txt",
+                    Perm::OWNER_READ,
+                    Mode::new(0),
+                    "user",
+                ),
+            ],
         },
     ]
 }

--- a/crates/ninep/src/test_utils/cases.rs
+++ b/crates/ninep/src/test_utils/cases.rs
@@ -120,6 +120,7 @@ macro_rules! generate_test_suite {
             create_with_double_dot_name_returns_error,
             duplicate_attach_returns_error,
             flush_returns_rflush,
+            flush_waits_for_blocked_read,
             open_known_fid_returns_ropen,
             open_open_fid_returns_error,
             open_unknown_fid_returns_error,
@@ -271,6 +272,34 @@ pub(crate) fn flush_returns_rflush() -> TestCase {
             resp: Rdata::Flush {},
         },
         Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn flush_waits_for_blocked_read() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["blocked"], vec![file_qid(BLOCKED_QID)]),
+        Step::Request {
+            req: Tdata::Read {
+                fid: 1,
+                offset: 0,
+                count: 4096,
+            },
+            resp: Rdata::Read {
+                data: Data(BLOCKED_CONTENT.to_vec()),
+            },
+        },
+        Step::Request {
+            req: Tdata::Flush { old_tag: 3 },
+            resp: Rdata::Flush {},
+        },
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "blocked", "user"),
+                Call::read(ClientId(0), BLOCKED_QID, 0, 4096, "user"),
+            ],
+        },
     ]
 }
 

--- a/crates/ninep/src/test_utils/cases.rs
+++ b/crates/ninep/src/test_utils/cases.rs
@@ -1,10 +1,16 @@
 use crate::{
-    fs::Mode,
+    fs::{FileMeta, Mode, Perm, Stat},
     sansio::{
-        protocol::{DEFAULT_MSIZE, Qid, Rdata, Tdata},
-        server::{AFID_NO_AUTH, E_NO_VERSION_MESSAGE, SUPPORTED_VERSION},
+        protocol::{DEFAULT_MSIZE, Data, NineP, Qid, RawStat, Rdata, Tdata},
+        server::{
+            AFID_NO_AUTH, ClientId, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_ILLEGAL_CREATE_NAME,
+            E_NO_VERSION_MESSAGE, E_UNKNOWN_FID, E_UNKNOWN_FILE, SUPPORTED_VERSION,
+        },
     },
-    test_utils::{Call, ROOT_QID},
+    test_utils::{
+        BLOCKED_CONTENT, BLOCKED_QID, CREATED_QID, Call, HELLO_CONTENT, HELLO_QID, ROOT_QID,
+        SUBDIR_QID, TEST_IOUNIT,
+    },
 };
 
 /// A test case to be run against a 9p server.
@@ -22,14 +28,14 @@ pub(crate) enum Step {
 }
 
 impl Step {
-    fn version_req(msize: u32) -> Step {
+    fn version_req() -> Step {
         Step::Request {
             req: Tdata::Version {
-                msize,
+                msize: DEFAULT_MSIZE,
                 version: SUPPORTED_VERSION.to_string(),
             },
             resp: Rdata::Version {
-                msize,
+                msize: DEFAULT_MSIZE,
                 version: SUPPORTED_VERSION.to_string(),
             },
         }
@@ -52,6 +58,42 @@ impl Step {
             },
         }
     }
+
+    fn walk_req(fid: u32, new_fid: u32, wnames: Vec<&str>, wqids: Vec<Qid>) -> Step {
+        Step::Request {
+            req: Tdata::Walk {
+                fid,
+                new_fid,
+                wnames: wnames.into_iter().map(str::to_string).collect(),
+            },
+            resp: Rdata::Walk { wqids },
+        }
+    }
+
+    fn err(req: Tdata, msg: &str) -> Step {
+        Step::Request {
+            req,
+            resp: Rdata::Error {
+                ename: msg.to_string(),
+            },
+        }
+    }
+}
+
+fn dir_qid(path: u64) -> Qid {
+    Qid {
+        ty: Mode::DIR.bits(),
+        version: 0,
+        path,
+    }
+}
+
+fn file_qid(path: u64) -> Qid {
+    Qid {
+        ty: Mode::FILE.bits(),
+        version: 0,
+        path,
+    }
 }
 
 /// Helper for generating shared behavioural tests of both the sync and tokio server
@@ -69,6 +111,29 @@ macro_rules! generate_test_suite {
             version_sets_negotiated_msize,
             attach_before_version_returns_error,
             attach_after_version_succeeds,
+            duplicate_attach_returns_error,
+            version_while_attached_clunks_all_open_fids,
+            connection_close_clunks_all_open_fids,
+            flush_returns_rflush,
+            walk_to_known_child_returns_qids,
+            walk_first_element_missing_returns_error,
+            walk_partial_returns_partial_qids,
+            walk_unknown_fid_returns_error,
+            clunk_known_fid_returns_rclunk_and_calls_serve9p,
+            clunk_unknown_fid_returns_error,
+            open_known_fid_returns_ropen,
+            open_unknown_fid_returns_error,
+            read_file_returns_data,
+            read_dir_returns_serialized_stats,
+            write_to_file_returns_byte_count,
+            write_with_oversized_offset_returns_error,
+            stat_known_fid_returns_rstat,
+            stat_unknown_fid_returns_error,
+            create_in_directory_returns_rcreate,
+            create_with_dot_name_returns_error,
+            create_on_non_directory_returns_error,
+            remove_known_fid_returns_rremove,
+            blocked_read_delivers_response_later,
         );
     };
 
@@ -92,7 +157,16 @@ macro_rules! generate_test_suite {
 // Test cases for use with the generate_test_suite macro above
 
 pub(crate) fn version_sets_negotiated_msize() -> TestCase {
-    vec![Step::version_req(DEFAULT_MSIZE / 2)]
+    vec![Step::Request {
+        req: Tdata::Version {
+            msize: DEFAULT_MSIZE / 2,
+            version: SUPPORTED_VERSION.to_string(),
+        },
+        resp: Rdata::Version {
+            msize: DEFAULT_MSIZE / 2,
+            version: SUPPORTED_VERSION.to_string(),
+        },
+    }]
 }
 
 pub(crate) fn attach_before_version_returns_error() -> TestCase {
@@ -114,8 +188,439 @@ pub(crate) fn attach_before_version_returns_error() -> TestCase {
 
 pub(crate) fn attach_after_version_succeeds() -> TestCase {
     vec![
-        Step::version_req(DEFAULT_MSIZE / 2),
+        Step::version_req(),
         Step::attach_req(),
         Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn duplicate_attach_returns_error() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::err(
+            Tdata::Attach {
+                fid: 1,
+                afid: AFID_NO_AUTH,
+                uname: "user".to_string(),
+                aname: "/".to_string(),
+            },
+            E_ALREADY_ATTACHED,
+        ),
+        Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn version_while_attached_clunks_all_open_fids() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Open { fid: 1, mode: 0 },
+            resp: Rdata::Open {
+                qid: file_qid(HELLO_QID),
+                iounit: TEST_IOUNIT,
+            },
+        },
+        Step::version_req(),
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
+                Call::open(ClientId(0), HELLO_QID, Mode::new(0), "user"),
+                Call::clunk(ClientId(0), ROOT_QID),
+                Call::clunk(ClientId(0), HELLO_QID),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn connection_close_clunks_all_open_fids() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Open { fid: 1, mode: 0 },
+            resp: Rdata::Open {
+                qid: file_qid(HELLO_QID),
+                iounit: TEST_IOUNIT,
+            },
+        },
+        Step::CloseStream,
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
+                Call::open(ClientId(0), HELLO_QID, Mode::new(0), "user"),
+                Call::clunk(ClientId(0), ROOT_QID),
+                Call::clunk(ClientId(0), HELLO_QID),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn flush_returns_rflush() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::Request {
+            req: Tdata::Flush { old_tag: 123 },
+            resp: Rdata::Flush {},
+        },
+        Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn walk_to_known_child_returns_qids() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::AssertCalls {
+            calls: vec![Call::walk(ClientId(0), ROOT_QID, "hello", "user")],
+        },
+    ]
+}
+
+pub(crate) fn walk_first_element_missing_returns_error() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::err(
+            Tdata::Walk {
+                fid: 0,
+                new_fid: 1,
+                wnames: vec!["missing".to_string()],
+            },
+            E_UNKNOWN_FILE,
+        ),
+        Step::AssertCalls {
+            calls: vec![Call::walk(ClientId(0), ROOT_QID, "missing", "user")],
+        },
+    ]
+}
+
+pub(crate) fn walk_partial_returns_partial_qids() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["subdir", "missing"], vec![dir_qid(SUBDIR_QID)]),
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "subdir", "user"),
+                Call::walk(ClientId(0), SUBDIR_QID, "missing", "user"),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn walk_unknown_fid_returns_error() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::err(
+            Tdata::Walk {
+                fid: 99,
+                new_fid: 1,
+                wnames: vec!["hello".to_string()],
+            },
+            E_UNKNOWN_FID,
+        ),
+        Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn clunk_known_fid_returns_rclunk_and_calls_serve9p() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Clunk { fid: 1 },
+            resp: Rdata::Clunk {},
+        },
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
+                Call::clunk(ClientId(0), HELLO_QID),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn clunk_unknown_fid_returns_error() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::err(Tdata::Clunk { fid: 99 }, E_UNKNOWN_FID),
+        Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn open_known_fid_returns_ropen() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Open { fid: 1, mode: 0 },
+            resp: Rdata::Open {
+                qid: file_qid(HELLO_QID),
+                iounit: TEST_IOUNIT,
+            },
+        },
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
+                Call::open(ClientId(0), HELLO_QID, Mode::new(0), "user"),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn open_unknown_fid_returns_error() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::err(Tdata::Open { fid: 99, mode: 0 }, E_UNKNOWN_FID),
+        Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn read_file_returns_data() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Read {
+                fid: 1,
+                offset: 0,
+                count: 5,
+            },
+            resp: Rdata::Read {
+                data: Data(HELLO_CONTENT[..5].to_vec()),
+            },
+        },
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
+                Call::read(ClientId(0), HELLO_QID, 0, 5, "user"),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn read_dir_returns_serialized_stats() -> TestCase {
+    let s1: RawStat = Stat::stub(FileMeta::file("hello", HELLO_QID)).into();
+    let s2: RawStat = Stat::stub(FileMeta::dir("subdir", SUBDIR_QID)).into();
+    let mut buf = s1.write_9p_bytes().unwrap();
+    buf.extend(s2.write_9p_bytes().unwrap());
+
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::Request {
+            req: Tdata::Read {
+                fid: 0,
+                offset: 0,
+                count: 4096,
+            },
+            resp: Rdata::Read { data: Data(buf) },
+        },
+        Step::AssertCalls {
+            calls: vec![Call::read_dir(ClientId(0), ROOT_QID, "user")],
+        },
+    ]
+}
+
+pub(crate) fn write_to_file_returns_byte_count() -> TestCase {
+    let payload = b"abc".to_vec();
+
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Write {
+                fid: 1,
+                offset: 0,
+                data: Data(payload.clone()),
+            },
+            resp: Rdata::Write { count: 3 },
+        },
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
+                Call::write(ClientId(0), HELLO_QID, 0, payload, "user"),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn write_with_oversized_offset_returns_error() -> TestCase {
+    let offset = u64::from(u32::MAX) + 1;
+
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Write {
+                fid: 1,
+                offset,
+                data: Data(vec![1]),
+            },
+            resp: Rdata::Error {
+                ename: format!("offset too large: {offset} > {}", u32::MAX),
+            },
+        },
+        Step::AssertCalls {
+            calls: vec![Call::walk(ClientId(0), ROOT_QID, "hello", "user")],
+        },
+    ]
+}
+
+pub(crate) fn stat_known_fid_returns_rstat() -> TestCase {
+    let stat: RawStat = Stat::stub(FileMeta::file("hello", HELLO_QID)).into();
+    let size = stat.n_bytes() as u16;
+
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Stat { fid: 1 },
+            resp: Rdata::Stat { size, stat },
+        },
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
+                Call::stat(ClientId(0), HELLO_QID, "user"),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn stat_unknown_fid_returns_error() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::err(Tdata::Stat { fid: 99 }, E_UNKNOWN_FID),
+        Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn create_in_directory_returns_rcreate() -> TestCase {
+    let perm = Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ;
+
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::Request {
+            req: Tdata::Create {
+                fid: 0,
+                name: "new.txt".to_string(),
+                perm: perm.bits(),
+                mode: 0,
+            },
+            resp: Rdata::Create {
+                qid: file_qid(CREATED_QID),
+                iounit: TEST_IOUNIT,
+            },
+        },
+        Step::AssertCalls {
+            calls: vec![Call::create(
+                ClientId(0),
+                ROOT_QID,
+                "new.txt",
+                perm,
+                Mode::new(0),
+                "user",
+            )],
+        },
+    ]
+}
+
+pub(crate) fn create_with_dot_name_returns_error() -> TestCase {
+    let perm = Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ;
+
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::err(
+            Tdata::Create {
+                fid: 0,
+                name: ".".to_string(),
+                perm: perm.bits(),
+                mode: 0,
+            },
+            E_ILLEGAL_CREATE_NAME,
+        ),
+        Step::AssertCalls { calls: vec![] },
+    ]
+}
+
+pub(crate) fn create_on_non_directory_returns_error() -> TestCase {
+    let perm = Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ;
+
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::err(
+            Tdata::Create {
+                fid: 1,
+                name: "child".to_string(),
+                perm: perm.bits(),
+                mode: 0,
+            },
+            E_CREATE_NON_DIR,
+        ),
+        Step::AssertCalls {
+            calls: vec![Call::walk(ClientId(0), ROOT_QID, "hello", "user")],
+        },
+    ]
+}
+
+pub(crate) fn remove_known_fid_returns_rremove() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Remove { fid: 1 },
+            resp: Rdata::Remove {},
+        },
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
+                Call::remove(ClientId(0), HELLO_QID, "user"),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn blocked_read_delivers_response_later() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["blocked"], vec![file_qid(BLOCKED_QID)]),
+        Step::Request {
+            req: Tdata::Read {
+                fid: 1,
+                offset: 0,
+                count: 4096,
+            },
+            resp: Rdata::Read {
+                data: Data(BLOCKED_CONTENT.to_vec()),
+            },
+        },
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "blocked", "user"),
+                Call::read(ClientId(0), BLOCKED_QID, 0, 4096, "user"),
+            ],
+        },
     ]
 }

--- a/crates/ninep/src/test_utils/cases.rs
+++ b/crates/ninep/src/test_utils/cases.rs
@@ -3,8 +3,9 @@ use crate::{
     sansio::{
         protocol::{DEFAULT_MSIZE, Data, NineP, Qid, RawStat, Rdata, Tdata},
         server::{
-            AFID_NO_AUTH, ClientId, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_ILLEGAL_CREATE_NAME,
-            E_NO_VERSION_MESSAGE, E_UNKNOWN_FID, E_UNKNOWN_FILE, SUPPORTED_VERSION,
+            AFID_NO_AUTH, ClientId, E_ALREADY_ATTACHED, E_CREATE_NON_DIR, E_FID_ALREADY_OPEN,
+            E_ILLEGAL_CREATE_NAME, E_NO_VERSION_MESSAGE, E_UNKNOWN_FID, E_UNKNOWN_FILE,
+            E_WALK_OPEN_FID, SUPPORTED_VERSION,
         },
     },
     test_utils::{
@@ -119,6 +120,7 @@ macro_rules! generate_test_suite {
             duplicate_attach_returns_error,
             flush_returns_rflush,
             open_known_fid_returns_ropen,
+            open_open_fid_returns_error,
             open_unknown_fid_returns_error,
             read_dir_returns_serialized_stats,
             read_file_returns_data,
@@ -129,6 +131,8 @@ macro_rules! generate_test_suite {
             version_while_attached_clunks_all_open_fids,
             walk_first_element_missing_returns_error,
             walk_partial_returns_partial_qids,
+            walk_open_fid_returns_error_after_create,
+            walk_open_fid_returns_error_after_open,
             walk_to_known_child_returns_qids,
             walk_unknown_fid_returns_error,
             write_to_directory_returns_error,
@@ -312,6 +316,74 @@ pub(crate) fn walk_partial_returns_partial_qids() -> TestCase {
     ]
 }
 
+pub(crate) fn walk_open_fid_returns_error_after_open() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Open { fid: 1, mode: 0 },
+            resp: Rdata::Open {
+                qid: file_qid(HELLO_QID),
+                iounit: TEST_IOUNIT,
+            },
+        },
+        Step::err(
+            Tdata::Walk {
+                fid: 1,
+                new_fid: 2,
+                wnames: vec![],
+            },
+            E_WALK_OPEN_FID,
+        ),
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
+                Call::open(ClientId(0), HELLO_QID, Mode::new(0), "user"),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn walk_open_fid_returns_error_after_create() -> TestCase {
+    let perm = Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ;
+
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::Request {
+            req: Tdata::Create {
+                fid: 0,
+                name: "new.txt".to_string(),
+                perm: perm.bits(),
+                mode: 0,
+            },
+            resp: Rdata::Create {
+                qid: file_qid(CREATED_QID),
+                iounit: TEST_IOUNIT,
+            },
+        },
+        Step::err(
+            Tdata::Walk {
+                fid: 0,
+                new_fid: 1,
+                wnames: vec![],
+            },
+            E_WALK_OPEN_FID,
+        ),
+        Step::AssertCalls {
+            calls: vec![Call::create(
+                ClientId(0),
+                ROOT_QID,
+                "new.txt",
+                perm,
+                Mode::new(0),
+                "user",
+            )],
+        },
+    ]
+}
+
 pub(crate) fn walk_unknown_fid_returns_error() -> TestCase {
     vec![
         Step::version_req(),
@@ -367,6 +439,28 @@ pub(crate) fn open_known_fid_returns_ropen() -> TestCase {
                 iounit: TEST_IOUNIT,
             },
         },
+        Step::AssertCalls {
+            calls: vec![
+                Call::walk(ClientId(0), ROOT_QID, "hello", "user"),
+                Call::open(ClientId(0), HELLO_QID, Mode::new(0), "user"),
+            ],
+        },
+    ]
+}
+
+pub(crate) fn open_open_fid_returns_error() -> TestCase {
+    vec![
+        Step::version_req(),
+        Step::attach_req(),
+        Step::walk_req(0, 1, vec!["hello"], vec![file_qid(HELLO_QID)]),
+        Step::Request {
+            req: Tdata::Open { fid: 1, mode: 0 },
+            resp: Rdata::Open {
+                qid: file_qid(HELLO_QID),
+                iounit: TEST_IOUNIT,
+            },
+        },
+        Step::err(Tdata::Open { fid: 1, mode: 0 }, E_FID_ALREADY_OPEN),
         Step::AssertCalls {
             calls: vec![
                 Call::walk(ClientId(0), ROOT_QID, "hello", "user"),

--- a/crates/ninep/src/test_utils/mod.rs
+++ b/crates/ninep/src/test_utils/mod.rs
@@ -1,0 +1,365 @@
+//! Shared test infrastructure for sync and tokio server tests.
+#![allow(dead_code)]
+use crate::{
+    fs::{FileMeta, FileType, IoUnit, Mode, Perm, Stat, WStat},
+    sansio::{
+        client::{MSIZE, State as ClientState},
+        protocol::{Rmessage, SharedBuf, Tdata, Tmessage},
+        server::ClientId,
+    },
+    sync::{
+        SyncNineP,
+        server::{ReadOutcome, Serve9p},
+    },
+    tokio::{AsyncNineP, server::AsyncServe9pFromSync},
+};
+use std::{
+    collections::HashMap,
+    io, mem,
+    os::unix::net::UnixStream,
+    sync::{Arc, Mutex},
+    time::SystemTime,
+};
+use tokio::io::DuplexStream;
+
+pub(crate) mod cases;
+
+pub(crate) const ROOT_QID: u64 = 0;
+pub(crate) const HELLO_QID: u64 = 1;
+pub(crate) const SUBDIR_QID: u64 = 2;
+pub(crate) const CREATED_QID: u64 = 99;
+
+pub(crate) const HELLO_CONTENT: &[u8] = b"hello world";
+pub(crate) const TEST_IOUNIT: IoUnit = 8192;
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct TestFs {
+    calls: RecordedCalls,
+}
+
+impl TestFs {
+    /// Obtain a handle to the [RecordedCalls] being made to this [TestFs].
+    ///
+    /// Use [RecordedCalls::take] to extract the calls up until that point in order to make
+    /// assertions.
+    pub(crate) fn calls(&self) -> RecordedCalls {
+        self.calls.clone()
+    }
+}
+
+impl Serve9p for TestFs {
+    fn walk(
+        &self,
+        cid: ClientId,
+        parent_qid: u64,
+        child: &str,
+        uname: &str,
+    ) -> crate::Result<FileMeta> {
+        self.calls.push(Call::walk(cid, parent_qid, child, uname));
+
+        match (parent_qid, child) {
+            (ROOT_QID, "hello") => Ok(FileMeta::file("hello", HELLO_QID)),
+            (ROOT_QID, "subdir") => Ok(FileMeta::dir("subdir", SUBDIR_QID)),
+            _ => Err(format!("not found: {child}")),
+        }
+    }
+
+    fn open(&self, cid: ClientId, qid: u64, mode: Mode, uname: &str) -> crate::Result<IoUnit> {
+        self.calls.push(Call::open(cid, qid, mode, uname));
+
+        Ok(TEST_IOUNIT)
+    }
+
+    fn clunk(&self, cid: ClientId, qid: u64) {
+        self.calls.push(Call::clunk(cid, qid));
+    }
+
+    fn create(
+        &self,
+        cid: ClientId,
+        parent: u64,
+        name: &str,
+        perm: Perm,
+        mode: Mode,
+        uname: &str,
+    ) -> crate::Result<(FileMeta, IoUnit)> {
+        self.calls
+            .push(Call::create(cid, parent, name, perm, mode, uname));
+
+        Ok((FileMeta::file(name, CREATED_QID), TEST_IOUNIT))
+    }
+
+    fn read(
+        &self,
+        cid: ClientId,
+        qid: u64,
+        offset: usize,
+        count: usize,
+        uname: &str,
+    ) -> crate::Result<ReadOutcome> {
+        self.calls.push(Call::read(cid, qid, offset, count, uname));
+
+        match qid {
+            HELLO_QID => {
+                let src = HELLO_CONTENT.get(offset..).unwrap_or(&[]);
+                Ok(ReadOutcome::Immediate(src[..count.min(src.len())].to_vec()))
+            }
+            _ => Err(format!("unreadable qid: {qid}")),
+        }
+    }
+
+    fn read_dir(&self, cid: ClientId, qid: u64, uname: &str) -> crate::Result<Vec<Stat>> {
+        self.calls.push(Call::read_dir(cid, qid, uname));
+
+        match qid {
+            ROOT_QID => Ok(vec![
+                Stat::stub(FileMeta::file("hello", HELLO_QID)),
+                Stat::stub(FileMeta::dir("subdir", SUBDIR_QID)),
+            ]),
+            SUBDIR_QID => Ok(vec![]),
+            _ => Err(format!("not a directory: {qid}")),
+        }
+    }
+
+    fn write(
+        &self,
+        cid: ClientId,
+        qid: u64,
+        offset: usize,
+        data: Vec<u8>,
+        uname: &str,
+    ) -> crate::Result<usize> {
+        let n = data.len();
+
+        self.calls.push(Call::write(cid, qid, offset, data, uname));
+
+        Ok(n)
+    }
+
+    fn remove(&self, cid: ClientId, qid: u64, uname: &str) -> crate::Result<()> {
+        self.calls.push(Call::remove(cid, qid, uname));
+
+        Ok(())
+    }
+
+    fn stat(&self, cid: ClientId, qid: u64, uname: &str) -> crate::Result<Stat> {
+        self.calls.push(Call::stat(cid, qid, uname));
+
+        match qid {
+            ROOT_QID => Ok(Stat::stub(FileMeta::dir("", ROOT_QID))),
+            HELLO_QID => Ok(Stat::stub(FileMeta::file("hello", HELLO_QID))),
+            SUBDIR_QID => Ok(Stat::stub(FileMeta::dir("subdir", SUBDIR_QID))),
+            _ => Err(format!("unknown qid: {qid}")),
+        }
+    }
+
+    fn write_stat(&self, cid: ClientId, qid: u64, wstat: WStat, uname: &str) -> crate::Result<()> {
+        self.calls.push(Call::write_stat(cid, qid, wstat, uname));
+
+        Ok(())
+    }
+}
+
+impl AsyncServe9pFromSync for TestFs {}
+
+/// Unlike the sync/tokio clients exported by the main crate, this client is a simple wrapper
+/// around the lower level 9p protocol to facilitate testing.
+pub(crate) struct TestClient<S> {
+    pub(crate) state: ClientState,
+    pub(crate) stream: S,
+    pub(crate) buf: SharedBuf,
+    pub(crate) msize: u32,
+}
+
+impl<S> TestClient<S> {
+    pub fn new(stream: S) -> Self {
+        Self {
+            state: ClientState {
+                msize: MSIZE,
+                fids: HashMap::from([(String::new(), 0)]),
+                next_fid: 1,
+            },
+            stream,
+            buf: SharedBuf::default(),
+            msize: MSIZE,
+        }
+    }
+}
+
+/// A [TestClient] backed by a [UnixStream].
+pub(crate) type SyncTestClient = TestClient<UnixStream>;
+
+impl SyncTestClient {
+    /// Synchronously send a Tmessage and receive back the Rmessage reply from the server
+    pub fn send_sync(&mut self, tag: u16, content: Tdata) -> io::Result<Rmessage> {
+        SyncNineP::write_to(&Tmessage { tag, content }, &mut self.stream)?;
+        <Rmessage as SyncNineP>::read_from(self.msize, &self.buf, &mut self.stream)
+    }
+}
+
+/// A [TestClient] backed by a [DuplexStream].
+pub(crate) type AsyncTestClient = TestClient<DuplexStream>;
+
+impl AsyncTestClient {
+    /// Asynchronously send a Tmessage and receive back the Rmessage reply from the server
+    pub async fn send_async(&mut self, tag: u16, content: Tdata) -> io::Result<Rmessage> {
+        AsyncNineP::write_to(&Tmessage { tag, content }, &mut self.stream).await?;
+        <Rmessage as AsyncNineP>::read_from(self.msize, &self.buf, &mut self.stream).await
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct RecordedCalls(Arc<Mutex<Vec<Call>>>);
+
+impl RecordedCalls {
+    fn push(&self, call: Call) {
+        self.0.lock().unwrap().push(call);
+    }
+
+    /// Extract the [Call]s that have been recorded up until this point.
+    ///
+    /// This method clears the internal log state of the associated [TestFs].
+    pub(crate) fn take(&self) -> Vec<Call> {
+        mem::take(&mut self.0.lock().unwrap())
+    }
+}
+
+/// A recorded method call to a [TestFs].
+#[rustfmt::skip]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Call {
+    Clunk { cid: ClientId, qid: u64, },
+    Create { cid: ClientId, parent: u64, name: String, perm: Perm, mode: Mode, uname: String, },
+    Open { cid: ClientId, qid: u64, mode: Mode, uname: String, },
+    Read { cid: ClientId, qid: u64, offset: usize, count: usize, uname: String, },
+    ReadDir { cid: ClientId, qid: u64, uname: String, },
+    Remove { cid: ClientId, qid: u64, uname: String, },
+    Stat { cid: ClientId, qid: u64, uname: String, },
+    Walk { cid: ClientId, parent_qid: u64, child: String, uname: String, },
+    Write { cid: ClientId, qid: u64, offset: usize, data: Vec<u8>, uname: String, },
+    WriteStat { cid: ClientId, qid: u64, wstat: WStat, uname: String, },
+}
+
+impl Call {
+    pub(crate) fn clunk(cid: ClientId, qid: u64) -> Self {
+        Self::Clunk { cid, qid }
+    }
+
+    pub(crate) fn create(
+        cid: ClientId,
+        parent: u64,
+        name: &str,
+        perm: Perm,
+        mode: Mode,
+        uname: &str,
+    ) -> Self {
+        Self::Create {
+            cid,
+            parent,
+            name: name.into(),
+            perm,
+            mode,
+            uname: uname.into(),
+        }
+    }
+
+    pub(crate) fn open(cid: ClientId, qid: u64, mode: Mode, uname: &str) -> Self {
+        Self::Open {
+            cid,
+            qid,
+            mode,
+            uname: uname.into(),
+        }
+    }
+
+    pub(crate) fn read(cid: ClientId, qid: u64, offset: usize, count: usize, uname: &str) -> Self {
+        Self::Read {
+            cid,
+            qid,
+            offset,
+            count,
+            uname: uname.into(),
+        }
+    }
+
+    pub(crate) fn read_dir(cid: ClientId, qid: u64, uname: &str) -> Self {
+        Self::ReadDir {
+            cid,
+            qid,
+            uname: uname.into(),
+        }
+    }
+
+    pub(crate) fn remove(cid: ClientId, qid: u64, uname: &str) -> Self {
+        Self::Remove {
+            cid,
+            qid,
+            uname: uname.into(),
+        }
+    }
+
+    pub(crate) fn stat(cid: ClientId, qid: u64, uname: &str) -> Self {
+        Self::Stat {
+            cid,
+            qid,
+            uname: uname.into(),
+        }
+    }
+
+    pub(crate) fn walk(cid: ClientId, parent_qid: u64, child: &str, uname: &str) -> Self {
+        Self::Walk {
+            cid,
+            parent_qid,
+            child: child.into(),
+            uname: uname.into(),
+        }
+    }
+
+    pub(crate) fn write(
+        cid: ClientId,
+        qid: u64,
+        offset: usize,
+        data: Vec<u8>,
+        uname: &str,
+    ) -> Self {
+        Self::Write {
+            cid,
+            qid,
+            offset,
+            data,
+            uname: uname.into(),
+        }
+    }
+
+    pub(crate) fn write_stat(cid: ClientId, qid: u64, wstat: WStat, uname: &str) -> Self {
+        Self::WriteStat {
+            cid,
+            qid,
+            wstat,
+            uname: uname.into(),
+        }
+    }
+}
+
+// Test only helper methods on existing structs
+impl Stat {
+    /// Create a new sub [Stat] with default perms and metadata.
+    pub(crate) fn stub(fm: FileMeta) -> Stat {
+        let perms = if fm.ty == FileType::Directory {
+            Perm::DIR | Perm::OWNER_READ | Perm::OWNER_EXEC
+        } else {
+            Perm::OWNER_READ | Perm::OWNER_WRITE | Perm::GROUP_READ | Perm::OTHER_READ
+        };
+
+        Stat {
+            fm,
+            perms,
+            n_bytes: 0,
+            last_accesses: SystemTime::UNIX_EPOCH,
+            last_modified: SystemTime::UNIX_EPOCH,
+            owner: "owner".to_string(),
+            group: "group".to_string(),
+            last_modified_by: "owner".to_string(),
+        }
+    }
+}

--- a/crates/ninep/src/test_utils/mod.rs
+++ b/crates/ninep/src/test_utils/mod.rs
@@ -16,6 +16,7 @@ use std::{
     io, mem,
     os::unix::net::UnixStream,
     sync::{Arc, Mutex, mpsc},
+    thread::{sleep, spawn},
     time::{Duration, SystemTime},
 };
 use tokio::io::DuplexStream;
@@ -48,7 +49,7 @@ impl TestFs {
 }
 
 impl Serve9p for TestFs {
-    fn walk(
+    fn walk_one(
         &self,
         cid: ClientId,
         parent_qid: u64,
@@ -112,10 +113,11 @@ impl Serve9p for TestFs {
             BLOCKED_QID => {
                 let (tx, rx) = mpsc::channel();
                 let data = BLOCKED_CONTENT.to_vec();
-                std::thread::spawn(move || {
-                    std::thread::sleep(Duration::from_millis(25));
+                spawn(move || {
+                    sleep(Duration::from_millis(25));
                     let _ = tx.send(data);
                 });
+
                 Ok(ReadOutcome::Blocked(rx))
             }
             _ => Err(format!("unreadable qid: {qid}")),
@@ -236,17 +238,17 @@ impl RecordedCalls {
 #[rustfmt::skip]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Call {
-    Clunk { cid: ClientId, qid: u64, },
-    Create { cid: ClientId, parent: u64, name: String, perm: Perm, mode: Mode, uname: String, },
-    Flush { cid: ClientId, old_tag: u16, },
-    Open { cid: ClientId, qid: u64, mode: Mode, uname: String, },
-    Read { cid: ClientId, qid: u64, offset: usize, count: usize, uname: String, },
-    ReadDir { cid: ClientId, qid: u64, uname: String, },
-    Remove { cid: ClientId, qid: u64, uname: String, },
-    Stat { cid: ClientId, qid: u64, uname: String, },
-    Walk { cid: ClientId, parent_qid: u64, child: String, uname: String, },
-    Write { cid: ClientId, qid: u64, offset: usize, data: Vec<u8>, uname: String, },
-    WriteStat { cid: ClientId, qid: u64, wstat: WStat, uname: String, },
+    Clunk { cid: ClientId, qid: u64 },
+    Create { cid: ClientId, parent: u64, name: String, perm: Perm, mode: Mode, uname: String },
+    Flush { cid: ClientId, old_tag: u16 },
+    Open { cid: ClientId, qid: u64, mode: Mode, uname: String },
+    Read { cid: ClientId, qid: u64, offset: usize, count: usize, uname: String },
+    ReadDir { cid: ClientId, qid: u64, uname: String },
+    Remove { cid: ClientId, qid: u64, uname: String },
+    Stat { cid: ClientId, qid: u64, uname: String },
+    Walk { cid: ClientId, parent_qid: u64, child: String, uname: String },
+    Write { cid: ClientId, qid: u64, offset: usize, data: Vec<u8>, uname: String },
+    WriteStat { cid: ClientId, qid: u64, wstat: WStat, uname: String },
 }
 
 impl Call {

--- a/crates/ninep/src/test_utils/mod.rs
+++ b/crates/ninep/src/test_utils/mod.rs
@@ -1,9 +1,8 @@
 //! Shared test infrastructure for sync and tokio server tests.
-#![allow(dead_code)]
 use crate::{
     fs::{FileMeta, FileType, IoUnit, Mode, Perm, Stat, WStat},
     sansio::{
-        client::{MSIZE, State as ClientState},
+        client::MSIZE,
         protocol::{Rmessage, SharedBuf, Tdata, Tmessage},
         server::ClientId,
     },
@@ -14,10 +13,9 @@ use crate::{
     tokio::{AsyncNineP, server::AsyncServe9pFromSync},
 };
 use std::{
-    collections::HashMap,
     io, mem,
     os::unix::net::UnixStream,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, mpsc},
     time::SystemTime,
 };
 use tokio::io::DuplexStream;
@@ -27,9 +25,11 @@ pub(crate) mod cases;
 pub(crate) const ROOT_QID: u64 = 0;
 pub(crate) const HELLO_QID: u64 = 1;
 pub(crate) const SUBDIR_QID: u64 = 2;
+pub(crate) const BLOCKED_QID: u64 = 3;
 pub(crate) const CREATED_QID: u64 = 99;
 
 pub(crate) const HELLO_CONTENT: &[u8] = b"hello world";
+pub(crate) const BLOCKED_CONTENT: &[u8] = b"delayed";
 pub(crate) const TEST_IOUNIT: IoUnit = 8192;
 
 #[derive(Debug, Default, Clone)]
@@ -60,6 +60,7 @@ impl Serve9p for TestFs {
         match (parent_qid, child) {
             (ROOT_QID, "hello") => Ok(FileMeta::file("hello", HELLO_QID)),
             (ROOT_QID, "subdir") => Ok(FileMeta::dir("subdir", SUBDIR_QID)),
+            (ROOT_QID, "blocked") => Ok(FileMeta::file("blocked", BLOCKED_QID)),
             _ => Err(format!("not found: {child}")),
         }
     }
@@ -103,6 +104,14 @@ impl Serve9p for TestFs {
             HELLO_QID => {
                 let src = HELLO_CONTENT.get(offset..).unwrap_or(&[]);
                 Ok(ReadOutcome::Immediate(src[..count.min(src.len())].to_vec()))
+            }
+            BLOCKED_QID => {
+                let (tx, rx) = mpsc::channel();
+                let data = BLOCKED_CONTENT.to_vec();
+                std::thread::spawn(move || {
+                    let _ = tx.send(data);
+                });
+                Ok(ReadOutcome::Blocked(rx))
             }
             _ => Err(format!("unreadable qid: {qid}")),
         }
@@ -165,7 +174,6 @@ impl AsyncServe9pFromSync for TestFs {}
 /// Unlike the sync/tokio clients exported by the main crate, this client is a simple wrapper
 /// around the lower level 9p protocol to facilitate testing.
 pub(crate) struct TestClient<S> {
-    pub(crate) state: ClientState,
     pub(crate) stream: S,
     pub(crate) buf: SharedBuf,
     pub(crate) msize: u32,
@@ -174,11 +182,6 @@ pub(crate) struct TestClient<S> {
 impl<S> TestClient<S> {
     pub fn new(stream: S) -> Self {
         Self {
-            state: ClientState {
-                msize: MSIZE,
-                fids: HashMap::from([(String::new(), 0)]),
-                next_fid: 1,
-            },
             stream,
             buf: SharedBuf::default(),
             msize: MSIZE,

--- a/crates/ninep/src/test_utils/mod.rs
+++ b/crates/ninep/src/test_utils/mod.rs
@@ -16,7 +16,7 @@ use std::{
     io, mem,
     os::unix::net::UnixStream,
     sync::{Arc, Mutex, mpsc},
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 use tokio::io::DuplexStream;
 
@@ -75,6 +75,10 @@ impl Serve9p for TestFs {
         self.calls.push(Call::clunk(cid, qid));
     }
 
+    fn flush(&self, cid: ClientId, old_tag: u16) {
+        self.calls.push(Call::flush(cid, old_tag));
+    }
+
     fn create(
         &self,
         cid: ClientId,
@@ -109,6 +113,7 @@ impl Serve9p for TestFs {
                 let (tx, rx) = mpsc::channel();
                 let data = BLOCKED_CONTENT.to_vec();
                 std::thread::spawn(move || {
+                    std::thread::sleep(Duration::from_millis(25));
                     let _ = tx.send(data);
                 });
                 Ok(ReadOutcome::Blocked(rx))
@@ -233,6 +238,7 @@ impl RecordedCalls {
 pub(crate) enum Call {
     Clunk { cid: ClientId, qid: u64, },
     Create { cid: ClientId, parent: u64, name: String, perm: Perm, mode: Mode, uname: String, },
+    Flush { cid: ClientId, old_tag: u16, },
     Open { cid: ClientId, qid: u64, mode: Mode, uname: String, },
     Read { cid: ClientId, qid: u64, offset: usize, count: usize, uname: String, },
     ReadDir { cid: ClientId, qid: u64, uname: String, },
@@ -264,6 +270,10 @@ impl Call {
             mode,
             uname: uname.into(),
         }
+    }
+
+    pub(crate) fn flush(cid: ClientId, old_tag: u16) -> Self {
+        Self::Flush { cid, old_tag }
     }
 
     pub(crate) fn open(cid: ClientId, qid: u64, mode: Mode, uname: &str) -> Self {

--- a/crates/ninep/src/tokio/client.rs
+++ b/crates/ninep/src/tokio/client.rs
@@ -23,6 +23,7 @@ pub struct Client<S> {
     state: Arc<Mutex<State>>,
     stream: Arc<Mutex<S>>,
     buf: SharedBuf,
+    msize: u32,
 }
 
 impl<S> Clone for Client<S> {
@@ -31,6 +32,7 @@ impl<S> Clone for Client<S> {
             state: Arc::clone(&self.state),
             stream: Arc::clone(&self.stream),
             buf: SharedBuf::default(),
+            msize: self.msize,
         }
     }
 }
@@ -45,6 +47,7 @@ impl<S> Client<S> {
             })),
             stream: Arc::new(Mutex::new(stream)),
             buf: SharedBuf::default(),
+            msize: MSIZE,
         }
     }
 }
@@ -111,6 +114,7 @@ macro_rules! run_9p_coro {
     ($self:ident, $method:ident, $($arg:expr),*) => {
         {
             let mut state = $self.state.lock().await;
+            let msize = state.msize;
             let mut coro = state.$method($($arg),*);
             loop {
                 coro = match coro.resume() {
@@ -119,7 +123,7 @@ macro_rules! run_9p_coro {
                         let mut stream = $self.stream.lock().await;
                         t.write_to(&mut *stream).await?;
 
-                        match Rmessage::read_from(&$self.buf, &mut *stream).await? {
+                        match Rmessage::read_from(msize, &$self.buf, &mut *stream).await? {
                             Rmessage {
                                 content: Rdata::Error { ename },
                                 ..
@@ -141,7 +145,7 @@ where
         let mut stream = self.stream.lock().await;
         Tmessage { tag, content }.write_to(&mut *stream).await?;
 
-        match Rmessage::read_from(&self.buf, &mut *stream).await? {
+        match Rmessage::read_from(self.msize, &self.buf, &mut *stream).await? {
             Rmessage {
                 content: Rdata::Error { ename },
                 ..
@@ -156,7 +160,11 @@ where
         uname: impl Into<String>,
         aname: impl Into<String>,
     ) -> io::Result<()> {
-        run_9p_coro!(self, handle_connect, uname.into(), aname.into())
+        run_9p_coro!(self, handle_connect, uname.into(), aname.into())?;
+        let msize = self.state.lock().await.msize;
+        self.msize = msize;
+
+        Ok(())
     }
 
     /// Associate the given path with a new fid.

--- a/crates/ninep/src/tokio/client.rs
+++ b/crates/ninep/src/tokio/client.rs
@@ -101,7 +101,7 @@ impl Client<TcpStream> {
     ) -> io::Result<Self> {
         let stream = TcpStream::connect(addr).await?;
         let mut fids = HashMap::new();
-        fids.insert(String::new(), 0);
+        fids.insert("/".to_string(), 0);
 
         let mut client = Self::new(fids, stream);
         client.connect(uname, aname).await?;

--- a/crates/ninep/src/tokio/mod.rs
+++ b/crates/ninep/src/tokio/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 use simple_coro::CoroState;
 use std::{future::Future, io, marker::Unpin};
 use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, DuplexStream},
     net::{TcpStream, UnixStream},
 };
 
@@ -93,5 +93,6 @@ pub trait AsyncStream: AsyncRead + AsyncWrite + Unpin + Send + Sized + 'static {
     }
 }
 
+impl AsyncStream for DuplexStream {}
 impl AsyncStream for UnixStream {}
 impl AsyncStream for TcpStream {}

--- a/crates/ninep/src/tokio/mod.rs
+++ b/crates/ninep/src/tokio/mod.rs
@@ -1,7 +1,7 @@
 //! Tokio based asynchronous implementation of 9p Servers and Clients
 use crate::{
     Result,
-    sansio::protocol::{NineP, Rdata, Rmessage, SharedBuf},
+    sansio::protocol::{NineP, Rdata, Rmessage, SharedBuf, validate_msize},
 };
 use simple_coro::CoroState;
 use std::{future::Future, io, marker::Unpin};
@@ -24,11 +24,15 @@ pub trait AsyncNineP: NineP + Send + Sync {
     }
 
     /// Decode self from 9p protocol bytes coming from the given [AsyncRead].
-    fn read_from<R>(buf: &SharedBuf, r: &mut R) -> impl Future<Output = io::Result<Self>> + Send
+    fn read_from<R>(
+        msize: u32,
+        buf: &SharedBuf,
+        r: &mut R,
+    ) -> impl Future<Output = io::Result<Self>> + Send
     where
         R: AsyncRead + Unpin + Send,
     {
-        read_from(buf, r)
+        read_from(msize, buf, r)
     }
 }
 
@@ -51,15 +55,20 @@ where
 }
 
 #[inline(always)]
-async fn read_from<T, R>(buf: &SharedBuf, r: &mut R) -> io::Result<T>
+async fn read_from<T, R>(msize: u32, buf: &SharedBuf, r: &mut R) -> io::Result<T>
 where
     T: NineP + Send,
     R: AsyncRead + Unpin + Send,
 {
-    let mut coro = T::read_9p_coro(buf);
+    let mut coro = T::read_9p_coro(msize, buf);
+    let mut total_bytes: u32 = 0;
+
     loop {
         coro = match coro.resume() {
             CoroState::Pending(c, n) => {
+                total_bytes = total_bytes.saturating_add(n as u32);
+                validate_msize(total_bytes, msize)?;
+
                 // SAFETY: coro is currently suspended and unable to take a reference to buf
                 let mut_buf = unsafe { buf.as_inner_mut() };
                 mut_buf.resize(n, 0);
@@ -77,8 +86,9 @@ where
 pub trait AsyncStream: AsyncRead + AsyncWrite + Unpin + Send + Sized + 'static {
     /// Reply to the specified tag with a given Result. Err's will be converted to 9p error
     /// messages automatically.
-    async fn reply(&mut self, tag: u16, resp: Result<Rdata>) {
-        let r: Rmessage = (tag, resp).into();
+    async fn reply(&mut self, msize: u32, tag: u16, resp: Result<Rdata>) {
+        let mut r: Rmessage = (tag, resp).into();
+        r.clamp(msize);
         let _ = r.write_to(self).await;
     }
 }

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -99,7 +99,7 @@ pub trait AsyncServe9p: Send + Sync + 'static {
     /// (of file type [Directory][FileType::Directory]) to a target `child`. This method is called
     /// for each element of that path in order, stopping either when the target is reached or some
     /// element of the path returns an error.
-    fn walk(
+    fn walk_one(
         &self,
         cid: ClientId,
         parent_qid: u64,
@@ -271,14 +271,14 @@ impl<T> AsyncServe9p for T
 where
     T: AsyncServe9pFromSync,
 {
-    async fn walk(
+    async fn walk_one(
         &self,
         cid: ClientId,
         parent_qid: u64,
         child: &str,
         uname: &str,
     ) -> Result<FileMeta> {
-        <T as Serve9p>::walk(self, cid, parent_qid, child, uname)
+        <T as Serve9p>::walk_one(self, cid, parent_qid, child, uname)
     }
 
     async fn open(&self, cid: ClientId, qid: u64, mode: Mode, uname: &str) -> Result<IoUnit> {
@@ -605,7 +605,7 @@ where
             coro = match coro.resume() {
                 CoroState::Complete(res) => return res,
                 CoroState::Pending(c, (qid, name, uname)) => {
-                    let res = self.s.walk(client_id, qid, &name, &uname).await;
+                    let res = self.s.walk_one(client_id, qid, &name, &uname).await;
                     c.send(res)
                 }
             };

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -660,3 +660,66 @@ where
         Ok(Rdata::Remove {})
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        generate_test_suite,
+        sansio::protocol::Rmessage,
+        test_utils::{AsyncTestClient, TestFs, cases::Step},
+    };
+    use tokio::{
+        io::{AsyncWriteExt, duplex},
+        task,
+    };
+
+    macro_rules! run_one {
+        ($case:expr) => {
+            // Setup the client and server
+            let fs = TestFs::default();
+            let recorded = fs.calls();
+            let (client_stream, server_stream) = duplex(8192);
+            let mut client = AsyncTestClient::new(client_stream);
+            let mut server = Server::new(fs);
+
+            let handle = task::spawn(async move {
+                server
+                    .new_session(server_stream)
+                    .handle_connection_async()
+                    .await;
+            });
+
+            // Run the test case
+            let mut next_tag = 0;
+            let mut did_shutdown = false;
+
+            for step in $case {
+                match step {
+                    Step::Request { req, resp } => {
+                        let tag = next_tag;
+                        next_tag += 1;
+
+                        let rmsg = client.send_async(tag, req).await.unwrap();
+                        assert_eq!(rmsg, Rmessage { tag, content: resp });
+                    }
+
+                    Step::AssertCalls { calls } => assert_eq!(recorded.take(), calls),
+
+                    Step::CloseStream => {
+                        let _ = client.stream.shutdown().await;
+                        did_shutdown = true;
+                    }
+                }
+            }
+
+            if !did_shutdown {
+                let _ = client.stream.shutdown().await;
+            }
+
+            handle.await.expect("server task join failed");
+        };
+    }
+
+    generate_test_suite!(tokio, run_one);
+}

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -9,15 +9,15 @@ use crate::{
         protocol::{Data, RawStat, Rdata, Tdata, Tmessage},
         server::{
             Attached, E_CREATE_NON_DIR, E_FID_ALREADY_OPEN, E_ILLEGAL_CREATE_NAME,
-            E_ILLEGAL_DIRECTORY_WRITE, E_UNKNOWN_FID, Either, FidMeta, Session, SessionType,
-            Unattached,
+            E_ILLEGAL_DIRECTORY_WRITE, E_UNKNOWN_FID, Either, FidMeta, FlushHandle, Session,
+            SessionType, Unattached,
         },
     },
     sync::server::Serve9p,
     tokio::{AsyncNineP, AsyncStream},
 };
 use simple_coro::CoroState;
-use std::{collections::btree_map::Entry, fs, future::Future, mem::size_of, path::PathBuf};
+use std::{fs, future::Future, mem::size_of, path::PathBuf};
 use tokio::{
     net::{TcpListener, UnixListener},
     sync::mpsc::{Receiver, UnboundedSender, channel, unbounded_channel},
@@ -380,9 +380,16 @@ where
         self.state.fids.clear();
     }
 
+    async fn flush_waiters_async(&mut self, flush_handle: &mut FlushHandle, tag: u16) {
+        for tag in flush_handle.pending_flush_tags(tag) {
+            self.reply_async(tag, Ok(Rdata::Flush {})).await;
+        }
+    }
+
     async fn handle_connection_async(mut self) {
         use Tdata::*;
         let (tx, mut rx) = unbounded_channel();
+        let mut flush_handle = FlushHandle::default();
 
         loop {
             let Tmessage { tag, content } = tokio::select! {
@@ -391,6 +398,7 @@ where
                     self.stream
                         .reply(self.msize, tag, Ok(Rdata::Read { data: Data(data) }))
                         .await;
+                    self.flush_waiters_async(&mut flush_handle, tag).await;
                     continue;
                 },
                 res = Tmessage::read_from(self.msize, &self.buf, &mut self.stream) => match res {
@@ -400,6 +408,10 @@ where
                 else => continue,
             };
 
+            if !content.is_flush() {
+                flush_handle.mark_pending(tag);
+            }
+
             let resp = match content {
                 Version { msize, version } => {
                     let resp = self.handle_version(msize, version);
@@ -408,7 +420,6 @@ where
                     Ok(resp)
                 }
                 Auth { .. } | Attach { .. } => Err("session is already attached".into()),
-                Flush { .. } => Ok(Rdata::Flush {}),
 
                 Walk {
                     fid,
@@ -437,9 +448,24 @@ where
                 Write { fid, offset, data } => self.handle_write_async(fid, offset, data.0).await,
                 Remove { fid } => self.handle_remove_async(fid).await,
                 Wstat { fid, stat, .. } => self.handle_wstat_async(fid, stat).await,
+                Flush { old_tag } => {
+                    let mut coro = flush_handle.flush_or_chain(tag, old_tag);
+                    loop {
+                        coro = match coro.resume() {
+                            CoroState::Pending(c, _) => {
+                                self.reply_async(tag, Ok(Rdata::Flush {})).await;
+                                c.send(())
+                            }
+                            CoroState::Complete(_) => break,
+                        }
+                    }
+
+                    continue;
+                }
             };
 
             self.reply_async(tag, resp).await;
+            self.flush_waiters_async(&mut flush_handle, tag).await;
         }
     }
 
@@ -496,13 +522,13 @@ where
         let client_id = self.client_id;
         let mut coro = self
             .session_state
-            .handle_attached_walk(fid, new_fid, &wnames);
+            .handle_attached_walk(fid, new_fid, wnames);
 
         loop {
             coro = match coro.resume() {
                 CoroState::Complete(res) => return res,
                 CoroState::Pending(c, (qid, name, uname)) => {
-                    let res = self.s.walk(client_id, qid, name, uname).await;
+                    let res = self.s.walk(client_id, qid, &name, &uname).await;
                     c.send(res)
                 }
             };
@@ -510,14 +536,13 @@ where
     }
 
     async fn handle_clunk_async(&mut self, fid: u32) -> Result<Rdata> {
-        match self.state.fids.entry(fid) {
-            Entry::Occupied(ent) => {
-                let meta = ent.remove();
+        match self.state.fids.remove(&fid) {
+            Some(meta) => {
                 self.s.clunk(self.client_id, meta.qid).await;
 
                 Ok(Rdata::Clunk {})
             }
-            Entry::Vacant(_) => Err(E_UNKNOWN_FID.to_string()),
+            None => Err(E_UNKNOWN_FID.to_string()),
         }
     }
 
@@ -632,11 +657,11 @@ where
         match coro.resume() {
             CoroState::Complete(res) => res,
             CoroState::Pending(c, Either::L((qid, uname))) => {
-                let stats = self.s.read_dir(cid, qid, uname).await?;
+                let stats = self.s.read_dir(cid, qid, &uname).await?;
                 c.send(stats).resume().unwrap()
             }
             CoroState::Pending(_, Either::R((qid, uname))) => {
-                let outcome = self.s.read(cid, qid, offset, count, uname).await?;
+                let outcome = self.s.read(cid, qid, offset, count, &uname).await?;
                 match outcome {
                     ReadOutcome::Immediate(data) => Ok(Some(Rdata::Read { data: Data(data) })),
                     ReadOutcome::Blocked(mut chan) => {

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -8,8 +8,8 @@ use crate::{
     sansio::{
         protocol::{Data, RawStat, Rdata, Tdata, Tmessage},
         server::{
-            Attached, E_CREATE_NON_DIR, E_ILLEGAL_CREATE_NAME, E_UNKNOWN_FID, Either, Session,
-            SessionType, Unattached,
+            Attached, E_CREATE_NON_DIR, E_ILLEGAL_CREATE_NAME, E_ILLEGAL_DIRECTORY_WRITE,
+            E_UNKNOWN_FID, Either, Session, SessionType, Unattached,
         },
     },
     sync::server::Serve9p,
@@ -632,11 +632,14 @@ where
     }
 
     async fn handle_write_async(&mut self, fid: u32, offset: u64, data: Vec<u8>) -> Result<Rdata> {
-        if offset > u32::MAX as u64 {
+        let fm = self.try_file_meta(fid)?;
+
+        if fm.ty == FileType::Directory {
+            return Err(E_ILLEGAL_DIRECTORY_WRITE.to_string());
+        } else if offset > u32::MAX as u64 {
             return Err(format!("offset too large: {offset} > {}", u32::MAX));
         }
 
-        let fm = self.try_file_meta(fid)?;
         let count = self
             .s
             .write(
@@ -653,9 +656,14 @@ where
 
     async fn handle_remove_async(&mut self, fid: u32) -> Result<Rdata> {
         let fm = self.try_file_meta(fid)?;
-        self.s
+        let res = self
+            .s
             .remove(self.client_id, fm.qid, &self.state.uname)
-            .await?;
+            .await;
+
+        // ensure that we clunk before erroring
+        self.s.clunk(self.client_id, fm.qid).await;
+        res?;
 
         Ok(Rdata::Remove {})
     }

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -12,13 +12,14 @@ use crate::{
             SessionType, Unattached,
         },
     },
+    sync::server::Serve9p,
     tokio::{AsyncNineP, AsyncStream},
 };
 use simple_coro::CoroState;
 use std::{collections::btree_map::Entry, fs, future::Future, mem::size_of, path::PathBuf};
 use tokio::{
     net::{TcpListener, UnixListener},
-    sync::mpsc::{Receiver, UnboundedSender, unbounded_channel},
+    sync::mpsc::{Receiver, UnboundedSender, channel, unbounded_channel},
     task::{JoinHandle, spawn},
 };
 
@@ -189,6 +190,102 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         wstat: WStat,
         uname: &str,
     ) -> impl Future<Output = Result<()>> + Send;
+}
+
+/// Helper trait for auto-implementing [AsyncServe9p] using an existing synchronous [Serve9p]
+/// implementation.
+///
+/// Each method will implemented by delegating to the existing synchronous implementation.
+pub trait AsyncServe9pFromSync: Serve9p {}
+
+impl<T> AsyncServe9p for T
+where
+    T: AsyncServe9pFromSync,
+{
+    async fn walk(
+        &self,
+        cid: ClientId,
+        parent_qid: u64,
+        child: &str,
+        uname: &str,
+    ) -> Result<FileMeta> {
+        <T as Serve9p>::walk(self, cid, parent_qid, child, uname)
+    }
+
+    async fn open(&self, cid: ClientId, qid: u64, mode: Mode, uname: &str) -> Result<IoUnit> {
+        <T as Serve9p>::open(self, cid, qid, mode, uname)
+    }
+
+    async fn clunk(&self, cid: ClientId, qid: u64) {
+        <T as Serve9p>::clunk(self, cid, qid);
+    }
+
+    async fn create(
+        &self,
+        cid: ClientId,
+        parent: u64,
+        name: &str,
+        perm: Perm,
+        mode: Mode,
+        uname: &str,
+    ) -> Result<(FileMeta, IoUnit)> {
+        <T as Serve9p>::create(self, cid, parent, name, perm, mode, uname)
+    }
+
+    async fn read(
+        &self,
+        cid: ClientId,
+        qid: u64,
+        offset: usize,
+        count: usize,
+        uname: &str,
+    ) -> Result<ReadOutcome> {
+        use crate::sync::server::ReadOutcome as SyncReadOutcome;
+
+        let ro = match <T as Serve9p>::read(self, cid, qid, offset, count, uname)? {
+            SyncReadOutcome::Immediate(data) => ReadOutcome::Immediate(data),
+            SyncReadOutcome::Blocked(srx) => {
+                let (tx, rx) = channel(1);
+
+                tokio::spawn(async move {
+                    if let Ok(data) = srx.recv() {
+                        _ = tx.send(data).await;
+                    }
+                });
+
+                ReadOutcome::Blocked(rx)
+            }
+        };
+
+        Ok(ro)
+    }
+
+    async fn read_dir(&self, cid: ClientId, qid: u64, uname: &str) -> Result<Vec<Stat>> {
+        <T as Serve9p>::read_dir(self, cid, qid, uname)
+    }
+
+    async fn write(
+        &self,
+        cid: ClientId,
+        qid: u64,
+        offset: usize,
+        data: Vec<u8>,
+        uname: &str,
+    ) -> Result<usize> {
+        <T as Serve9p>::write(self, cid, qid, offset, data, uname)
+    }
+
+    async fn remove(&self, cid: ClientId, qid: u64, uname: &str) -> Result<()> {
+        <T as Serve9p>::remove(self, cid, qid, uname)
+    }
+
+    async fn stat(&self, cid: ClientId, qid: u64, uname: &str) -> Result<Stat> {
+        <T as Serve9p>::stat(self, cid, qid, uname)
+    }
+
+    async fn write_stat(&self, cid: ClientId, qid: u64, wstat: WStat, uname: &str) -> Result<()> {
+        <T as Serve9p>::write_stat(self, cid, qid, wstat, uname)
+    }
 }
 
 impl<S> Server<S>

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -8,7 +8,8 @@ use crate::{
     sansio::{
         protocol::{Data, RawStat, Rdata, Tdata, Tmessage},
         server::{
-            Attached, E_CREATE_NON_DIR, E_UNKNOWN_FID, Either, Session, SessionType, Unattached,
+            Attached, E_CREATE_NON_DIR, E_ILLEGAL_CREATE_NAME, E_UNKNOWN_FID, Either, Session,
+            SessionType, Unattached,
         },
     },
     tokio::{AsyncNineP, AsyncStream},
@@ -464,6 +465,10 @@ where
         perm: Perm,
         mode: Mode,
     ) -> Result<Rdata> {
+        if name == "." || name == ".." {
+            return Err(E_ILLEGAL_CREATE_NAME.to_string());
+        }
+
         let fm = self.try_file_meta(fid)?;
         if fm.ty != FileType::Directory {
             return Err(E_CREATE_NON_DIR.to_string());

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -8,8 +8,9 @@ use crate::{
     sansio::{
         protocol::{Data, RawStat, Rdata, Tdata, Tmessage},
         server::{
-            Attached, E_CREATE_NON_DIR, E_ILLEGAL_CREATE_NAME, E_ILLEGAL_DIRECTORY_WRITE,
-            E_UNKNOWN_FID, Either, Session, SessionType, Unattached,
+            Attached, E_CREATE_NON_DIR, E_FID_ALREADY_OPEN, E_ILLEGAL_CREATE_NAME,
+            E_ILLEGAL_DIRECTORY_WRITE, E_UNKNOWN_FID, Either, FidMeta, Session, SessionType,
+            Unattached,
         },
     },
     sync::server::Serve9p,
@@ -373,8 +374,8 @@ where
 {
     /// Explicitly clunk all
     async fn clunk_and_clear_async(&mut self) {
-        for &qid in self.state.fids.values() {
-            self.s.clunk(self.client_id, qid).await;
+        for meta in self.state.fids.values() {
+            self.s.clunk(self.client_id, meta.qid).await;
         }
         self.state.fids.clear();
     }
@@ -511,8 +512,8 @@ where
     async fn handle_clunk_async(&mut self, fid: u32) -> Result<Rdata> {
         match self.state.fids.entry(fid) {
             Entry::Occupied(ent) => {
-                let qid = ent.remove();
-                self.s.clunk(self.client_id, qid).await;
+                let meta = ent.remove();
+                self.s.clunk(self.client_id, meta.qid).await;
 
                 Ok(Rdata::Clunk {})
             }
@@ -543,11 +544,21 @@ where
     }
 
     async fn handle_open_async(&mut self, fid: u32, mode: Mode) -> Result<Rdata> {
+        if self.try_fid_meta(fid)?.is_open {
+            return Err(E_FID_ALREADY_OPEN.to_string());
+        }
+
         let fm = self.try_file_meta(fid)?;
         let iounit = self
             .s
             .open(self.client_id, fm.qid, mode, &self.state.uname)
             .await?;
+
+        self.state
+            .fids
+            .get_mut(&fid)
+            .expect("known fid after try_file_meta")
+            .is_open = true;
 
         Ok(Rdata::Open {
             qid: fm.as_qid(),
@@ -578,7 +589,7 @@ where
 
         // fid is now changed to point to the newly created file rather than the parent
         let qid = fm.as_qid();
-        self.state.fids.insert(fid, fm.qid);
+        self.state.fids.insert(fid, FidMeta::open(fm.qid));
         self.qids.entry(fm.qid).or_insert(fm);
 
         Ok(Rdata::Create { qid, iounit })

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -582,9 +582,20 @@ where
             return Err(E_CREATE_NON_DIR.to_string());
         }
 
+        let parent = self
+            .s
+            .stat(self.client_id, fm.qid, &self.state.uname)
+            .await?;
         let (fm, iounit) = self
             .s
-            .create(self.client_id, fm.qid, &name, perm, mode, &self.state.uname)
+            .create(
+                self.client_id,
+                fm.qid,
+                &name,
+                perm.apply_create_mask(parent.perms),
+                mode,
+                &self.state.uname,
+            )
             .await?;
 
         // fid is now changed to point to the newly created file rather than the parent

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -93,14 +93,12 @@ pub trait AsyncServe9p: Send + Sync + 'static {
     //     async { Err("authentication not required".to_string()) }
     // }
 
-    /// Lookup a child node under a known parent directory by name.
+    /// Lookup the [FileMeta] for `child` under the directory represented by `parent_qid`.
     ///
-    /// `9p` Twalk messages received by the server will specify a full path from a known parent
-    /// to a target child. This method is called for each element of that path in sequence in order,
-    /// stopping either when the target is reached or some element of the path returns an error.
-    ///
-    /// [Server] will ensure that this method is only called for known parents who have previously
-    /// been identified has having [FileType::Directory].
+    /// `9p` walk messages received by the [Server] will specify a full path from a known parent
+    /// (of file type [Directory][FileType::Directory]) to a target `child`. This method is called
+    /// for each element of that path in order, stopping either when the target is reached or some
+    /// element of the path returns an error.
     fn walk(
         &self,
         cid: ClientId,
@@ -109,11 +107,16 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         uname: &str,
     ) -> impl Future<Output = Result<FileMeta>> + Send;
 
-    /// Open an existing file in the requested mode for subsequent I/O via [read](AsyncServe9p::read) and
-    /// [write](AsyncServe9p::write) calls.
+    /// Open an existing file for subsequent I/O via [read](AsyncServe9p::read) and
+    /// [write](AsyncServe9p::write) messages.
+    ///
+    /// [Server] calls this only for known, currently-closed fids. On success, [Server] marks the
+    /// fid as open with further `walk`, `open` and `create` messages using that fid being rejected
+    /// until the fid is clunked (either [explicitly](AsyncServe9p::clunk) or via session reset).
     ///
     /// The return of this method is an [IoUnit] used to inform the client of the maximum number of
-    /// bytes that will be supported per read/write call on this resource.
+    /// bytes that will be supported per read/write call on this resource. An `Err` should be
+    /// returned if access is denied, mode is unsupported, or the target cannot be opened.
     fn open(
         &self,
         cid: ClientId,
@@ -122,7 +125,15 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         uname: &str,
     ) -> impl Future<Output = Result<IoUnit>> + Send;
 
-    /// Clunk a currently open file.
+    /// Release client specific server-side resources associated with with provided qid.
+    ///
+    /// [Server] calls this when a fid is discarded (i.e. [clunk](AsyncServe9p::clunk), successful
+    /// or failed [remove](AsyncServe9p::remove), `version` session reset, or connection close). It
+    /// is possible that the provided qid may represent a file that was never opened for I/O in
+    /// this session.
+    ///
+    /// Implementations should be resilient to repeated calls for the same qid. (The default
+    /// implementation is a no-op.)
     #[expect(unused_variables)]
     fn clunk(&self, cid: ClientId, qid: u64) -> impl Future<Output = ()> + Send {
         async {}
@@ -130,11 +141,11 @@ pub trait AsyncServe9p: Send + Sync + 'static {
 
     /// Handle "best effort" cancellation of an in-flight message identified by `old_tag`.
     ///
-    /// Invoked when the server receives a flush message for a message that is still pending. As
-    /// per the 9p spec, this is a hint _only_: the server is still permitted to complete any
+    /// Invoked when the server receives a `flush` message for a message that is still pending. As
+    /// per the `9p` spec, this is a hint _only_: the server is still permitted to complete any
     /// outstanding work and send a response to the original message being flushed.
     ///
-    /// Clients are permitted to send multiple flush messages for the same tag. As such,
+    /// Clients are permitted to send multiple `flush` messages for the same tag. As such,
     /// implementations of this method should be resilient to being called multiple times with the
     /// same arguments. (The default implementation is a no-op.)
     #[expect(unused_variables)]
@@ -142,7 +153,16 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         async {}
     }
 
-    /// Create a new file in the given parent directory.
+    /// Create a new entry in `parent`, returning its [metadata][FileMeta] and [IoUnit].
+    ///
+    /// [Server] ensures that this method is only called when the target fid is known, pointing to
+    /// a directory and not currently open for I/O. [Server] also handles rejecting `.` and `..` as
+    /// invalid entry names, and applying `9p` permission masking before this call, meaning `perm`
+    /// is already normalized against the parent directory's permissions.
+    ///
+    /// On success, [Server] rebinds the creating fid to the qid found in the returned [FileMeta]
+    /// and marks it as open for I/O. Implementations should return `Err` if `name` already exists
+    /// or creation cannot be completed for any reason.
     fn create(
         &self,
         cid: ClientId,
@@ -153,7 +173,16 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         uname: &str,
     ) -> impl Future<Output = Result<(FileMeta, IoUnit)>> + Send;
 
-    /// Read `count` bytes from the requested file starting from the given `offset`.
+    /// Read up to `count` bytes from `qid` starting at `offset`.
+    ///
+    /// [Server] calls this for non-directory files only; directory reads are routed through
+    /// [read_dir](AsyncServe9p::read_dir). The returned [ReadOutcome] controls how the response is
+    /// sent to the client: [Immediate][ReadOutcome::Immediate] is send directly to the client on
+    /// completion of this method, while [blocked][ReadOutcome::Blocked] spawns a background task
+    /// to wait for data to become available before responding.
+    ///
+    /// Implementations should tolerate flush hints while blocked (see
+    /// [flush](AsyncServe9p::flush)) and must respect client specified byte `count` limit.
     fn read(
         &self,
         cid: ClientId,
@@ -163,7 +192,12 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         uname: &str,
     ) -> impl Future<Output = Result<ReadOutcome>> + Send;
 
-    /// List the contents of the given directory.
+    /// List [Stat] entries for a given client's view of a directory.
+    ///
+    /// [Server] calls this for `read` requests on a directory, handling read offsets and count
+    /// limits automatically (unlike [read][AsyncServe9p::read]). Implementations should return the
+    /// full logical entry list in stable order for the client's view of the directory (as
+    /// identified by `cid`).
     fn read_dir(
         &self,
         cid: ClientId,
@@ -171,7 +205,16 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         uname: &str,
     ) -> impl Future<Output = Result<Vec<Stat>>> + Send;
 
-    /// Write the given `data` to the requested file starting at `offset`
+    /// Write the provided `data` to the file denoted by `qid` starting at the provided byte
+    /// `offset`.
+    ///
+    /// [Server] ensures that this is only called for entries of type [file][FileType::Regular].
+    ///
+    /// Returns the number of bytes written. Returning `n < data.len()` is permitted and is treated
+    /// as a short write which may result in further `write` messages from the client.
+    ///
+    /// Implementations are required to enforce mode/permission rules and return `Err` when writes
+    /// are not permitted.
     fn write(
         &self,
         cid: ClientId,
@@ -181,7 +224,11 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         uname: &str,
     ) -> impl Future<Output = Result<usize>> + Send;
 
-    /// Remove the requested file from the filesystem.
+    /// Remove the entry identified by `qid` from the filesystem.
+    ///
+    /// [Server] calls this for each `remove` message received from the client followed by
+    /// [clunking][AsyncServe9p::clunk] the `qid` regardless of success. Implementations should
+    /// return `Err` when removal is not permitted or fails.
     fn remove(
         &self,
         cid: ClientId,
@@ -189,7 +236,10 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         uname: &str,
     ) -> impl Future<Output = Result<()>> + Send;
 
-    /// Request a machine independent "directory entry" for the given resource.
+    /// Fetch the current [Stat] metadata for the filesystem entry identified by `qid`.
+    ///
+    /// [Server] uses this for client `stat` messages and internally for
+    /// [create][AsyncServe9p::create] permission masking against parent directories.
     fn stat(
         &self,
         cid: ClientId,
@@ -197,7 +247,11 @@ pub trait AsyncServe9p: Send + Sync + 'static {
         uname: &str,
     ) -> impl Future<Output = Result<Stat>> + Send;
 
-    /// Attempt to set the machine independent "directory entry" for the given resource.
+    /// Apply a [WStat] update to the [Stat] of the filesystem entry identified by `qid`.
+    ///
+    /// [Server] validates fid/qid identity before calling this and passes a [WStat] containing
+    /// only caller-requested field changes. Implementations must enforce authorization and
+    /// supported field semantics, returning `Err` for invalid or disallowed changes.
     fn write_stat(
         &self,
         cid: ClientId,

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -683,12 +683,12 @@ mod tests {
             let mut client = AsyncTestClient::new(client_stream);
             let mut server = Server::new(fs);
 
-            let handle = task::spawn(async move {
+            let mut handle = Some(task::spawn(async move {
                 server
                     .new_session(server_stream)
                     .handle_connection_async()
                     .await;
-            });
+            }));
 
             // Run the test case
             let mut next_tag = 0;
@@ -708,6 +708,9 @@ mod tests {
 
                     Step::CloseStream => {
                         let _ = client.stream.shutdown().await;
+                        if let Some(h) = handle.take() {
+                            h.await.expect("server task join failed");
+                        }
                         did_shutdown = true;
                     }
                 }
@@ -717,7 +720,9 @@ mod tests {
                 let _ = client.stream.shutdown().await;
             }
 
-            handle.await.expect("server task join failed");
+            if let Some(h) = handle.take() {
+                h.await.expect("server task join failed");
+            }
         };
     }
 

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -403,8 +403,8 @@ where
             coro = match coro.resume() {
                 CoroState::Complete(res) => return res,
                 CoroState::Pending(c, (qid, name, uname)) => {
-                    let fm = self.s.walk(client_id, qid, name, uname).await?;
-                    c.send(fm)
+                    let res = self.s.walk(client_id, qid, name, uname).await;
+                    c.send(res)
                 }
             };
         }

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -123,8 +123,22 @@ pub trait AsyncServe9p: Send + Sync + 'static {
     ) -> impl Future<Output = Result<IoUnit>> + Send;
 
     /// Clunk a currently open file.
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn clunk(&self, cid: ClientId, qid: u64) -> impl Future<Output = ()> + Send {
+        async {}
+    }
+
+    /// Handle "best effort" cancellation of an in-flight message identified by `old_tag`.
+    ///
+    /// Invoked when the server receives a flush message for a message that is still pending. As
+    /// per the 9p spec, this is a hint _only_: the server is still permitted to complete any
+    /// outstanding work and send a response to the original message being flushed.
+    ///
+    /// Clients are permitted to send multiple flush messages for the same tag. As such,
+    /// implementations of this method should be resilient to being called multiple times with the
+    /// same arguments. (The default implementation is a no-op.)
+    #[expect(unused_variables)]
+    fn flush(&self, cid: ClientId, old_tag: u16) -> impl Future<Output = ()> + Send {
         async {}
     }
 
@@ -219,6 +233,10 @@ where
 
     async fn clunk(&self, cid: ClientId, qid: u64) {
         <T as Serve9p>::clunk(self, cid, qid);
+    }
+
+    async fn flush(&self, cid: ClientId, old_tag: u16) {
+        <T as Serve9p>::flush(self, cid, old_tag);
     }
 
     async fn create(
@@ -456,7 +474,12 @@ where
                                 self.reply_async(tag, Ok(Rdata::Flush {})).await;
                                 c.send(())
                             }
-                            CoroState::Complete(_) => break,
+                            CoroState::Complete(sent_flush) => {
+                                if !sent_flush {
+                                    self.s.flush(self.client_id, old_tag).await;
+                                }
+                                break;
+                            }
                         }
                     }
 
@@ -721,7 +744,7 @@ mod tests {
     use super::*;
     use crate::{
         generate_test_suite,
-        sansio::protocol::Rmessage,
+        sansio::protocol::{Rmessage, Tmessage},
         test_utils::{AsyncTestClient, TestFs, cases::Step},
     };
     use tokio::{
@@ -746,17 +769,30 @@ mod tests {
             }));
 
             // Run the test case
-            let mut next_tag = 0;
             let mut did_shutdown = false;
 
             for step in $case {
                 match step {
-                    Step::Request { req, resp } => {
-                        let tag = next_tag;
-                        next_tag += 1;
-
+                    Step::Request { tag, req, resp } => {
                         let rmsg = client.send_async(tag, req).await.unwrap();
                         assert_eq!(rmsg, Rmessage { tag, content: resp });
+                    }
+
+                    Step::Send { tag, req } => {
+                        AsyncNineP::write_to(&Tmessage::new(tag, req), &mut client.stream)
+                            .await
+                            .unwrap();
+                    }
+
+                    Step::Receive { tag, resp } => {
+                        let rmsg = <Rmessage as AsyncNineP>::read_from(
+                            client.msize,
+                            &client.buf,
+                            &mut client.stream,
+                        )
+                        .await
+                        .unwrap();
+                        assert_eq!(rmsg, Rmessage::new(tag, resp));
                     }
 
                     Step::AssertCalls { calls } => assert_eq!(recorded.take(), calls),

--- a/crates/ninep/src/tokio/server.rs
+++ b/crates/ninep/src/tokio/server.rs
@@ -241,7 +241,7 @@ where
     U: AsyncStream,
 {
     async fn reply_async(&mut self, tag: u16, resp: Result<Rdata>) {
-        self.stream.reply(tag, resp).await
+        self.stream.reply(self.session_state.msize, tag, resp).await
     }
 }
 
@@ -252,7 +252,7 @@ where
 {
     async fn handle_connection_async(mut self) {
         loop {
-            let t = match Tmessage::read_from(&self.buf, &mut self.stream).await {
+            let t = match Tmessage::read_from(self.msize, &self.buf, &mut self.stream).await {
                 Ok(t) => t,
                 Err(_) => return,
             };
@@ -290,11 +290,11 @@ where
                 // Blocked read came through so send it to the client
                 Some((tag, data)) = rx.recv() => {
                     self.stream
-                        .reply(tag, Ok(Rdata::Read { data: Data(data) }))
+                        .reply(self.msize, tag, Ok(Rdata::Read { data: Data(data) }))
                         .await;
                     continue;
                 },
-                res = Tmessage::read_from(&self.buf, &mut self.stream) => match res {
+                res = Tmessage::read_from(self.msize, &self.buf, &mut self.stream) => match res {
                     Ok(t) => t,
                     Err(_) => return self.clunk_and_clear_async().await,
                 },

--- a/src/fsys/mod.rs
+++ b/src/fsys/mod.rs
@@ -472,7 +472,13 @@ impl Serve9p for AdFs {
         Ok(())
     }
 
-    fn walk(&self, cid: ClientId, parent_qid: u64, child: &str, uname: &str) -> Result<FileMeta> {
+    fn walk_one(
+        &self,
+        cid: ClientId,
+        parent_qid: u64,
+        child: &str,
+        uname: &str,
+    ) -> Result<FileMeta> {
         trace!(?cid, %parent_qid, %child, %uname, "handling walk request");
         let mut s = self.state.lock().unwrap();
         s.buffer_nodes.update();

--- a/tests/scenario_tests.rs
+++ b/tests/scenario_tests.rs
@@ -359,7 +359,7 @@ impl ScriptedUi {
     }
 
     fn spawn_fsys(&self, f: Fsys) {
-        match UnixClient::new_unix_with_explicit_path(&self.uname, &self.socket_path, "") {
+        match UnixClient::new_unix_with_explicit_path(&self.uname, &self.socket_path, "/") {
             Ok(client) => {
                 // We need to mark that we are pending before spawning the background thread
                 // for running the fsys operation otherwise we race with the main editor


### PR DESCRIPTION
Following implementing the fix for #178 I've taken a look at the `ninep` crate as whole for the first time in a while and there are a number of things that can be improved. In particular, there were a number of places where I wasn't being fully spec compliant, and testing was severely lacking (with most practical verification of the code being via the `ad` test suite rather than in-crate tests).

The focus for this PR so far is on the server implementations and protocol fixes. There is further work to do on the client side of things and more tests to be written still. I also think I might have a go at providing some more quality of life improvements as part of the `0.6` release, but depending on how I get on I may defer than to `0.7` in order to not pile up an even larger diff.

# Breaking changes

- walks are now spec compliant (fids only bound on fully successful walk, limited to 16 elements)
- msize is now enforced (default was previously used regardless of the value negotiated in version messages)
- `.` and `..` are now rejected as names in `create` messages
- file "open" state is now tracked and used to reject invalid messages
- `create` permissions are now correctly masked by the permissions of the parent directory
- `flush` messages are now queued based on the in-flight message rather than returning immediately
- the `walk` methods on the `Serve9p` and `AsyncServe9p` traits have been renamed to `walk_one` to better represent their usage
- Default root name for servers and clients is now spec compliant `"/"` rather than `""`

# Misc. changes
- Dependency on `simple_coro` has been bumped to `0.1.5`
- Doc comments on the `Serve9p` and `AsyncServe9p` traits have been improved
- The sync `Server` implementation now always runs a second reader thread per-connection in order to correctly handle `flush` messages
- Support tokio's DuplexStream as an `AsyncStream`