### PR TITLE
Rework editor actions

### DIFF
--- a/benches/benchmarks/ts_update.rs
+++ b/benches/benchmarks/ts_update.rs
@@ -1,5 +1,5 @@
 // Update times for running TreeSitter syntax highlighting
-use ad_editor::{Config, buffer::Buffer, dot::TextObject, editor::Action};
+use ad_editor::{Config, buffer::Buffer, dot::TextObject, editor::BAction};
 use ad_event::Source;
 use criterion::{Criterion, criterion_group};
 use parking_lot::RwLock;
@@ -26,8 +26,8 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("append newline and update", |b| {
         b.iter(|| {
-            buf.handle_action(Action::DotSet(TextObject::BufferEnd, 1), Source::Fsys);
-            buf.handle_action(Action::InsertChar { c: '\n' }, Source::Fsys);
+            buf.handle_action(BAction::DotSet(TextObject::BufferEnd, 1), Source::Fsys);
+            buf.handle_action(BAction::InsertChar { c: '\n' }, Source::Fsys);
             buf.update_ts_state(0, 70);
         })
     });

--- a/crates/ad_client/src/sync/mod.rs
+++ b/crates/ad_client/src/sync/mod.rs
@@ -452,7 +452,11 @@ mod tests {
         EventData, EventOutcome,
         test_util::{TestEditor, mbs_cancelled, mbs_line, mbs_user},
     };
-    use ad_editor::{editor::Action, input::Event, key::Input};
+    use ad_editor::{
+        editor::{Action, BAction, EAction},
+        input::Event,
+        key::Input,
+    };
     use ad_event::Source;
     use simple_test_case::test_case;
     use std::{
@@ -648,10 +652,10 @@ mod tests {
         }
     }
 
-    #[test_case(Action::LoadDot { new_window: false }, "load"; "load")]
-    #[test_case(Action::ExecuteDot , "execute"; "execute")]
-    #[test_case(Action::InsertChar { c: 'a' } , "insert"; "insert")]
-    #[test_case(Action::Delete, "delete"; "delete")]
+    #[test_case(EAction::LoadDot { bufid: None, new_window: false }.into(), "load"; "load")]
+    #[test_case(EAction::ExecuteDot { bufid: None }.into(), "execute"; "execute")]
+    #[test_case(BAction::InsertChar { c: 'a' }.for_active(), "insert"; "insert")]
+    #[test_case(BAction::Delete.for_active(), "delete"; "delete")]
     #[test]
     fn run_event_filter_works(action: Action, expected: &str) {
         let (client, ted) = prepare(&[("foo", "foo content")]);
@@ -684,7 +688,9 @@ mod tests {
         let current_id = client.current_buffer().unwrap();
         assert_eq!(current_id, 1);
 
-        _ = ted.tx.send(Event::Action(Action::InsertChar { c: 'a' }));
+        _ = ted
+            .tx
+            .send(Event::action(BAction::InsertChar { c: 'a' }.for_active()));
 
         let body = client.for_buffer(1).read_body().unwrap();
         assert_eq!(body, "afoo content");

--- a/crates/ad_client/src/tokio/mod.rs
+++ b/crates/ad_client/src/tokio/mod.rs
@@ -488,7 +488,11 @@ mod tests {
         EventData, EventOutcome,
         test_util::{TestEditor, mbs_cancelled, mbs_line, mbs_user},
     };
-    use ad_editor::{editor::Action, input::Event, key::Input};
+    use ad_editor::{
+        editor::{Action, BAction, EAction},
+        input::Event,
+        key::Input,
+    };
     use ad_event::Source;
     use simple_test_case::test_case;
     use std::{sync::Arc, time::Duration};
@@ -683,10 +687,10 @@ mod tests {
         }
     }
 
-    #[test_case(Action::LoadDot { new_window: false }, "load"; "load")]
-    #[test_case(Action::ExecuteDot , "execute"; "execute")]
-    #[test_case(Action::InsertChar { c: 'a' } , "insert"; "insert")]
-    #[test_case(Action::Delete, "delete"; "delete")]
+    #[test_case(EAction::LoadDot { bufid: None, new_window: false }.into(), "load"; "load")]
+    #[test_case(EAction::ExecuteDot { bufid: None }.into(), "execute"; "execute")]
+    #[test_case(BAction::InsertChar { c: 'a' }.for_active() , "insert"; "insert")]
+    #[test_case(BAction::Delete.for_active(), "delete"; "delete")]
     #[tokio::test]
     async fn run_event_filter_works(action: Action, expected: &str) {
         let (client, ted) = prepare(&[("foo", "foo content")]).await;
@@ -718,7 +722,9 @@ mod tests {
         let current_id = client.current_buffer().await.unwrap();
         assert_eq!(current_id, 1);
 
-        _ = ted.tx.send(Event::Action(Action::InsertChar { c: 'a' }));
+        _ = ted
+            .tx
+            .send(Event::action(BAction::InsertChar { c: 'a' }.for_active()));
 
         let body = client.for_buffer(1).read_body().await.unwrap();
         assert_eq!(body, "afoo content");

--- a/fuzz/fuzz_targets/fuzz_input_handling.rs
+++ b/fuzz/fuzz_targets/fuzz_input_handling.rs
@@ -2,7 +2,7 @@
 
 use ad_editor::{
     Config, Editor, EditorMode, LogBuffer, PlumbingRules,
-    editor::{Action, Click, MiniBufferState},
+    editor::{Click, EAction, MiniBufferState},
     input::Event,
     key::Input,
     system::System,
@@ -114,7 +114,7 @@ impl UserInterface for ScriptedUi {
     ) {
         let event = match self.actions.pop() {
             Some(TestAction::Input(input)) => Event::Input(input),
-            None => Event::Action(Action::Exit { force: true }),
+            None => Event::action(EAction::Exit { force: true }),
         };
 
         self.tx.as_ref().unwrap().send(event).unwrap();

--- a/reference-tests/src/lib.rs
+++ b/reference-tests/src/lib.rs
@@ -1,6 +1,6 @@
 //! Reference editing tests for the ad Buffer implementation using
 //! <https://github.com/josephg/editing-traces>
-use ad_editor::{Source, buffer::Buffer, editor::Action};
+use ad_editor::{Source, buffer::Buffer, editor::BAction};
 use libflate::gzip::Decoder;
 use serde::Deserialize;
 use std::{
@@ -70,12 +70,12 @@ impl TestPatch {
     pub fn apply(self, b: &mut Buffer) {
         if self.delete_len > 0 {
             b.set_dot_from_range(self.position, self.position + self.delete_len - 1);
-            b.handle_action(Action::Delete, Source::Fsys);
+            b.handle_action(BAction::Delete, Source::Fsys);
         }
 
         b.set_dot_from_cursor(self.position);
         b.handle_action(
-            Action::InsertString {
+            BAction::InsertString {
                 s: self.insert_content,
             },
             Source::Fsys,

--- a/src/buffer/buffers.rs
+++ b/src/buffer/buffers.rs
@@ -3,8 +3,8 @@ use crate::{
     config::Config,
     dot::TextObject,
     lsp::LspManagerHandle,
-    ziplist,
     ziplist::{Position, ZipList},
+    zlist,
 };
 use ad_event::Source;
 use parking_lot::RwLock;
@@ -41,7 +41,7 @@ impl Buffers {
     pub fn new(lsp_handle: Arc<LspManagerHandle>, config: Arc<RwLock<Config>>) -> Self {
         Self {
             next_id: 1,
-            inner: ziplist![Buffer::new_unnamed(0, "", config.clone())],
+            inner: zlist![Buffer::new_unnamed(0, "", config.clone())],
             jump_list: JumpList::default(),
             lsp_handle,
             config,
@@ -52,7 +52,7 @@ impl Buffers {
     pub(crate) fn new_with_raw_sender(tx_req: Sender<Req>, config: Arc<RwLock<Config>>) -> Self {
         Self {
             next_id: 1,
-            inner: ziplist![Buffer::new_unnamed(0, "", config.clone())],
+            inner: zlist![Buffer::new_unnamed(0, "", config.clone())],
             jump_list: JumpList::default(),
             lsp_handle: Arc::new(LspManagerHandle::new_stubbed(tx_req)),
             config,

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     Config, MAX_NAME_LEN, UNNAMED_BUFFER,
     config::ftype_config_for_path_and_first_line,
     dot::{Cur, Dot, Range, TextObject, find::find_forward_wrapping},
-    editor::BAction,
+    editor::{ActionOutcome, BAction},
     exec::{Addr, Address},
     fsys::InputFilter,
     lsp::Coords,
@@ -54,14 +54,6 @@ pub(crate) const WELCOME_SQUIRREL: &str = r#"+----------------------------------
 pub(crate) const DEFAULT_OUTPUT_BUFFER: &str = "+output";
 const HTTPS: &str = "https://";
 const HTTP: &str = "http://";
-
-// Used to inform the editor that further action needs to be taken by it after a Buffer has
-// finished processing a given Action.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ActionOutcome {
-    SetClipboard(String),
-    SetStatusMessage(String),
-}
 
 /// Buffer kinds control how each buffer interacts with the rest of the editor functionality
 #[derive(Default, Debug, Clone, PartialEq, Eq)]

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -3,10 +3,9 @@ use crate::{
     Config, MAX_NAME_LEN, UNNAMED_BUFFER,
     config::ftype_config_for_path_and_first_line,
     dot::{Cur, Dot, Range, TextObject, find::find_forward_wrapping},
-    editor::Action,
+    editor::BAction,
     exec::{Addr, Address},
     fsys::InputFilter,
-    key::Input,
     lsp::Coords,
     syntax::{LineIter, SyntaxState},
     util::{normalize_line_endings, truncate_string_to_columns},
@@ -616,12 +615,12 @@ impl Buffer {
 
     /// Fully clear the contents of this buffer, notifying fsys of the change
     pub fn clear(&mut self) {
-        self.handle_action(Action::DotSet(TextObject::BufferStart, 1), Source::Fsys);
+        self.handle_action(BAction::DotSet(TextObject::BufferStart, 1), Source::Fsys);
         self.handle_action(
-            Action::DotExtendForward(TextObject::BufferEnd, 1),
+            BAction::DotExtendForward(TextObject::BufferEnd, 1),
             Source::Fsys,
         );
-        self.handle_action(Action::Delete, Source::Fsys);
+        self.handle_action(BAction::Delete, Source::Fsys);
         self.xdot.clamp_idx(self.txt.len_chars());
     }
 
@@ -875,7 +874,7 @@ impl Buffer {
     pub(crate) fn append(&mut self, s: String, source: Source) {
         let dot = self.dot;
         self.set_dot(TextObject::BufferEnd, 1);
-        self.handle_action(Action::InsertString { s }, source);
+        self.handle_action(BAction::InsertString { s }, source);
         self.dot = dot;
         self.dot.clamp_idx(self.txt.len_chars());
         self.xdot.clamp_idx(self.txt.len_chars());
@@ -883,23 +882,28 @@ impl Buffer {
     }
 
     /// The error result of this function is an error string that should be displayed to the user
-    pub fn handle_action(&mut self, a: Action, source: Source) -> Option<ActionOutcome> {
-        match a {
-            Action::Delete => {
+    pub fn handle_action(&mut self, action: BAction, source: Source) -> Option<ActionOutcome> {
+        let (match_indent, expand_tab, tabstop) = {
+            let cfg = self.config.read();
+            (cfg.match_indent, cfg.expand_tab, cfg.tabstop)
+        };
+
+        match action {
+            BAction::Delete => {
                 let (c, deleted) = self.delete_dot(self.dot, Some(source));
                 self.dot = Dot::Cur { c };
                 self.dot.clamp_idx(self.txt.len_chars());
                 self.xdot.clamp_idx(self.txt.len_chars());
                 return deleted.map(ActionOutcome::SetClipboard);
             }
-            Action::InsertChar { c } => {
+            BAction::InsertChar { c } => {
                 let (c, _) = self.insert_char(self.dot, c, Some(source));
                 self.dot = Dot::Cur { c };
                 self.dot.clamp_idx(self.txt.len_chars());
                 self.xdot.clamp_idx(self.txt.len_chars());
                 return None;
             }
-            Action::InsertString { s } => {
+            BAction::InsertString { s } => {
                 let (c, _) = self.insert_string(self.dot, s, Some(source));
                 self.dot = Dot::Cur { c };
                 self.dot.clamp_idx(self.txt.len_chars());
@@ -907,43 +911,33 @@ impl Buffer {
                 return None;
             }
 
-            Action::Redo => return self.redo(),
-            Action::Undo => return self.undo(),
+            BAction::NewEditLogTransaction => self.new_edit_log_transaction(),
+            BAction::Redo => return self.redo(),
+            BAction::Undo => return self.undo(),
 
-            Action::CurToLine { y } => {
+            BAction::CurToLine { y } => {
                 self.dot = Dot::Cur {
                     c: Cur::from_yx(y, 0, self),
                 };
             }
 
-            Action::DotCollapseFirst => self.collapse_dot(true),
-            Action::DotCollapseLast => self.collapse_dot(false),
-            Action::DotExtendBackward(tobj, count) => self.extend_dot_backward(tobj, count),
-            Action::DotExtendForward(tobj, count) => self.extend_dot_forward(tobj, count),
-            Action::DotFlip => self.flip_dot(),
-            Action::DotSet(t, count) => self.set_dot(t, count),
-            Action::DotSetFromCoords { coords } => self.set_dot_from_coords(coords),
+            BAction::DotCollapseFirst => self.collapse_dot(true),
+            BAction::DotCollapseLast => self.collapse_dot(false),
+            BAction::DotExtendBackward(tobj, count) => self.extend_dot_backward(tobj, count),
+            BAction::DotExtendForward(tobj, count) => self.extend_dot_forward(tobj, count),
+            BAction::DotFlip => self.flip_dot(),
+            BAction::DotSet(t, count) => self.set_dot(t, count),
+            BAction::DotSetFromCoords { coords } => self.set_dot_from_coords(coords),
 
-            Action::XDotSetFromCoords { coords } => self.set_xdot_from_coords(coords),
-            Action::XInsertString { s } => self.insert_xdot(s),
+            BAction::XDotSetFromCoords { coords } => self.set_xdot_from_coords(coords),
+            BAction::XInsertString { s } => self.insert_xdot(s),
 
-            Action::RenameActiveBuffer { name } => return self.set_filename(name),
-            Action::RawInput { i } => return self.handle_raw_input(i),
+            BAction::ExpandDot => self.expand_cur_dot(),
 
-            _ => (),
-        }
+            BAction::Rename { name } => return self.set_filename(name),
+            BAction::MarkClean => self.dirty = false,
 
-        None
-    }
-
-    fn handle_raw_input(&mut self, k: Input) -> Option<ActionOutcome> {
-        let (match_indent, expand_tab, tabstop) = {
-            let cfg = self.config.read();
-            (cfg.match_indent, cfg.expand_tab, cfg.tabstop)
-        };
-
-        match k {
-            Input::Return => {
+            BAction::RawReturn => {
                 let mut s = "\n".to_string();
                 if match_indent {
                     let cur = self.dot.first_cur();
@@ -960,10 +954,9 @@ impl Buffer {
                 let c = self.insert_string(self.dot, s, Some(Source::Keyboard)).0;
 
                 self.dot = Dot::Cur { c };
-                return None;
             }
 
-            Input::Tab => {
+            BAction::RawTab => {
                 let (c, _) = if expand_tab {
                     self.insert_string(self.dot, " ".repeat(tabstop), Some(Source::Keyboard))
                 } else {
@@ -971,21 +964,16 @@ impl Buffer {
                 };
 
                 self.dot = Dot::Cur { c };
-                return None;
             }
 
-            Input::Char(ch) => {
+            BAction::RawChar(ch) => {
                 let (c, _) = self.insert_char(self.dot, ch, Some(Source::Keyboard));
                 self.dot = Dot::Cur { c };
-                return None;
             }
 
-            Input::Arrow(arr) => self.set_dot(TextObject::Arr(arr), 1),
-
-            _ => return None,
+            BAction::RawArrow(arr) => self.set_dot(TextObject::Arr(arr), 1),
         }
 
-        self.changed_since_last_render = true;
         None
     }
 
@@ -1431,7 +1419,7 @@ impl Buffer {
 
         let dot_after_edit = self.dot.with_offset_saturating(offset);
         self.dot = self.xdot;
-        self.handle_action(Action::InsertString { s }, Source::Fsys);
+        self.handle_action(BAction::InsertString { s }, Source::Fsys);
         (self.xdot, self.dot) = (self.dot, dot_after_edit);
         self.dot.clamp_idx(self.txt.len_chars()); // xdot clamped as part of handling the insert
     }
@@ -1475,7 +1463,7 @@ pub(crate) mod tests {
         let s = lines.join("\n");
 
         for c in s.chars() {
-            b.handle_action(Action::InsertChar { c }, Source::Keyboard);
+            b.handle_action(BAction::InsertChar { c }, Source::Keyboard);
         }
 
         b
@@ -1518,20 +1506,20 @@ pub(crate) mod tests {
 
         // Insert from the start of the buffer
         for c in "hello w".chars() {
-            b.handle_action(Action::InsertChar { c }, Source::Keyboard);
+            b.handle_action(BAction::InsertChar { c }, Source::Keyboard);
         }
 
         // move back to insert a character inside of the text we already have
         b.handle_action(
-            Action::DotSet(TextObject::Arr(Arrow::Left), 2),
+            BAction::DotSet(TextObject::Arr(Arrow::Left), 2),
             Source::Keyboard,
         );
-        b.handle_action(Action::InsertChar { c: ',' }, Source::Keyboard);
+        b.handle_action(BAction::InsertChar { c: ',' }, Source::Keyboard);
 
         // move forward to the end of the line to finish inserting
-        b.handle_action(Action::DotSet(TextObject::LineEnd, 1), Source::Keyboard);
+        b.handle_action(BAction::DotSet(TextObject::LineEnd, 1), Source::Keyboard);
         for c in "orld!".chars() {
-            b.handle_action(Action::InsertChar { c }, Source::Keyboard);
+            b.handle_action(BAction::InsertChar { c }, Source::Keyboard);
         }
 
         // inserted characters should be in the correct positions
@@ -1539,19 +1527,19 @@ pub(crate) mod tests {
     }
 
     #[test_case(
-        Action::InsertChar { c: 'x' },
+        BAction::InsertChar { c: 'x' },
         in_c(LINE_1.len() + 1, 'x');
         "char"
     )]
     #[test_case(
-        Action::InsertString { s: "x".to_string() },
+        BAction::InsertString { s: "x".to_string() },
         in_s(LINE_1.len() + 1, "x");
         "string"
     )]
     #[test]
-    fn insert_w_range_dot_works(a: Action, edit: Edit) {
+    fn insert_w_range_dot_works(a: BAction, edit: Edit) {
         let mut b = simple_initial_buffer();
-        b.handle_action(Action::DotSet(TextObject::Line, 1), Source::Keyboard);
+        b.handle_action(BAction::DotSet(TextObject::Line, 1), Source::Keyboard);
 
         let outcome = b.handle_action(a, Source::Keyboard);
         assert_eq!(outcome, None);
@@ -1577,7 +1565,7 @@ pub(crate) mod tests {
     #[test]
     fn move_forward_at_end_of_buffer_is_fine() {
         let mut b = Buffer::new_unnamed(0, "", Default::default());
-        b.handle_raw_input(Input::Arrow(Arrow::Right));
+        b.handle_action(BAction::RawArrow(Arrow::Right), Source::Fsys);
 
         let c = Cur { idx: 0 };
         assert_eq!(b.dot, Dot::Cur { c });
@@ -1586,7 +1574,7 @@ pub(crate) mod tests {
     #[test]
     fn delete_in_empty_buffer_is_fine() {
         let mut b = Buffer::new_unnamed(0, "", Default::default());
-        b.handle_action(Action::Delete, Source::Keyboard);
+        b.handle_action(BAction::Delete, Source::Keyboard);
         let c = Cur { idx: 0 };
         let lines = b.string_lines();
 
@@ -1600,10 +1588,10 @@ pub(crate) mod tests {
     fn simple_delete_works() {
         let mut b = simple_initial_buffer();
         b.handle_action(
-            Action::DotSet(TextObject::Arr(Arrow::Left), 1),
+            BAction::DotSet(TextObject::Arr(Arrow::Left), 1),
             Source::Keyboard,
         );
-        b.handle_action(Action::Delete, Source::Keyboard);
+        b.handle_action(BAction::Delete, Source::Keyboard);
 
         let c = Cur::from_yx(1, LINE_2.len() - 1, &b);
         let lines = b.string_lines();
@@ -1624,8 +1612,8 @@ pub(crate) mod tests {
     #[test]
     fn delete_range_works() {
         let mut b = simple_initial_buffer();
-        b.handle_action(Action::DotSet(TextObject::Line, 1), Source::Keyboard);
-        b.handle_action(Action::Delete, Source::Keyboard);
+        b.handle_action(BAction::DotSet(TextObject::Line, 1), Source::Keyboard);
+        b.handle_action(BAction::Delete, Source::Keyboard);
 
         let c = Cur::from_yx(1, 0, &b);
         let lines = b.string_lines();
@@ -1661,19 +1649,19 @@ pub(crate) mod tests {
         b.new_edit_log_transaction();
 
         b.handle_action(
-            Action::DotExtendBackward(TextObject::Word, 1),
+            BAction::DotExtendBackward(TextObject::Word, 1),
             Source::Keyboard,
         );
-        b.handle_action(Action::Delete, Source::Keyboard);
+        b.handle_action(BAction::Delete, Source::Keyboard);
 
         b.set_dot(TextObject::BufferStart, 1);
         b.handle_action(
-            Action::DotExtendForward(TextObject::Word, 1),
+            BAction::DotExtendForward(TextObject::Word, 1),
             Source::Keyboard,
         );
-        b.handle_action(Action::Delete, Source::Keyboard);
+        b.handle_action(BAction::Delete, Source::Keyboard);
 
-        b.handle_action(Action::Undo, Source::Keyboard);
+        b.handle_action(BAction::Undo, Source::Keyboard);
 
         let lines = b.string_lines();
 
@@ -1686,7 +1674,7 @@ pub(crate) mod tests {
         let mut b = Buffer::new_unnamed(0, initial_content, Default::default());
 
         b.insert_string(Dot::Cur { c: c(0) }, "bar".to_string(), None);
-        b.handle_action(Action::Undo, Source::Keyboard);
+        b.handle_action(BAction::Undo, Source::Keyboard);
 
         assert_eq!(b.string_lines(), vec!["foo foo foo", ""]);
     }
@@ -1698,7 +1686,7 @@ pub(crate) mod tests {
 
         let r = Range::from_cursors(c(0), c(2), true);
         b.delete_dot(Dot::Range { r }, None);
-        b.handle_action(Action::Undo, Source::Keyboard);
+        b.handle_action(BAction::Undo, Source::Keyboard);
 
         assert_eq!(b.string_lines(), vec!["foo foo foo", ""]);
     }
@@ -1714,8 +1702,8 @@ pub(crate) mod tests {
 
         assert_eq!(b.string_lines(), vec!["bar foo foo", ""]);
 
-        b.handle_action(Action::Undo, Source::Keyboard);
-        b.handle_action(Action::Undo, Source::Keyboard);
+        b.handle_action(BAction::Undo, Source::Keyboard);
+        b.handle_action(BAction::Undo, Source::Keyboard);
 
         assert_eq!(b.string_lines(), vec!["foo foo foo", ""]);
     }
@@ -1827,7 +1815,7 @@ pub(crate) mod tests {
         b.extend_dot_forward(TextObject::BufferEnd, 1);
 
         b.handle_action(
-            Action::InsertString {
+            BAction::InsertString {
                 s: "bar".to_owned(),
             },
             Source::Fsys,
@@ -1848,7 +1836,7 @@ pub(crate) mod tests {
         b.set_dot(TextObject::BufferStart, 1);
         b.extend_dot_forward(TextObject::BufferEnd, 1);
 
-        b.handle_action(Action::InsertChar { c: 'a' }, Source::Fsys);
+        b.handle_action(BAction::InsertChar { c: 'a' }, Source::Fsys);
 
         assert_eq!(b.txt.to_string(), "a");
         assert_eq!(b.dot, Dot::Cur { c: Cur { idx: 1 } });
@@ -1858,7 +1846,7 @@ pub(crate) mod tests {
     fn match_indent_works() {
         let mut b = Buffer::new_virtual(0, "test", "  foo", Default::default());
         b.set_dot(TextObject::BufferEnd, 1);
-        b.handle_raw_input(Input::Return);
+        b.handle_action(BAction::RawReturn, Source::Fsys);
         assert_eq!(b.txt.to_string(), "  foo\n  ");
     }
 
@@ -1871,7 +1859,7 @@ pub(crate) mod tests {
             Default::default(),
         );
         b.set_dot(TextObject::BufferEnd, 1);
-        b.handle_raw_input(Input::Return);
+        b.handle_action(BAction::RawReturn, Source::Fsys);
 
         assert_eq!(
             b.txt.to_string(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,7 @@
 //! A minimal config file format for ad
 use crate::{
     buffer::Buffer,
-    editor::{Action, Actions},
+    editor::{Actions, EAction},
     key::{Arrow, Input},
     syntax::TK_DEFAULT,
     trie::Trie,
@@ -304,8 +304,12 @@ pub enum KeyAction {
 impl KeyAction {
     fn into_actions(self) -> Actions {
         match self {
-            Self::Execute { run } => Actions::Single(Action::ExecuteString { s: run }),
-            Self::Keys { send_keys } => Actions::Single(Action::SendKeys { ks: send_keys.0 }),
+            Self::Execute { run } => EAction::ExecuteString {
+                bufid: None,
+                s: run,
+            }
+            .into(),
+            Self::Keys { send_keys } => EAction::SendKeys { ks: send_keys.0 }.into(),
         }
     }
 }

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -24,12 +24,6 @@ use std::{
 };
 use tracing::{debug, error, info, trace, warn};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Actions {
-    Single(Action),
-    Multi(Vec<Action>),
-}
-
 /// How the current viewport should be set in relation to dot.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ViewPort {
@@ -41,27 +35,88 @@ pub enum ViewPort {
     Top,
 }
 
-/// Supported actions for interacting with the editor state
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Actions {
+    Single(Action),
+    Multi(Vec<Action>),
+}
+
+impl Actions {
+    pub fn single(action: impl Into<Action>) -> Self {
+        Self::Single(action.into())
+    }
+
+    pub fn multi<T>(actions: Vec<T>) -> Self
+    where
+        T: Into<Action>,
+    {
+        Self::Multi(actions.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<T> From<T> for Actions
+where
+    T: Into<Action>,
+{
+    fn from(value: T) -> Self {
+        Self::single(value)
+    }
+}
+
+impl<T> From<Vec<T>> for Actions
+where
+    T: Into<Action>,
+{
+    fn from(values: Vec<T>) -> Self {
+        Self::multi(values)
+    }
+}
+
 #[rustfmt::skip]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
-    Noop,
+    /// Actions handled by an individual buffer. If bufid is Some, the Buffer with that ID handles
+    /// the action. If bufid is None, the currently active Buffer within Buffers handles the action.
+    Buffer { bufid: Option<usize>, action: BAction },
 
-    AppendToOutputBuffer { bufid: usize, content: String },
-    BalanceActiveColumn,
-    BalanceAll,
-    BalanceColumns,
-    BalanceWindows,
-    ChangeDirectory { path: Option<String> },
-    CleanupChild { id: u32 },
-    ClearEphemeralMode { name: String },
-    ClearScratch,
-    CommandMode,
-    CurToLine { y:usize },
+    /// Actions handled by the main Editor struct directly. This includes some actions that end up
+    /// being tied to specific buffers when their execution requires state from the editor.
+    Editor(EAction),
+
+    /// Actions handled by the UI layout
+    Ui(UAction),
+}
+
+impl From<EAction> for Action {
+    fn from(action: EAction) -> Self {
+        Self::Editor(action)
+    }
+}
+
+impl From<UAction> for Action {
+    fn from(action: UAction) -> Self {
+        Self::Ui(action)
+    }
+}
+
+/// Actions handled by an individual Buffer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BAction {
+    CurToLine { y: usize },
+
     Delete,
-    DeleteBuffer { bufid: usize, force: bool },
-    DeleteColumn { force: bool },
-    DeleteWindow { force: bool },
+    InsertChar { c: char },
+    InsertString { s: String },
+    XDotSetFromCoords { coords: Coords },
+    XInsertString { s: String },
+
+    // Instead of being passed RawInput { i: Input }, we unpack only the variants of Input that a
+    // Buffer ends up processing.
+    RawReturn,
+    RawTab,
+    RawChar(char),
+    RawArrow(Arrow),
+
     DotCollapseFirst,
     DotCollapseLast,
     DotExtendBackward(TextObject, usize),
@@ -69,23 +124,69 @@ pub enum Action {
     DotFlip,
     DotSet(TextObject, usize),
     DotSetFromCoords { coords: Coords },
-    DragWindow { direction: Arrow },
-    EditCommand { cmd: String },
-    EditorCommand { cmd: String },
-    EnsureFileIsOpen { path: String },
-    ExecuteDot,
-    ExecuteString { s: String },
-    Exit { force: bool },
     ExpandDot,
+
+    MarkClean,
+    Rename { name: String },
+
+    NewEditLogTransaction,
+    Redo,
+    Undo,
+}
+
+impl BAction {
+    pub fn for_buffer(self, bufid: usize) -> Action {
+        Action::Buffer {
+            bufid: Some(bufid),
+            action: self,
+        }
+    }
+
+    pub fn for_active(self) -> Action {
+        Action::Buffer {
+            bufid: None,
+            action: self,
+        }
+    }
+}
+
+/// Actions handled by the main Editor state.
+#[rustfmt::skip]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EAction {
+    Noop,
+
+    ClearEphemeralMode { name: String },
+    CommandMode,
+    RunMode,
+    SamMode,
+    SetMode { m: &'static str },
+
+    DebugBufferContents,
+    DebugEditLog,
     FindFile { new_window: bool },
     FindRepoFile { new_window: bool },
+    KillRunningChild { idx: Option<usize> },
+    MbSelect(MbSelector),
+    SearchInCurrentBuffer,
+    SelectBuffer,
+
+    ShowHelp,
+    TsShowTree,
+    ViewLogs,
+
+    AppendToOutputBuffer { bufid: usize, content: String },
+    ChangeDirectory { path: Option<String> },
+    CleanupChild { id: u32 },
+    DeleteBuffer { bufid: usize, force: bool },
+    EnsureFileIsOpen { path: String },
+    Exit { force: bool },
     FocusBuffer { id: usize },
-    InsertChar { c: char },
-    InsertString { s: String },
+    ReloadConfig,
+
     JumpListForward,
     JumpListBack,
-    KillRunningChild { idx: Option<usize> },
-    LoadDot { new_window: bool },
+
     LspCompletion,
     LspFormat,
     LspGotoDeclaration,
@@ -99,56 +200,67 @@ pub enum Action {
     LspShowDiagnostics,
     LspStart,
     LspStop,
-    MarkClean { bufid: usize },
-    MbSelect(MbSelector),
-    NewEditLogTransaction,
-    NewColumn,
-    NewWindow,
-    NextBuffer,
-    NextColumn,
-    NextWindowInColumn,
+
     OpenFile { path: String, new_window: bool },
-    OpenTransientScratch { name: String, txt: String },
     OpenVirtualFile { name: String, txt: String, new_window: bool },
-    Paste,
+
     Plumb { txt: String, new_window: bool },
-    PreviousBuffer,
-    PreviousColumn,
-    PreviousWindowInColumn,
     RawInput { i: Input },
-    Redo,
-    ReloadActiveBuffer,
-    ReloadBuffer { id: usize },
-    ReloadConfig,
-    RenameActiveBuffer { name: String },
-    ResizeActiveColumn { delta: i16 },
-    ResizeActiveWindow { delta: i16 },
-    RunMode,
-    SamMode,
+
     SaveBuffer { force: bool },
     SaveBufferAll { force: bool },
     SaveBufferAs { path: String, force: bool },
-    SearchInCurrentBuffer,
+    ReloadBuffer { bufid: Option<usize> },
+
     SendKeys { ks: Vec<Input> },
-    SelectBuffer,
-    SetViewPort(ViewPort),
-    SetMode { m: &'static str },
+
     SetStatusMessage { message: String },
-    ShellPipe { cmd: String },
-    ShellReplace { cmd: String },
-    ShellRun { cmd: String },
-    ShellSend { cmd: String },
-    ShowHelp,
+
+    ClearScratch,
     ToggleScratch,
-    TsShowTree,
-    Undo,
-    ViewLogs,
-    XDotSetFromCoords { coords: Coords },
-    XInsertString { s: String },
+    OpenTransientScratch { name: String, txt: String },
+
+    Paste,
     Yank,
 
-    DebugBufferContents,
-    DebugEditLog,
+    EditCommand { bufid: Option<usize>, cmd: String },
+    EditorCommand { bufid: Option<usize>, cmd: String },
+    ExecuteDot { bufid: Option<usize> },
+    ExecuteString { bufid: Option<usize>, s: String },
+    LoadDot { bufid: Option<usize>, new_window: bool },
+    ShellPipe { bufid: Option<usize>, cmd: String },
+    ShellReplace { bufid: Option<usize>, cmd: String },
+    ShellRun { bufid: Option<usize>, cmd: String },
+    ShellSend { bufid: Option<usize>, cmd: String },
+}
+
+/// Actions handled by the UI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UAction {
+    BalanceActiveColumn,
+    BalanceAll,
+    BalanceColumns,
+    BalanceWindows,
+
+    DeleteColumn { force: bool },
+    DeleteWindow { force: bool },
+
+    DragWindow { direction: Arrow },
+
+    NewColumn,
+    NewWindow,
+
+    NextBuffer,
+    NextColumn,
+    NextWindowInColumn,
+    PreviousBuffer,
+    PreviousColumn,
+    PreviousWindowInColumn,
+
+    ResizeActiveColumn { delta: i16 },
+    ResizeActiveWindow { delta: i16 },
+
+    SetViewPort(ViewPort),
 }
 
 impl<S> Editor<S>
@@ -251,7 +363,7 @@ where
 
         let dir = dir.to_path_buf();
         let mb = SimpleMbSelect::new("> ", lines, move |selection| match selection {
-            MiniBufferSelection::Line { line, .. } => Some(Actions::Single(Action::OpenFile {
+            MiniBufferSelection::Line { line, .. } => Some(Actions::single(EAction::OpenFile {
                 path: dir.join(line.trim()).to_string_lossy().to_string(),
                 new_window,
             })),
@@ -318,12 +430,6 @@ where
         }
     }
 
-    pub(crate) fn mark_clean(&mut self, bufid: usize) {
-        if let Some(b) = self.layout.buffer_with_id_mut(bufid) {
-            b.dirty = false;
-        }
-    }
-
     pub(super) fn save_current_buffer(&mut self, fname: Option<String>, force: bool) {
         trace!("attempting to save current buffer");
         let p = match self.get_buffer_save_path(fname, force) {
@@ -331,7 +437,7 @@ where
             None => return,
         };
 
-        let b = self.layout.active_buffer_mut_ignoring_scratch();
+        let b = self.layout.active_buffer_ignoring_scratch_mut();
         match b.save_to_disk_at(p, force) {
             Ok(msg) => {
                 self.lsp_manager.document_changed(b);
@@ -406,7 +512,7 @@ where
             // Attempting to save without a name so we prompt for one and verify it
             (None, Bk::Unnamed) => {
                 let mb = SimpleMbSelect::new("Save as: ", Vec::new(), move |sel| {
-                    Some(Actions::Single(Action::SaveBufferAs {
+                    Some(Actions::single(EAction::SaveBufferAs {
                         path: sel.into_content()?,
                         force,
                     }))
@@ -428,8 +534,8 @@ where
                     move |sel| {
                         if let Some("y" | "Y" | "yes") = sel.into_content().as_deref() {
                             Some(Actions::Multi(vec![
-                                Action::RenameActiveBuffer { name: name.clone() },
-                                Action::SaveBuffer { force },
+                                BAction::Rename { name: name.clone() }.for_active(),
+                                EAction::SaveBuffer { force }.into(),
                             ]))
                         } else {
                             None
@@ -447,22 +553,24 @@ where
         }
 
         self.layout
-            .active_buffer_mut_ignoring_scratch()
+            .active_buffer_ignoring_scratch_mut()
             .set_filename(desired_path.clone());
 
         Some(desired_path)
     }
 
-    pub(super) fn reload_buffer(&mut self, id: usize) {
-        let msg = match self.layout.buffer_with_id_mut(id) {
-            Some(b) => {
-                let msg = b.reload_from_disk();
-                self.lsp_manager.document_changed(b);
-                msg
-            }
-            // Silently ignoring attempts to reload unknown buffers
-            None => return,
+    pub(super) fn reload_buffer(&mut self, bufid: Option<usize>) {
+        let b = match bufid {
+            Some(id) => match self.layout.buffer_with_id_mut(id) {
+                Some(b) => b,
+                // Silently ignoring attempts to reload unknown buffers
+                None => return,
+            },
+            None => self.layout.active_buffer_ignoring_scratch_mut(),
         };
+
+        let msg = b.reload_from_disk();
+        self.lsp_manager.document_changed(b);
 
         self.set_status_message(msg);
     }
@@ -480,15 +588,6 @@ where
 
         self.set_status_message(msg);
         self.ui.state_change(StateChange::ConfigUpdated);
-    }
-
-    pub(super) fn reload_active_buffer(&mut self) {
-        let msg = self
-            .layout
-            .active_buffer_mut_ignoring_scratch()
-            .reload_from_disk();
-
-        self.set_status_message(msg);
     }
 
     pub(super) fn set_mode(&mut self, name: &str) {
@@ -523,7 +622,7 @@ where
     pub(super) fn paste_from_clipboard(&mut self, source: Source) {
         trace!("pasting from clipboard");
         match self.system.read_clipboard() {
-            Ok(s) => self.handle_action(Action::InsertString { s }, source),
+            Ok(s) => self.handle_action(BAction::InsertString { s }.for_active(), source),
             Err(e) => self.set_status_message(format!("Error reading clipboard: {e}")),
         }
     }
@@ -540,9 +639,9 @@ where
 
         let mb = SimpleMbSelect::new("> ", numbered_lines, |selection| match selection {
             MiniBufferSelection::Line { cy, .. } => Some(Actions::Multi(vec![
-                Action::CurToLine { y: cy },
-                Action::DotSet(TextObject::Line, 1),
-                Action::SetViewPort(ViewPort::Center),
+                BAction::CurToLine { y: cy }.for_active(),
+                BAction::DotSet(TextObject::Line, 1).for_active(),
+                UAction::SetViewPort(ViewPort::Center).into(),
             ])),
             _ => None,
         });
@@ -593,7 +692,7 @@ where
                     .0
                     .parse::<usize>()
                     .ok()
-                    .map(|id| Actions::Single(Action::FocusBuffer { id })),
+                    .map(|id| Actions::single(EAction::FocusBuffer { id })),
                 _ => None,
             },
         );
@@ -651,10 +750,6 @@ where
         self.push_minibuffer(mb.into_selector());
     }
 
-    pub(super) fn expand_current_dot(&mut self) {
-        self.layout.active_buffer_mut().expand_cur_dot();
-    }
-
     /// Default semantics for attempting to load the current dot:
     ///   - an event filter is in place -> pass to the event filter
     ///   - a plumbing rule matches the load -> run the plumbing rule
@@ -667,11 +762,27 @@ where
     /// lifted almost directly from acme on plan9 and the curious user is encouraged to read the
     /// materials available at http://acme.cat-v.org/ to learn more about what is possible with
     /// such a system.
-    pub(super) fn default_load_dot(&mut self, source: Source, load_in_new_window: bool) {
-        // Grabbing the ID in this way allows us to treat loads in the scratch buffer as being from
-        // the active buffer.
-        let id = self.layout.active_buffer_ignoring_scratch().id;
-        let b = self.layout.active_buffer_mut();
+    pub(super) fn default_load_dot(
+        &mut self,
+        bufid: Option<usize>,
+        load_in_new_window: bool,
+        source: Source,
+    ) {
+        let (id, b) = match bufid {
+            Some(id) => match self.layout.buffer_with_id_mut(id) {
+                Some(b) => (id, b),
+                None => return,
+            },
+            None => {
+                // Grabbing the ID in this way allows us to treat loads in the scratch buffer as being from
+                // the active buffer.
+                let id = self.layout.active_buffer_ignoring_scratch().id;
+                let b = self.layout.active_buffer_mut();
+
+                (id, b)
+            }
+        };
+
         b.expand_cur_dot();
         if b.notify_load(source) {
             return; // input filter in place
@@ -800,11 +911,11 @@ where
                 let b = self.layout.active_buffer_mut();
                 b.dot = b.map_addr(&addr);
                 self.layout.clamp_scroll();
-                self.handle_action(Action::SetViewPort(ViewPort::Center), Source::Fsys);
+                self.handle_action(UAction::SetViewPort(ViewPort::Center).into(), Source::Fsys);
             }
         } else {
             b.find_forward(s);
-            self.handle_action(Action::SetViewPort(ViewPort::Center), Source::Fsys);
+            self.handle_action(UAction::SetViewPort(ViewPort::Center).into(), Source::Fsys);
         }
     }
 
@@ -817,8 +928,20 @@ where
     /// lifted almost directly from acme on plan9 and the curious user is encouraged to read the
     /// materials available at http://acme.cat-v.org/ to learn more about what is possible with
     /// such a system.
-    pub(super) fn default_execute_dot(&mut self, arg: Option<(Range, String)>, source: Source) {
-        let b = self.layout.active_buffer_mut();
+    pub(super) fn default_execute_dot(
+        &mut self,
+        bufid: Option<usize>,
+        arg: Option<(Range, String)>,
+        source: Source,
+    ) {
+        let b = match bufid {
+            Some(id) => match self.layout.buffer_with_id_mut(id) {
+                Some(b) => b,
+                None => return,
+            },
+            None => self.layout.active_buffer_mut(),
+        };
+
         b.expand_cur_dot();
         if b.notify_execute(source, arg.clone()) {
             return; // input filter in place
@@ -834,36 +957,42 @@ where
             cmd.push_str(&arg);
         }
 
-        match self.parse_command(&cmd) {
+        match self.parse_command(self.active_buffer_id(), &cmd) {
             Some(actions) => self.handle_actions(actions, source),
-            None => self.run_shell_cmd(&cmd),
+            None => self.run_shell_cmd(bufid, &cmd),
         }
     }
 
-    /// Silently focus `bufid` (no jumplist record) and execute the given string. If executing the
-    /// string doesn't change the focused buffer we then reset back to the buffer that was active.
-    pub(super) fn execute_explicit_string(&mut self, bufid: usize, s: &str, source: Source) {
+    pub(super) fn execute_explicit_string(
+        &mut self,
+        bufid: Option<usize>,
+        s: &str,
+        source: Source,
+    ) {
         let current_id = self.active_buffer_id();
-        self.layout.focus_id_silent(bufid);
+        let id = bufid.unwrap_or(current_id);
+        self.layout.focus_id_silent(id);
 
-        match self.parse_command(s.trim()) {
+        match self.parse_command(id, s.trim()) {
             Some(actions) => self.handle_actions(actions, source),
-            None => self.run_shell_cmd(s.trim()),
+            None => self.run_shell_cmd(bufid, s.trim()),
         }
 
-        if self.active_buffer_id() == bufid {
+        if self.active_buffer_id() == id {
             self.layout.focus_id_silent(current_id);
         }
     }
 
-    pub(super) fn execute_command(&mut self, cmd: &str) {
+    pub(super) fn execute_command(&mut self, bufid: Option<usize>, cmd: &str) {
+        let bufid = bufid.unwrap_or_else(|| self.active_buffer_id());
+
         debug!(%cmd, "executing command");
-        if let Some(actions) = self.parse_command(cmd.trim_end()) {
+        if let Some(actions) = self.parse_command(bufid, cmd.trim_end()) {
             self.handle_actions(actions, Source::Fsys);
         }
     }
 
-    pub(super) fn execute_edit_command(&mut self, cmd: &str) {
+    pub(super) fn execute_edit_command(&mut self, bufid: Option<usize>, cmd: &str) {
         debug!(%cmd, "executing edit command");
         let prog = match Program::try_parse(cmd) {
             Ok(prog) => prog,
@@ -875,7 +1004,14 @@ where
         };
 
         let mut buf = Vec::new();
-        let b = self.layout.active_buffer_mut_ignoring_scratch();
+        let b = match bufid {
+            Some(id) => match self.layout.buffer_with_id_mut(id) {
+                Some(b) => b,
+                None => return,
+            },
+            None => self.layout.active_buffer_ignoring_scratch_mut(),
+        };
+
         let fname = b.full_name().to_string();
 
         let mut runner = EditorRunner {
@@ -887,7 +1023,7 @@ where
         match prog.execute(b, &mut runner, &fname, &mut buf) {
             Ok(new_dot) => {
                 self.layout.record_jump_position();
-                self.layout.active_buffer_mut_ignoring_scratch().dot = new_dot;
+                self.layout.active_buffer_ignoring_scratch_mut().dot = new_dot;
             }
 
             Err(e) => self.set_status_message(format!("Error running edit command: {e:?}")),
@@ -910,9 +1046,12 @@ where
     fn set_ephemeral_mode(&mut self, name: &str) -> Vec<Action> {
         self.modes.insert(0, Mode::ephemeral_mode(name));
 
-        vec![Action::ClearEphemeralMode {
-            name: name.to_string(),
-        }]
+        vec![
+            EAction::ClearEphemeralMode {
+                name: name.to_string(),
+            }
+            .into(),
+        ]
     }
 
     pub(super) fn clear_ephemeral_mode(&mut self, name: &str) {
@@ -923,7 +1062,7 @@ where
         let mut actions = self.set_ephemeral_mode("COMMAND");
         let mb = SimpleMbSelect::new(":", Vec::new(), move |selection| {
             if let Some(cmd) = selection.into_content() {
-                actions.push(Action::EditorCommand { cmd });
+                actions.push(EAction::EditorCommand { bufid: None, cmd }.into());
             };
 
             Some(Actions::Multi(take(&mut actions)))
@@ -936,7 +1075,7 @@ where
         let mut actions = self.set_ephemeral_mode("RUN");
         let mb = SimpleMbSelect::new("!", Vec::new(), move |selection| {
             if let Some(cmd) = selection.into_content() {
-                actions.push(Action::ShellRun { cmd });
+                actions.push(EAction::ShellRun { bufid: None, cmd }.into());
             };
 
             Some(Actions::Multi(take(&mut actions)))
@@ -949,7 +1088,7 @@ where
         let mut actions = self.set_ephemeral_mode("EDIT");
         let mb = SimpleMbSelect::new("% ", Vec::new(), move |selection| {
             if let Some(cmd) = selection.into_content() {
-                actions.push(Action::EditCommand { cmd });
+                actions.push(EAction::EditCommand { bufid: None, cmd }.into());
             };
 
             Some(Actions::Multi(take(&mut actions)))
@@ -974,9 +1113,12 @@ where
         let mut actions = self.set_ephemeral_mode("LSP-RENAME");
         let mb = SimpleMbSelect::new("LSP Rename> ", Vec::new(), move |selection| {
             if let Some(new_name) = selection.into_content() {
-                actions.push(Action::LspRename {
-                    new_name: Some(new_name),
-                });
+                actions.push(
+                    EAction::LspRename {
+                        new_name: Some(new_name),
+                    }
+                    .into(),
+                );
             };
 
             Some(Actions::Multi(take(&mut actions)))
@@ -985,40 +1127,52 @@ where
         self.push_minibuffer(mb.into_selector());
     }
 
-    pub(super) fn pipe_dot_through_shell_cmd(&mut self, raw_cmd_str: &str) {
-        let (s, d) = {
-            let b = self.layout.active_buffer_ignoring_scratch();
-            (b.dot_contents(), b.dir().unwrap_or(&self.cwd))
+    pub(super) fn pipe_dot_through_shell_cmd(&mut self, bufid: Option<usize>, raw_cmd_str: &str) {
+        let b = match bufid {
+            Some(id) => match self.layout.buffer_with_id_mut(id) {
+                Some(b) => b,
+                None => return,
+            },
+            None => self.layout.active_buffer_ignoring_scratch_mut(),
         };
 
-        let id = self.active_buffer_id();
+        let (s, d, id) = (b.dot_contents(), b.dir().unwrap_or(&self.cwd), b.id);
         let res = self.system.pipe_through_command(raw_cmd_str, &s, d, id);
 
         match res {
-            Ok(s) => self.forward_action_to_active_buffer_ignoring_scratch(
-                Action::InsertString { s },
-                Source::Fsys,
-            ),
+            Ok(s) => self.handle_buffer_action(Some(id), BAction::InsertString { s }, Source::Fsys),
             Err(e) => self.set_status_message(format!("Error running external command: {e}")),
         }
     }
 
-    pub(super) fn replace_dot_with_shell_cmd(&mut self, raw_cmd_str: &str) {
-        let b = self.layout.active_buffer_ignoring_scratch();
-        let d = b.dir().unwrap_or(&self.cwd);
-        let id = b.id;
+    pub(super) fn replace_dot_with_shell_cmd(&mut self, bufid: Option<usize>, raw_cmd_str: &str) {
+        let b = match bufid {
+            Some(id) => match self.layout.buffer_with_id_mut(id) {
+                Some(b) => b,
+                None => return,
+            },
+            None => self.layout.active_buffer_ignoring_scratch_mut(),
+        };
+
+        let (d, id) = (b.dir().unwrap_or(&self.cwd), b.id);
         let res = self.system.run_command_blocking(raw_cmd_str, d, id);
 
         match res {
-            Ok(s) => self.handle_action(Action::InsertString { s }, Source::Fsys),
+            Ok(s) => self.handle_buffer_action(Some(id), BAction::InsertString { s }, Source::Fsys),
             Err(e) => self.set_status_message(format!("Error running external command: {e}")),
         }
     }
 
-    pub(super) fn run_shell_cmd(&mut self, raw_cmd_str: &str) {
-        let b = self.layout.active_buffer_ignoring_scratch();
-        let d = b.dir().unwrap_or(&self.cwd);
-        let id = b.id;
+    pub(super) fn run_shell_cmd(&mut self, bufid: Option<usize>, raw_cmd_str: &str) {
+        let b = match bufid {
+            Some(id) => match self.layout.buffer_with_id_mut(id) {
+                Some(b) => b,
+                None => return,
+            },
+            None => self.layout.active_buffer_ignoring_scratch_mut(),
+        };
+
+        let (d, id) = (b.dir().unwrap_or(&self.cwd), b.id);
         let res = self
             .system
             .run_command(raw_cmd_str, d, id, self.tx_events.clone());
@@ -1037,7 +1191,7 @@ where
         let known = self.system.running_children();
         let mb = SimpleMbSelect::new("Kill", known, |selection| match selection {
             MiniBufferSelection::Line { cy, .. } => {
-                Some(Actions::Single(Action::KillRunningChild { idx: Some(cy) }))
+                Some(Actions::single(EAction::KillRunningChild { idx: Some(cy) }))
             }
             _ => None,
         });
@@ -1060,13 +1214,13 @@ where
                     move |sel| {
                         let mut actions = match sel.into_content().as_deref() {
                             Some("y" | "Y" | "yes") => {
-                                vec![Action::ReloadBuffer { id }]
+                                vec![EAction::ReloadBuffer { bufid: Some(id) }.into()]
                             }
                             _ => return None,
                         };
 
                         if id != current_id {
-                            actions.push(Action::FocusBuffer { id });
+                            actions.push(EAction::FocusBuffer { id }.into());
                         }
 
                         Some(Actions::Multi(actions))
@@ -1189,7 +1343,7 @@ recv {}({})",
         ed.open_file("bar", false);
         assert_eq!(ed.active_buffer_id(), 2);
 
-        ed.execute_explicit_string(bufid, cmd, Source::Keyboard);
+        ed.execute_explicit_string(Some(bufid), cmd, Source::Keyboard);
         assert_eq!(ed.active_buffer_id(), active);
     }
 }

--- a/src/editor/actions.rs
+++ b/src/editor/actions.rs
@@ -263,6 +263,16 @@ pub enum UAction {
     SetViewPort(ViewPort),
 }
 
+// Used to inform the editor that further action needs to be taken by it after another component
+// has finished processing a given Action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActionOutcome {
+    Exit(bool),
+    NotifyFocusChange(usize),
+    SetClipboard(String),
+    SetStatusMessage(String),
+}
+
 impl<S> Editor<S>
 where
     S: System,
@@ -413,20 +423,6 @@ where
                 let was_last_buffer = self.layout.close_buffer(id);
                 self.running = !was_last_buffer;
             }
-        }
-    }
-
-    pub(crate) fn delete_active_window(&mut self, force: bool) {
-        let is_last_window = self.layout.close_active_window();
-        if is_last_window {
-            self.exit(force);
-        }
-    }
-
-    pub(crate) fn delete_active_column(&mut self, force: bool) {
-        let is_last_column = self.layout.close_active_column();
-        if is_last_column {
-            self.exit(force);
         }
     }
 

--- a/src/editor/commands.rs
+++ b/src/editor/commands.rs
@@ -1,9 +1,8 @@
 //! Command mode commands for ad
 use crate::{
     editor::{
-        Action::*,
         Actions::{self, *},
-        Editor, ViewPort,
+        BAction, EAction, Editor, UAction, ViewPort,
     },
     system::System,
 };
@@ -15,7 +14,7 @@ pub fn parse_command_fuzz(input: &str) {
 }
 
 fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Actions, String> {
-    if let Some(actions) = try_parse_single_char_command(input) {
+    if let Some(actions) = try_parse_single_char_command(input, active_buffer_id) {
         return Ok(actions);
     }
 
@@ -24,28 +23,29 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
 
     match command {
         "b" | "buffer" => match args.parse::<usize>() {
-            Ok(id) => Ok(Single(FocusBuffer { id })),
+            Ok(id) => Ok(EAction::FocusBuffer { id }.into()),
             Err(_) => Err(format!("'{args}' is not a valid buffer id")),
         },
-        "bn" | "next-buffer" => Ok(Single(NextBuffer)),
-        "bp" | "prev-buffer" => Ok(Single(PreviousBuffer)),
-        "next-column" => Ok(Single(NextColumn)),
-        "next-window" => Ok(Single(NextWindowInColumn)),
-        "prev-column" => Ok(Single(PreviousColumn)),
-        "prev-window" => Ok(Single(PreviousWindowInColumn)),
+        "bn" | "next-buffer" => Ok(UAction::NextBuffer.into()),
+        "bp" | "prev-buffer" => Ok(UAction::PreviousBuffer.into()),
+        "next-column" => Ok(UAction::NextColumn.into()),
+        "next-window" => Ok(UAction::NextWindowInColumn.into()),
+        "prev-column" => Ok(UAction::PreviousColumn.into()),
+        "prev-window" => Ok(UAction::PreviousWindowInColumn.into()),
 
-        "balance-all" => Ok(Single(BalanceAll)),
-        "balance-column" => Ok(Single(BalanceActiveColumn)),
-        "balance-columns" => Ok(Single(BalanceColumns)),
-        "balance-windows" => Ok(Single(BalanceWindows)),
+        "balance-all" => Ok(UAction::BalanceAll.into()),
+        "balance-column" => Ok(UAction::BalanceActiveColumn.into()),
+        "balance-columns" => Ok(UAction::BalanceColumns.into()),
+        "balance-windows" => Ok(UAction::BalanceWindows.into()),
 
         "cd" | "change-directory" => {
             if args.is_empty() {
-                Ok(Single(ChangeDirectory { path: None }))
+                Ok(EAction::ChangeDirectory { path: None }.into())
             } else {
-                Ok(Single(ChangeDirectory {
+                Ok(EAction::ChangeDirectory {
                     path: Some(args.to_string()),
-                }))
+                }
+                .into())
             }
         }
 
@@ -59,70 +59,84 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
                 }
             };
 
-            Ok(Single(MarkClean { bufid }))
+            Ok(BAction::MarkClean.for_buffer(bufid).into())
         }
 
-        "db" | "delete-buffer" => Ok(Single(DeleteBuffer {
+        "db" | "delete-buffer" => Ok(EAction::DeleteBuffer {
             bufid: try_parse_bufid(args, active_buffer_id)?,
             force: false,
-        })),
+        }
+        .into()),
 
-        "db!" | "delete-buffer!" => Ok(Single(DeleteBuffer {
+        "db!" | "delete-buffer!" => Ok(EAction::DeleteBuffer {
             bufid: try_parse_bufid(args, active_buffer_id)?,
             force: true,
-        })),
+        }
+        .into()),
 
-        "dc" | "delete-column" => Ok(Single(DeleteColumn { force: false })),
-        "dc!" | "delete-column!" => Ok(Single(DeleteColumn { force: true })),
-        "dw" | "delete-window" => Ok(Single(DeleteWindow { force: false })),
-        "dw!" | "delete-window!" => Ok(Single(DeleteWindow { force: true })),
+        "dc" | "delete-column" => Ok(UAction::DeleteColumn { force: false }.into()),
+        "dc!" | "delete-column!" => Ok(UAction::DeleteColumn { force: true }.into()),
+        "dw" | "delete-window" => Ok(UAction::DeleteWindow { force: false }.into()),
+        "dw!" | "delete-window!" => Ok(UAction::DeleteWindow { force: true }.into()),
 
-        "echo" => Ok(Single(SetStatusMessage {
+        "echo" => Ok(EAction::SetStatusMessage {
             message: args.to_string(),
-        })),
+        }
+        .into()),
 
-        "expand-dot" => Ok(Single(ExpandDot)),
+        "expand-dot" => Ok(BAction::ExpandDot.for_active().into()),
 
         "E" | "Edit" => {
             if args.is_empty() {
                 Err("No Edit script provided".to_string())
             } else {
-                Ok(Single(EditCommand {
+                Ok(EAction::EditCommand {
+                    bufid: Some(active_buffer_id),
                     cmd: args.to_string(),
-                }))
+                }
+                .into())
             }
         }
 
-        "execute" => Ok(Single(ExecuteDot)),
-        "help" => Ok(Single(ShowHelp)),
-        "kill" => Ok(Single(KillRunningChild { idx: None })),
-        "load" => Ok(Single(LoadDot { new_window: false })),
-        "plumb" => Ok(Single(Plumb {
+        "execute" => Ok(EAction::ExecuteDot {
+            bufid: Some(active_buffer_id),
+        }
+        .into()),
+        "help" => Ok(EAction::ShowHelp.into()),
+        "kill" => Ok(EAction::KillRunningChild { idx: None }.into()),
+        "load" => Ok(EAction::LoadDot {
+            bufid: Some(active_buffer_id),
+            new_window: false,
+        }
+        .into()),
+        "plumb" => Ok(EAction::Plumb {
             txt: args.to_string(),
             new_window: false,
-        })),
+        }
+        .into()),
 
-        "lsp-completion" => Ok(Single(LspCompletion)),
-        "lsp-find-references" => Ok(Single(LspReferences)),
-        "lsp-format" => Ok(Single(LspFormat)),
-        "lsp-goto-declaration" => Ok(Single(LspGotoDeclaration)),
-        "lsp-goto-definition" => Ok(Single(LspGotoDefinition)),
-        "lsp-goto-type-definition" => Ok(Single(LspGotoTypeDefinition)),
-        "lsp-hover" => Ok(Single(LspHover)),
-        "lsp-rename" => Ok(Single(LspRenamePrepare)),
-        "lsp-show-capabilities" => Ok(Single(LspShowCapabilities)),
-        "lsp-show-diagnostics" => Ok(Single(LspShowDiagnostics)),
-        "lsp-start" => Ok(Single(LspStart)),
-        "lsp-stop" => Ok(Single(LspStop)),
+        "lsp-completion" => Ok(EAction::LspCompletion.into()),
+        "lsp-find-references" => Ok(EAction::LspReferences.into()),
+        "lsp-format" => Ok(EAction::LspFormat.into()),
+        "lsp-goto-declaration" => Ok(EAction::LspGotoDeclaration.into()),
+        "lsp-goto-definition" => Ok(EAction::LspGotoDefinition.into()),
+        "lsp-goto-type-definition" => Ok(EAction::LspGotoTypeDefinition.into()),
+        "lsp-hover" => Ok(EAction::LspHover.into()),
+        "lsp-rename" => Ok(EAction::LspRenamePrepare.into()),
+        "lsp-show-capabilities" => Ok(EAction::LspShowCapabilities.into()),
+        "lsp-show-diagnostics" => Ok(EAction::LspShowDiagnostics.into()),
+        "lsp-start" => Ok(EAction::LspStart.into()),
+        "lsp-stop" => Ok(EAction::LspStop.into()),
 
         "o" | "open" => {
             if args.is_empty() {
                 Err("No filename provided".to_string())
             } else {
-                Ok(Single(OpenFile {
+                Ok(EAction::OpenFile {
                     path: args.to_string(),
                     new_window: false,
-                }))
+                }
+                .into())
             }
         }
 
@@ -130,10 +144,11 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
             if args.is_empty() {
                 Err("No filename provided".to_string())
             } else {
-                Ok(Single(OpenFile {
+                Ok(EAction::OpenFile {
                     path: args.to_string(),
                     new_window: true,
-                }))
+                }
+                .into())
             }
         }
 
@@ -142,11 +157,12 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
                 Err("No filename provided".to_string())
             } else {
                 let (name, txt) = args.split_once(' ').unwrap_or((args, ""));
-                Ok(Single(OpenVirtualFile {
+                Ok(EAction::OpenVirtualFile {
                     name: name.to_string(),
                     txt: txt.to_string(),
                     new_window: false,
-                }))
+                }
+                .into())
             }
         }
 
@@ -155,97 +171,104 @@ fn parse_command(input: &str, active_buffer_id: usize, cwd: &Path) -> Result<Act
                 Err("No filename provided".to_string())
             } else {
                 let (name, txt) = args.split_once(' ').unwrap_or((args, ""));
-                Ok(Single(OpenVirtualFile {
+                Ok(EAction::OpenVirtualFile {
                     name: name.to_string(),
                     txt: txt.to_string(),
                     new_window: true,
-                }))
+                }
+                .into())
             }
         }
 
-        "new-column" => Ok(Single(NewColumn)),
-        "new-window" => Ok(Single(NewWindow)),
+        "new-column" => Ok(UAction::NewColumn.into()),
+        "new-window" => Ok(UAction::NewWindow.into()),
 
-        "pwd" => Ok(Single(SetStatusMessage {
+        "pwd" => Ok(EAction::SetStatusMessage {
             message: cwd.display().to_string(),
-        })),
+        }
+        .into()),
 
-        "q" | "quit" | "Exit" => Ok(Single(Exit { force: false })),
-        "q!" | "quit!" | "Exit!" => Ok(Single(Exit { force: true })),
+        "q" | "quit" | "Exit" => Ok(EAction::Exit { force: false }.into()),
+        "q!" | "quit!" | "Exit!" => Ok(EAction::Exit { force: true }.into()),
 
-        "reload-config" => Ok(Single(ReloadConfig)),
+        "reload-config" => Ok(EAction::ReloadConfig.into()),
         "reload-buffer" | "Get" => {
             if args.is_empty() {
-                Ok(Single(ReloadActiveBuffer))
+                Ok(EAction::ReloadBuffer {
+                    bufid: Some(active_buffer_id),
+                }
+                .into())
             } else {
                 match args.parse::<usize>() {
-                    Ok(id) => Ok(Single(ReloadBuffer { id })),
+                    Ok(id) => Ok(EAction::ReloadBuffer { bufid: Some(id) }.into()),
                     Err(_) => Err(format!("'{args}' is not a valid buffer id")),
                 }
             }
         }
 
-        "rename-buffer" => Ok(Single(RenameActiveBuffer {
+        "rename-buffer" => Ok(BAction::Rename {
             name: args.to_string(),
-        })),
+        }
+        .for_buffer(active_buffer_id)
+        .into()),
 
         "resize-column" => match args.parse::<i16>() {
-            Ok(delta) => Ok(Single(ResizeActiveColumn { delta })),
+            Ok(delta) => Ok(UAction::ResizeActiveColumn { delta }.into()),
             Err(_) => Err(format!("'{args}' is not a valid delta")),
         },
         "resize-window" => match args.parse::<i16>() {
-            Ok(delta) => Ok(Single(ResizeActiveWindow { delta })),
+            Ok(delta) => Ok(UAction::ResizeActiveWindow { delta }.into()),
             Err(_) => Err(format!("'{args}' is not a valid delta")),
         },
 
-        "clear-scratch" => Ok(Single(ClearScratch)),
-        "toggle-scratch" => Ok(Single(ToggleScratch)),
+        "clear-scratch" => Ok(EAction::ClearScratch.into()),
+        "toggle-scratch" => Ok(EAction::ToggleScratch.into()),
 
-        "ts-show-tree" => Ok(Single(TsShowTree)),
-
-        "view-logs" => Ok(Single(ViewLogs)),
+        "ts-show-tree" => Ok(EAction::TsShowTree.into()),
+        "view-logs" => Ok(EAction::ViewLogs.into()),
 
         "w" | "write" => {
             if args.is_empty() {
-                Ok(Single(SaveBuffer { force: false }))
+                Ok(EAction::SaveBuffer { force: false }.into())
             } else {
-                Ok(Single(SaveBufferAs {
+                Ok(EAction::SaveBufferAs {
                     path: args.to_string(),
                     force: false,
-                }))
+                }
+                .into())
             }
         }
         "w!" | "write!" => {
             if args.is_empty() {
-                Ok(Single(SaveBuffer { force: true }))
+                Ok(EAction::SaveBuffer { force: true }.into())
             } else {
-                Ok(Single(SaveBufferAs {
+                Ok(EAction::SaveBufferAs {
                     path: args.to_string(),
                     force: true,
-                }))
+                }
+                .into())
             }
         }
 
-        "wa" | "write-all" => Ok(Single(SaveBufferAll { force: false })),
-        "wa!" | "write-all!" => Ok(Single(SaveBufferAll { force: true })),
+        "wa" | "write-all" => Ok(EAction::SaveBufferAll { force: false }.into()),
+        "wa!" | "write-all!" => Ok(EAction::SaveBufferAll { force: true }.into()),
 
         "wq" | "write-quit" => Ok(Multi(vec![
-            SaveBuffer { force: false },
-            Exit { force: false },
+            EAction::SaveBuffer { force: false }.into(),
+            EAction::Exit { force: false }.into(),
         ])),
 
         "wq!" | "write-quit!" => Ok(Multi(vec![
-            SaveBuffer { force: true },
-            Exit { force: true },
+            EAction::SaveBuffer { force: true }.into(),
+            EAction::Exit { force: true }.into(),
         ])),
 
-        "viewport-bottom" => Ok(Single(SetViewPort(ViewPort::Bottom))),
-        "viewport-top" => Ok(Single(SetViewPort(ViewPort::Top))),
-        "viewport-center" => Ok(Single(SetViewPort(ViewPort::Center))),
+        "viewport-bottom" => Ok(UAction::SetViewPort(ViewPort::Bottom).into()),
+        "viewport-top" => Ok(UAction::SetViewPort(ViewPort::Top).into()),
+        "viewport-center" => Ok(UAction::SetViewPort(ViewPort::Center).into()),
 
         "" => Err(String::new()),
         _ => Err(String::new()),
-        // _ => Err(format!("Not an editor command: {command}")),
     }
 }
 
@@ -253,8 +276,8 @@ impl<S> Editor<S>
 where
     S: System,
 {
-    pub(super) fn parse_command(&mut self, input: &str) -> Option<Actions> {
-        match parse_command(input, self.active_buffer_id(), &self.cwd) {
+    pub(super) fn parse_command(&mut self, bufid: usize, input: &str) -> Option<Actions> {
+        match parse_command(input, bufid, &self.cwd) {
             Ok(actions) => Some(actions),
             Err(msg) if msg.is_empty() => None,
             Err(msg) => {
@@ -276,20 +299,36 @@ fn try_parse_bufid(args: &str, active_buffer_id: usize) -> Result<usize, String>
     }
 }
 
-fn try_parse_single_char_command(input: &str) -> Option<Actions> {
+fn try_parse_single_char_command(input: &str, active_buffer_id: usize) -> Option<Actions> {
     match input.chars().next() {
-        Some('!') => Some(Single(ShellRun {
-            cmd: input[1..].to_string(),
-        })),
-        Some('|') => Some(Single(ShellPipe {
-            cmd: input[1..].to_string(),
-        })),
-        Some('<') => Some(Single(ShellReplace {
-            cmd: input[1..].to_string(),
-        })),
-        Some('>') => Some(Single(ShellSend {
-            cmd: input[1..].to_string(),
-        })),
+        Some('!') => Some(
+            EAction::ShellRun {
+                bufid: Some(active_buffer_id),
+                cmd: input[1..].to_string(),
+            }
+            .into(),
+        ),
+        Some('|') => Some(
+            EAction::ShellPipe {
+                bufid: Some(active_buffer_id),
+                cmd: input[1..].to_string(),
+            }
+            .into(),
+        ),
+        Some('<') => Some(
+            EAction::ShellReplace {
+                bufid: Some(active_buffer_id),
+                cmd: input[1..].to_string(),
+            }
+            .into(),
+        ),
+        Some('>') => Some(
+            EAction::ShellSend {
+                bufid: Some(active_buffer_id),
+                cmd: input[1..].to_string(),
+            }
+            .into(),
+        ),
 
         _ => None,
     }

--- a/src/editor/minibuffer.rs
+++ b/src/editor/minibuffer.rs
@@ -6,7 +6,7 @@ use crate::{
     Config,
     buffer::{Buffer, Buffers, GapBuffer, Slice},
     dot::TextObject,
-    editor::{Action, Actions, Editor},
+    editor::{Actions, BAction, Editor},
     input::Event,
     key::{Arrow, Input},
     system::System,
@@ -187,12 +187,12 @@ impl MiniBuffer {
         match input {
             Input::Char(c) => {
                 self.input
-                    .handle_action(Action::InsertChar { c }, Source::Keyboard);
+                    .handle_action(BAction::InsertChar { c }, Source::Keyboard);
             }
             Input::Ctrl('h') | Input::Backspace | Input::Del => {
                 for action in [
-                    Action::DotSet(TextObject::Arr(Arrow::Left), 1),
-                    Action::Delete,
+                    BAction::DotSet(TextObject::Arr(Arrow::Left), 1),
+                    BAction::Delete,
                 ] {
                     self.input.handle_action(action, Source::Keyboard);
                 }
@@ -201,17 +201,17 @@ impl MiniBuffer {
             // Readline style bindings
             Input::Ctrl('a') => {
                 self.input
-                    .handle_action(Action::DotSet(TextObject::LineStart, 1), Source::Keyboard);
+                    .handle_action(BAction::DotSet(TextObject::LineStart, 1), Source::Keyboard);
             }
             Input::Ctrl('e') => {
                 self.input
-                    .handle_action(Action::DotSet(TextObject::LineEnd, 1), Source::Keyboard);
+                    .handle_action(BAction::DotSet(TextObject::LineEnd, 1), Source::Keyboard);
             }
             Input::Ctrl('w') => {
                 for action in [
-                    Action::DotSet(TextObject::Arr(Arrow::Left), 1),
-                    Action::DotExtendBackward(TextObject::Word, 1),
-                    Action::Delete,
+                    BAction::DotSet(TextObject::Arr(Arrow::Left), 1),
+                    BAction::DotExtendBackward(TextObject::Word, 1),
+                    BAction::Delete,
                 ] {
                     self.input.handle_action(action, Source::Keyboard);
                 }
@@ -238,13 +238,13 @@ impl MiniBuffer {
             // Alt-hjkl and arrows navigate the options
             Input::Alt('h') | Input::Arrow(Arrow::Left) => {
                 self.input.handle_action(
-                    Action::DotSet(TextObject::Arr(Arrow::Left), 1),
+                    BAction::DotSet(TextObject::Arr(Arrow::Left), 1),
                     Source::Keyboard,
                 );
             }
             Input::Alt('l') | Input::Arrow(Arrow::Right) => {
                 self.input.handle_action(
-                    Action::DotSet(TextObject::Arr(Arrow::Right), 1),
+                    BAction::DotSet(TextObject::Arr(Arrow::Right), 1),
                     Source::Keyboard,
                 );
             }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1,7 +1,7 @@
 //! The main control flow and functionality of the `ad` editor.
 use crate::{
     LogBuffer,
-    buffer::{ActionOutcome, Buffer, BufferId, WELCOME_SQUIRREL},
+    buffer::{Buffer, BufferId, WELCOME_SQUIRREL},
     config::Config,
     die,
     dot::TextObject,
@@ -34,7 +34,7 @@ mod commands;
 mod minibuffer;
 mod mouse;
 
-pub use actions::{Action, BAction, EAction, UAction};
+pub use actions::{Action, ActionOutcome, BAction, EAction, UAction};
 pub use minibuffer::MiniBufferState;
 pub use mouse::Click;
 
@@ -706,75 +706,23 @@ where
             None => self.layout.active_buffer_mut(),
         };
 
-        if let Some(o) = b.handle_action(a, source) {
-            match o {
-                ActionOutcome::SetStatusMessage(msg) => self.set_status_message(&msg),
-                ActionOutcome::SetClipboard(s) => self.set_clipboard(s),
-            }
+        if let Some(ao) = b.handle_action(a, source) {
+            self.handle_action_outcome(ao);
         }
     }
 
     fn handle_ui_action(&mut self, uaction: UAction) {
-        use UAction::*;
+        if let Some(ao) = self.layout.handle_ui_action(uaction) {
+            self.handle_action_outcome(ao);
+        }
+    }
 
-        match uaction {
-            BalanceActiveColumn => self.layout.balance_active_column(),
-            BalanceAll => self.layout.balance_all(),
-            BalanceColumns => self.layout.balance_columns(),
-            BalanceWindows => self.layout.balance_windows(),
-
-            DeleteColumn { force } => self.delete_active_column(force),
-            DeleteWindow { force } => self.delete_active_window(force),
-
-            DragWindow {
-                direction: Arrow::Up,
-            } => self.layout.drag_up(),
-            DragWindow {
-                direction: Arrow::Down,
-            } => self.layout.drag_down(),
-            DragWindow {
-                direction: Arrow::Left,
-            } => self.layout.drag_left(),
-            DragWindow {
-                direction: Arrow::Right,
-            } => self.layout.drag_right(),
-
-            NewColumn => self.layout.new_column(),
-            NewWindow => self.layout.new_window(),
-            NextBuffer => {
-                let id = self.layout.focus_next_buffer();
-                _ = self.tx_fsys.send(LogEvent::Focus(id));
-            }
-            NextColumn => {
-                self.layout.next_column();
-                let id = self.active_buffer_id();
-                _ = self.tx_fsys.send(LogEvent::Focus(id));
-            }
-            NextWindowInColumn => {
-                self.layout.next_window_in_column();
-                let id = self.active_buffer_id();
-                _ = self.tx_fsys.send(LogEvent::Focus(id));
-            }
-
-            PreviousBuffer => {
-                let id = self.layout.focus_previous_buffer();
-                _ = self.tx_fsys.send(LogEvent::Focus(id));
-            }
-            PreviousColumn => {
-                self.layout.prev_column();
-                let id = self.active_buffer_id();
-                _ = self.tx_fsys.send(LogEvent::Focus(id));
-            }
-            PreviousWindowInColumn => {
-                self.layout.prev_window_in_column();
-                let id = self.active_buffer_id();
-                _ = self.tx_fsys.send(LogEvent::Focus(id));
-            }
-
-            ResizeActiveColumn { delta } => self.layout.resize_active_column(delta),
-            ResizeActiveWindow { delta } => self.layout.resize_active_window(delta),
-
-            SetViewPort(vp) => self.layout.set_viewport(vp),
+    fn handle_action_outcome(&mut self, ao: ActionOutcome) {
+        match ao {
+            ActionOutcome::Exit(force) => self.exit(force),
+            ActionOutcome::NotifyFocusChange(id) => _ = self.tx_fsys.send(LogEvent::Focus(id)),
+            ActionOutcome::SetStatusMessage(msg) => self.set_status_message(&msg),
+            ActionOutcome::SetClipboard(s) => self.set_clipboard(s),
         }
     }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -34,7 +34,7 @@ mod commands;
 mod minibuffer;
 mod mouse;
 
-pub use actions::Action;
+pub use actions::{Action, BAction, EAction, UAction};
 pub use minibuffer::MiniBufferState;
 pub use mouse::Click;
 
@@ -160,7 +160,7 @@ where
         let mut layout = Layout::new(100, 100, lsp_manager.clone(), config.clone());
         if show_splash && layout.is_empty_squirrel() {
             layout
-                .active_buffer_mut_ignoring_scratch()
+                .active_buffer_ignoring_scratch_mut()
                 .txt
                 .insert_str(0, WELCOME_SQUIRREL);
         }
@@ -353,7 +353,7 @@ where
             Event::Action(a) => self.handle_action(a, Source::Fsys),
             Event::Actions(a) => self.handle_actions(a, Source::Fsys),
             Event::BracketedPaste(s) => {
-                self.handle_action(Action::InsertString { s }, Source::Fsys)
+                self.handle_action(BAction::InsertString { s }.for_active(), Source::Fsys)
             }
             Event::Input(i) => self.handle_input(i),
             Event::Message(msg) => self.handle_message(msg),
@@ -439,7 +439,7 @@ where
 
         match req {
             ControlMessage { msg } => {
-                self.execute_command(&msg);
+                self.execute_command(None, &msg);
                 default_handled();
             }
 
@@ -467,7 +467,7 @@ where
                 b.set_dot_from_addr_string(&s);
             }),
             SetBufferDot { id, s } => self.handle_buffer_mutation(id, tx, s, |b, s| {
-                b.handle_action(Action::InsertString { s }, Source::Fsys);
+                b.handle_action(BAction::InsertString { s }, Source::Fsys);
             }),
             SetBufferXAddr { id, s } => self.handle_buffer_mutation(id, tx, s, |b, s| {
                 b.set_xdot_from_addr_string(&s);
@@ -509,7 +509,7 @@ where
             }
 
             ExecuteInBuffer { id, txt } => {
-                self.execute_explicit_string(id, &txt, Source::Fsys);
+                self.execute_explicit_string(Some(id), &txt, Source::Fsys);
                 default_handled();
             }
         }
@@ -546,54 +546,43 @@ where
 
     /// Process a single action and update editor state accordingly
     pub fn handle_action(&mut self, action: Action, source: Source) {
-        use Action::*;
-
         match action {
+            Action::Buffer { bufid, action } => {
+                self.handle_buffer_action(bufid, action, source);
+            }
+            Action::Editor(eaction) => self.handle_editor_action(eaction, source),
+            Action::Ui(uaction) => self.handle_ui_action(uaction),
+        }
+    }
+
+    fn handle_editor_action(&mut self, eaction: EAction, source: Source) {
+        use EAction::*;
+
+        match eaction {
             Noop => (),
 
             AppendToOutputBuffer { bufid, content } => self
                 .layout
                 .write_output_for_buffer(bufid, content, &self.cwd),
-            BalanceActiveColumn => self.layout.balance_active_column(),
-            BalanceAll => self.layout.balance_all(),
-            BalanceColumns => self.layout.balance_columns(),
-            BalanceWindows => self.layout.balance_windows(),
             ChangeDirectory { path } => self.change_directory(path),
             CleanupChild { id } => self.system.cleanup_child(id),
             ClearScratch => self.layout.scratch.b.clear(),
             ClearEphemeralMode { name } => self.clear_ephemeral_mode(&name),
             CommandMode => self.command_mode(),
             DeleteBuffer { bufid, force } => self.delete_buffer(bufid, force),
-            DeleteColumn { force } => self.delete_active_column(force),
-            DeleteWindow { force } => self.delete_active_window(force),
-            DragWindow {
-                direction: Arrow::Up,
-            } => self.layout.drag_up(),
-            DragWindow {
-                direction: Arrow::Down,
-            } => self.layout.drag_down(),
-            DragWindow {
-                direction: Arrow::Left,
-            } => self.layout.drag_left(),
-            DragWindow {
-                direction: Arrow::Right,
-            } => self.layout.drag_right(),
-            EditCommand { cmd } => self.execute_edit_command(&cmd),
-            EditorCommand { cmd } => self.execute_command(&cmd),
+            EditCommand { bufid, cmd } => self.execute_edit_command(bufid, &cmd),
+            EditorCommand { bufid, cmd } => self.execute_command(bufid, &cmd),
             EnsureFileIsOpen { path } => self.layout.ensure_file_is_open(&path),
-            ExecuteDot => self.default_execute_dot(None, source),
-            ExecuteString { s } => {
-                self.execute_explicit_string(self.active_buffer_id(), &s, source)
-            }
+            ExecuteDot { bufid } => self.default_execute_dot(bufid, None, source),
+            ExecuteString { bufid, s } => self.execute_explicit_string(bufid, &s, source),
             Exit { force } => self.exit(force),
-            ExpandDot => self.expand_current_dot(),
             FindFile { new_window } => self.find_file(new_window),
             FindRepoFile { new_window } => self.find_repo_file(new_window),
             FocusBuffer { id } => self.focus_buffer(id, false), // allow focusing another window
             JumpListForward => self.jump_forward(),
             JumpListBack => self.jump_backward(),
             KillRunningChild { idx } => self.kill_running_child(idx),
-            LoadDot { new_window } => self.default_load_dot(source, new_window),
+            LoadDot { bufid, new_window } => self.default_load_dot(bufid, new_window, source),
             LspShowCapabilities => {
                 if let Some((name, txt)) = self
                     .lsp_manager
@@ -639,9 +628,117 @@ where
                 .find_references(self.layout.active_buffer_ignoring_scratch()),
             LspRename { new_name } => self.lsp_rename(new_name),
             LspRenamePrepare => self.prepare_lsp_rename(),
-            MarkClean { bufid } => self.mark_clean(bufid),
             MbSelect(sel) => self.push_minibuffer(sel),
-            NewEditLogTransaction => self.layout.active_buffer_mut().new_edit_log_transaction(),
+            OpenFile { path, new_window } => {
+                self.open_file_relative_to_effective_directory(&path, new_window)
+            }
+            OpenTransientScratch { name, txt } => self.layout.open_transient_scratch(name, txt),
+            OpenVirtualFile {
+                name,
+                txt,
+                new_window,
+            } => self.open_virtual(name, txt, new_window),
+            Paste => self.paste_from_clipboard(source),
+            Plumb { txt, new_window } => self.plumb(txt, new_window),
+            ReloadBuffer { bufid } => self.reload_buffer(bufid),
+            ReloadConfig => self.reload_config(),
+            RunMode => self.run_mode(),
+            SamMode => self.sam_mode(),
+            SaveBuffer { force } => self.save_current_buffer(None, force),
+            SaveBufferAll { force } => self.save_all_buffers(force),
+            SaveBufferAs { path, force } => self.save_current_buffer(Some(path), force),
+            SearchInCurrentBuffer => self.search_in_current_buffer(),
+            SendKeys { ks } => self.handle_explicit_inputs(ks),
+            SelectBuffer => self.select_buffer(),
+            SetMode { m } => self.set_mode(m),
+            SetStatusMessage { message } => self.set_status_message(&message),
+            ShellPipe { bufid, cmd } => self.pipe_dot_through_shell_cmd(bufid, &cmd),
+            ShellReplace { bufid, cmd } => self.replace_dot_with_shell_cmd(bufid, &cmd),
+            ShellRun { bufid, cmd } => self.run_shell_cmd(bufid, &cmd),
+            ShellSend { bufid, cmd } => self.run_shell_cmd(bufid, &cmd),
+            ShowHelp => self.show_help(),
+            ToggleScratch => self.layout.toggle_scratch(),
+            TsShowTree => self.show_active_ts_tree(),
+            ViewLogs => self.view_logs(),
+            Yank => self.set_clipboard(self.layout.active_buffer().dot_contents()),
+
+            DebugBufferContents => self.debug_buffer_contents(),
+            DebugEditLog => self.debug_edit_log(),
+
+            RawInput { i } => match i {
+                Input::Mouse(evt) => self.handle_mouse_event(evt),
+
+                Input::PageUp | Input::PageDown => {
+                    let arr = if i == Input::PageUp {
+                        Arrow::Up
+                    } else {
+                        Arrow::Down
+                    };
+
+                    self.handle_buffer_action(
+                        None,
+                        BAction::DotSet(TextObject::Arr(arr), self.layout.active_window_rows()),
+                        Source::Keyboard,
+                    );
+                }
+
+                Input::Arrow(a) => self.handle_buffer_action(None, BAction::RawArrow(a), source),
+                Input::Char(c) => self.handle_buffer_action(None, BAction::RawChar(c), source),
+                Input::Return => self.handle_buffer_action(None, BAction::RawReturn, source),
+                Input::Tab => self.handle_buffer_action(None, BAction::RawTab, source),
+
+                _ => (),
+            },
+        }
+    }
+
+    pub(super) fn handle_buffer_action(
+        &mut self,
+        bufid: Option<usize>,
+        a: BAction,
+        source: Source,
+    ) {
+        let b = match bufid {
+            Some(id) => match self.layout.buffer_with_id_mut(id) {
+                Some(b) => b,
+                None => return,
+            },
+            None => self.layout.active_buffer_mut(),
+        };
+
+        if let Some(o) = b.handle_action(a, source) {
+            match o {
+                ActionOutcome::SetStatusMessage(msg) => self.set_status_message(&msg),
+                ActionOutcome::SetClipboard(s) => self.set_clipboard(s),
+            }
+        }
+    }
+
+    fn handle_ui_action(&mut self, uaction: UAction) {
+        use UAction::*;
+
+        match uaction {
+            BalanceActiveColumn => self.layout.balance_active_column(),
+            BalanceAll => self.layout.balance_all(),
+            BalanceColumns => self.layout.balance_columns(),
+            BalanceWindows => self.layout.balance_windows(),
+
+            DeleteColumn { force } => self.delete_active_column(force),
+            DeleteWindow { force } => self.delete_active_window(force),
+
+            DragWindow {
+                direction: Arrow::Up,
+            } => self.layout.drag_up(),
+            DragWindow {
+                direction: Arrow::Down,
+            } => self.layout.drag_down(),
+            DragWindow {
+                direction: Arrow::Left,
+            } => self.layout.drag_left(),
+            DragWindow {
+                direction: Arrow::Right,
+            } => self.layout.drag_right(),
+
             NewColumn => self.layout.new_column(),
             NewWindow => self.layout.new_window(),
             NextBuffer => {
@@ -658,17 +755,7 @@ where
                 let id = self.active_buffer_id();
                 _ = self.tx_fsys.send(LogEvent::Focus(id));
             }
-            OpenFile { path, new_window } => {
-                self.open_file_relative_to_effective_directory(&path, new_window)
-            }
-            OpenTransientScratch { name, txt } => self.layout.open_transient_scratch(name, txt),
-            OpenVirtualFile {
-                name,
-                txt,
-                new_window,
-            } => self.open_virtual(name, txt, new_window),
-            Paste => self.paste_from_clipboard(source),
-            Plumb { txt, new_window } => self.plumb(txt, new_window),
+
             PreviousBuffer => {
                 let id = self.layout.focus_previous_buffer();
                 _ = self.tx_fsys.send(LogEvent::Focus(id));
@@ -683,51 +770,11 @@ where
                 let id = self.active_buffer_id();
                 _ = self.tx_fsys.send(LogEvent::Focus(id));
             }
-            ReloadActiveBuffer => self.reload_active_buffer(),
-            ReloadBuffer { id } => self.reload_buffer(id),
-            ReloadConfig => self.reload_config(),
+
             ResizeActiveColumn { delta } => self.layout.resize_active_column(delta),
             ResizeActiveWindow { delta } => self.layout.resize_active_window(delta),
-            RunMode => self.run_mode(),
-            SamMode => self.sam_mode(),
-            SaveBuffer { force } => self.save_current_buffer(None, force),
-            SaveBufferAll { force } => self.save_all_buffers(force),
-            SaveBufferAs { path, force } => self.save_current_buffer(Some(path), force),
-            SearchInCurrentBuffer => self.search_in_current_buffer(),
-            SendKeys { ks } => self.handle_explicit_inputs(ks),
-            SelectBuffer => self.select_buffer(),
-            SetMode { m } => self.set_mode(m),
-            SetStatusMessage { message } => self.set_status_message(&message),
+
             SetViewPort(vp) => self.layout.set_viewport(vp),
-            ShellPipe { cmd } => self.pipe_dot_through_shell_cmd(&cmd),
-            ShellReplace { cmd } => self.replace_dot_with_shell_cmd(&cmd),
-            ShellRun { cmd } => self.run_shell_cmd(&cmd),
-            ShowHelp => self.show_help(),
-            ToggleScratch => self.layout.toggle_scratch(),
-            TsShowTree => self.show_active_ts_tree(),
-            ViewLogs => self.view_logs(),
-            Yank => self.set_clipboard(self.layout.active_buffer().dot_contents()),
-
-            DebugBufferContents => self.debug_buffer_contents(),
-            DebugEditLog => self.debug_edit_log(),
-
-            RawInput { i } if i == Input::PageUp || i == Input::PageDown => {
-                let arr = if i == Input::PageUp {
-                    Arrow::Up
-                } else {
-                    Arrow::Down
-                };
-
-                self.forward_action_to_active_buffer(
-                    DotSet(TextObject::Arr(arr), self.layout.active_window_rows()),
-                    Source::Keyboard,
-                );
-            }
-            RawInput {
-                i: Input::Mouse(evt),
-            } => self.handle_mouse_event(evt),
-
-            a => self.forward_action_to_active_buffer(a, source),
         }
     }
 
@@ -740,32 +787,6 @@ where
     fn jump_backward(&mut self) {
         if let Some(id) = self.layout.jump_backward() {
             _ = self.tx_fsys.send(LogEvent::Focus(id));
-        }
-    }
-
-    pub(super) fn forward_action_to_active_buffer(&mut self, a: Action, source: Source) {
-        if let Some(o) = self.layout.active_buffer_mut().handle_action(a, source) {
-            match o {
-                ActionOutcome::SetStatusMessage(msg) => self.set_status_message(&msg),
-                ActionOutcome::SetClipboard(s) => self.set_clipboard(s),
-            }
-        }
-    }
-
-    pub(super) fn forward_action_to_active_buffer_ignoring_scratch(
-        &mut self,
-        a: Action,
-        source: Source,
-    ) {
-        if let Some(o) = self
-            .layout
-            .active_buffer_mut_ignoring_scratch()
-            .handle_action(a, source)
-        {
-            match o {
-                ActionOutcome::SetStatusMessage(msg) => self.set_status_message(&msg),
-                ActionOutcome::SetClipboard(s) => self.set_clipboard(s),
-            }
         }
     }
 }
@@ -791,9 +812,11 @@ mod tests {
         ed.update_window_size(100, 80);
         ed.open_file(ed.cwd.join("test"), false);
         ed.handle_action(
-            Action::ShellRun {
+            EAction::ShellRun {
+                bufid: None,
                 cmd: "yes".to_string(),
-            },
+            }
+            .into(),
             Source::Keyboard,
         );
 
@@ -815,8 +838,9 @@ mod tests {
         // drain any pending writes from the script
         while let Ok(evt) = ed.rx_events.try_recv() {
             match evt {
-                Event::Action(Action::AppendToOutputBuffer { .. }) => (),
-                Event::Action(Action::CleanupChild { .. }) => (),
+                Event::Action(Action::Editor(
+                    EAction::AppendToOutputBuffer { .. } | EAction::CleanupChild { .. },
+                )) => (),
                 _ => panic!("expected AppendToOutputBuffer or CleanupChild but got {evt:?}"),
             }
         }
@@ -826,7 +850,7 @@ mod tests {
 
         match ed.rx_events.try_recv() {
             Err(_) => (),
-            Ok(Event::Action(Action::CleanupChild { .. })) => (),
+            Ok(Event::Action(Action::Editor(EAction::CleanupChild { .. }))) => (),
             Ok(evt) => panic!("expected no events or CleanupChild, got {evt:?}"),
         }
     }

--- a/src/editor/mouse.rs
+++ b/src/editor/mouse.rs
@@ -1,7 +1,7 @@
 //! Handling for acme-style mouse interactions with the editor.
 use crate::{
     dot::{Dot, Range},
-    editor::{Action, Editor},
+    editor::{BAction, Editor},
     fsys::LogEvent,
     key::{MouseButton, MouseEvent, MouseEventKind, MouseMod},
     system::System,
@@ -263,7 +263,7 @@ where
                     } else if !is_right && !*cut_handled {
                         *selection = self.layout.active_buffer().dot.as_range();
                         *cut_handled = true;
-                        self.forward_action_to_active_buffer(Action::Delete, Source::Mouse);
+                        self.handle_buffer_action(None, BAction::Delete, Source::Mouse);
                     }
                 } else if (is_right && *btn == Middle) || (!is_right && *btn == Right) {
                     self.held_click = None;
@@ -297,7 +297,7 @@ where
             // used as an argument to the command being executed.
             if is_right {
                 self.layout.active_buffer_mut().dot = Dot::from(selection);
-                self.default_load_dot(Source::Mouse, load_in_new_window);
+                self.default_load_dot(None, load_in_new_window, Source::Mouse);
             } else {
                 let dot = self.layout.active_buffer().dot;
                 self.layout.active_buffer_mut().dot = Dot::from(selection);
@@ -305,10 +305,10 @@ where
                 if dot.is_range() {
                     // Execute as if the click selection was dot then reset dot
                     let arg = dot.content(self.layout.active_buffer()).trim().to_string();
-                    self.default_execute_dot(Some((dot.as_range(), arg)), Source::Mouse);
+                    self.default_execute_dot(None, Some((dot.as_range(), arg)), Source::Mouse);
                     self.layout.active_buffer_mut().dot = dot;
                 } else {
-                    self.default_execute_dot(None, Source::Mouse);
+                    self.default_execute_dot(None, None, Source::Mouse);
                 }
             }
         } else {
@@ -320,9 +320,9 @@ where
             }
 
             if is_right {
-                self.default_load_dot(Source::Mouse, load_in_new_window);
+                self.default_load_dot(None, load_in_new_window, Source::Mouse);
             } else {
-                self.default_execute_dot(None, Source::Mouse);
+                self.default_execute_dot(None, None, Source::Mouse);
             }
         }
     }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -2,7 +2,7 @@
 use crate::{
     buffer::{Buffer, GapBuffer},
     dot::{Cur, Dot},
-    editor::Action,
+    editor::BAction,
     parse::ParseInput,
     regex::{self, Regex},
 };
@@ -123,7 +123,7 @@ impl Edit for GapBuffer {
 impl Edit for Buffer {
     fn insert(&mut self, idx: usize, s: &str) {
         self.dot = Dot::Cur { c: Cur { idx } };
-        self.handle_action(Action::InsertString { s: s.to_string() }, Source::Fsys);
+        self.handle_action(BAction::InsertString { s: s.to_string() }, Source::Fsys);
     }
 
     fn remove(&mut self, from: usize, to: usize) {
@@ -131,7 +131,7 @@ impl Edit for Buffer {
             return;
         }
         self.dot = Dot::from_char_indices(from, to.saturating_sub(1)).collapse_null_range();
-        self.handle_action(Action::Delete, Source::Fsys);
+        self.handle_action(BAction::Delete, Source::Fsys);
     }
 
     fn begin_edit_transaction(&mut self) {
@@ -508,7 +508,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{buffer::Buffer, editor::Action};
+    use crate::buffer::Buffer;
     use simple_test_case::test_case;
     use std::{collections::HashMap, env, io};
 
@@ -680,7 +680,7 @@ mod tests {
 
         prog.execute(&mut b, &mut runner, "test", &mut vec![])
             .unwrap();
-        while b.handle_action(Action::Undo, Source::Keyboard).is_none() {}
+        while b.handle_action(BAction::Undo, Source::Keyboard).is_none() {}
         let final_content = b.str_contents();
 
         assert_eq!(&final_content, initial_content);

--- a/src/fsys/mod.rs
+++ b/src/fsys/mod.rs
@@ -30,7 +30,7 @@
 //!       body
 //!       event
 //! ```
-use crate::{editor::Action, input::Event, ui::SCRATCH_ID};
+use crate::{editor::EAction, input::Event, ui::SCRATCH_ID};
 use ninep::{
     Result,
     fs::{IoUnit, Mode, Perm, Qid, Stat, Timestamp, WStat},
@@ -203,7 +203,10 @@ impl State {
             }
         };
 
-        if let Err(e) = self.tx.send(Event::Action(Action::FocusBuffer { id })) {
+        if let Err(e) = self
+            .tx
+            .send(Event::Action(EAction::FocusBuffer { id }.into()))
+        {
             error!("unable to send event to main loop: {e}");
             return Ok(0);
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -23,3 +23,18 @@ pub enum Event {
     /// A signal that our window size has changed
     WinsizeChanged { rows: usize, cols: usize },
 }
+
+impl Event {
+    pub fn action(action: impl Into<Action>) -> Self {
+        Self::Action(action.into())
+    }
+
+    pub fn actions<T>(actions: Vec<T>) -> Self
+    where
+        T: Into<Action>,
+    {
+        Self::Actions(Actions::Multi(
+            actions.into_iter().map(Into::into).collect(),
+        ))
+    }
+}

--- a/src/lsp/messages/mod.rs
+++ b/src/lsp/messages/mod.rs
@@ -1,6 +1,6 @@
 //! Traits and handlers for processing LSP messages
 use crate::{
-    editor::Action,
+    editor::BAction,
     lsp::{Coords, capabilities::PositionEncoding},
 };
 use lsp_types::{Position, TextDocumentIdentifier, TextDocumentPositionParams, TextEdit, Uri};
@@ -83,16 +83,16 @@ impl EditAction {
             s,
             use_xdot,
         }: EditAction,
-    ) -> [Action; 2] {
+    ) -> [BAction; 2] {
         if use_xdot {
             [
-                Action::XDotSetFromCoords { coords },
-                Action::XInsertString { s },
+                BAction::XDotSetFromCoords { coords },
+                BAction::XInsertString { s },
             ]
         } else {
             [
-                Action::DotSetFromCoords { coords },
-                Action::InsertString { s },
+                BAction::DotSetFromCoords { coords },
+                BAction::InsertString { s },
             ]
         }
     }
@@ -117,7 +117,7 @@ impl EditAction {
 ///   text document. Overlapping text edits are not supported.
 ///
 /// Also see <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEditArray>
-pub(crate) fn edit_actions_as_editor_actions(mut edit_actions: Vec<EditAction>) -> Vec<Action> {
+pub(crate) fn edit_actions_as_editor_actions(mut edit_actions: Vec<EditAction>) -> Vec<BAction> {
     edit_actions.sort_by_key(|a| a.coords);
     edit_actions.reverse();
 
@@ -231,7 +231,7 @@ fn main() {}"#;
                 .collect(),
         );
 
-        for action in actions {
+        for action in actions.into_iter() {
             b.handle_action(action, Source::Fsys);
         }
 
@@ -307,7 +307,7 @@ fn main() {}"#;
                 .collect(),
         );
 
-        for action in actions {
+        for action in actions.into_iter() {
             b.handle_action(action, Source::Fsys);
         }
 

--- a/src/lsp/messages/request/completion.rs
+++ b/src/lsp/messages/request/completion.rs
@@ -2,7 +2,7 @@ use crate::{
     buffer::Buffers,
     die,
     dot::{Cur, Dot, Range},
-    editor::{Action, Actions, MbSelect, MiniBufferSelection},
+    editor::{Actions, EAction, MbSelect, MiniBufferSelection},
     lsp::{
         LspManager, Pos, PositionEncoding, PreparedMessage, Req,
         capabilities::Coords,
@@ -58,7 +58,7 @@ impl LspRequest for req::Completion {
             .map(|item| Completion::new(item, pos.clone(), enc, lsp_id, &man.tx_req))
             .collect();
 
-        Some(Actions::Single(Action::MbSelect(
+        Some(Actions::single(EAction::MbSelect(
             Completions(completions).into_selector(),
         )))
     }
@@ -273,12 +273,13 @@ fn actions_for_resolved_completion_item(
 
     let actions = edit_actions_as_editor_actions(edit_actions);
 
-    Actions::Multi(actions)
+    Actions::Multi(actions.into_iter().map(|a| a.for_active()).collect())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::editor::BAction;
     use ad_event::Source;
     use simple_test_case::test_case;
     use std::sync::mpsc::channel;
@@ -295,7 +296,7 @@ mod tests {
         let mut buffers = Buffers::new_stubbed(&[1], tx, Default::default());
         buffers
             .active_mut()
-            .handle_action(Action::InsertString { s: s.to_string() }, Source::Fsys);
+            .handle_action(BAction::InsertString { s: s.to_string() }, Source::Fsys);
 
         let initial_input = completions.initial_input(&buffers);
 

--- a/src/lsp/messages/request/format.rs
+++ b/src/lsp/messages/request/format.rs
@@ -44,6 +44,8 @@ impl LspRequest for Formatting {
                 .collect(),
         );
 
-        Some(Actions::Multi(actions))
+        Some(Actions::Multi(
+            actions.into_iter().map(|a| a.for_active()).collect(),
+        ))
     }
 }

--- a/src/lsp/messages/request/goto.rs
+++ b/src/lsp/messages/request/goto.rs
@@ -1,5 +1,5 @@
 use crate::{
-    editor::{Action, Actions, ViewPort},
+    editor::{Actions, BAction, EAction, UAction, ViewPort},
     lsp::{
         LspManager, Pos,
         capabilities::Coords,
@@ -57,12 +57,13 @@ macro_rules! impl_goto_req {
                 };
 
                 Some(Actions::Multi(vec![
-                    Action::OpenFile {
+                    EAction::OpenFile {
                         path,
                         new_window: false,
-                    },
-                    Action::DotSetFromCoords { coords },
-                    Action::SetViewPort(ViewPort::Center),
+                    }
+                    .into(),
+                    BAction::DotSetFromCoords { coords }.for_active(),
+                    UAction::SetViewPort(ViewPort::Center).into(),
                 ]))
             }
         }

--- a/src/lsp/messages/request/hover.rs
+++ b/src/lsp/messages/request/hover.rs
@@ -1,5 +1,5 @@
 use crate::{
-    editor::{Action, Actions},
+    editor::{Actions, EAction},
     lsp::{
         LSP_FILE, LspManager, Pos,
         messages::{request::LspRequest, txtdoc_pos},
@@ -44,7 +44,7 @@ impl LspRequest for HoverRequest {
             }
         };
 
-        Some(Actions::Single(Action::OpenTransientScratch {
+        Some(Actions::single(EAction::OpenTransientScratch {
             name: LSP_FILE.to_string(),
             txt,
         }))

--- a/src/lsp/messages/request/references.rs
+++ b/src/lsp/messages/request/references.rs
@@ -1,6 +1,6 @@
 use crate::{
     buffer::Buffers,
-    editor::{Action, Actions, MbSelect, MiniBufferSelection, ViewPort},
+    editor::{Actions, BAction, EAction, MbSelect, MiniBufferSelection, UAction, ViewPort},
     lsp::{
         LspManager, Pos, PositionEncoding,
         capabilities::Coords,
@@ -48,12 +48,15 @@ impl LspRequest for req::References {
             .collect();
         let mut actions: Vec<_> = refs
             .iter()
-            .map(|r| Action::EnsureFileIsOpen {
-                path: r.path.clone(),
+            .map(|r| {
+                EAction::EnsureFileIsOpen {
+                    path: r.path.clone(),
+                }
+                .into()
             })
             .collect();
 
-        actions.push(Action::MbSelect(References(refs).into_selector()));
+        actions.push(EAction::MbSelect(References(refs).into_selector()).into());
 
         Some(Actions::Multi(actions))
     }
@@ -113,12 +116,13 @@ impl MbSelect for References {
         match sel {
             MiniBufferSelection::Line { cy, .. } => self.0.get(cy).map(|r| {
                 Actions::Multi(vec![
-                    Action::OpenFile {
+                    EAction::OpenFile {
                         path: r.path.clone(),
                         new_window: false,
-                    },
-                    Action::DotSetFromCoords { coords: r.coords },
-                    Action::SetViewPort(ViewPort::Center),
+                    }
+                    .into(),
+                    BAction::DotSetFromCoords { coords: r.coords }.for_active(),
+                    UAction::SetViewPort(ViewPort::Center).into(),
                 ])
             }),
 

--- a/src/lsp/messages/request/rename.rs
+++ b/src/lsp/messages/request/rename.rs
@@ -1,5 +1,5 @@
 use crate::{
-    editor::{Action, Actions},
+    editor::{Actions, BAction, EAction},
     lsp::{
         Coords, LspManager, Pos,
         messages::{EditAction, edit_actions_as_editor_actions, request::LspRequest, txtdoc_pos},
@@ -33,14 +33,14 @@ impl LspRequest for PrepareRenameRequest {
         _: &mut LspManager,
     ) -> Option<Actions> {
         match res {
-            Some(_) => Some(Actions::Multi(vec![
-                Action::SetStatusMessage {
+            Some(_) => Some(Actions::multi(vec![
+                EAction::SetStatusMessage {
                     message: "triggering LSP rename".to_string(),
                 },
-                Action::LspRename { new_name: None },
+                EAction::LspRename { new_name: None },
             ])),
 
-            None => Some(Actions::Single(Action::SetStatusMessage {
+            None => Some(Actions::single(EAction::SetStatusMessage {
                 message: "LSP rename not possible".into(),
             })),
         }
@@ -96,29 +96,40 @@ impl LspRequest for Rename {
             let uri = text_document.uri;
             let path = uri.to_string().strip_prefix("file://").unwrap().to_owned();
 
-            actions.push(Action::OpenFile {
-                path,
-                new_window: false,
-            });
-            actions.extend(edit_actions_as_editor_actions(
-                edits
-                    .into_iter()
-                    .map(|edit| {
-                        let edit = match edit {
-                            OneOf::Left(edit) => edit,
-                            OneOf::Right(annotated_edit) => annotated_edit.text_edit,
-                        };
+            actions.push(
+                EAction::OpenFile {
+                    path,
+                    new_window: false,
+                }
+                .into(),
+            );
 
-                        EditAction::from_text_edit(edit, enc)
-                    })
-                    .collect(),
-            ));
+            actions.extend(
+                edit_actions_as_editor_actions(
+                    edits
+                        .into_iter()
+                        .map(|edit| {
+                            let edit = match edit {
+                                OneOf::Left(edit) => edit,
+                                OneOf::Right(annotated_edit) => annotated_edit.text_edit,
+                            };
+
+                            EditAction::from_text_edit(edit, enc)
+                        })
+                        .collect(),
+                )
+                .into_iter()
+                .map(|a| a.for_active()),
+            );
         }
 
-        actions.push(Action::FocusBuffer { id: buffer_id });
-        actions.push(Action::DotSetFromCoords {
-            coords: Coords::new_from_pos(pos, enc),
-        });
+        actions.push(EAction::FocusBuffer { id: buffer_id }.into());
+        actions.push(
+            BAction::DotSetFromCoords {
+                coords: Coords::new_from_pos(pos, enc),
+            }
+            .for_active(),
+        );
 
         Some(Actions::Multi(actions))
     }

--- a/src/lsp/messages/server_notification.rs
+++ b/src/lsp/messages/server_notification.rs
@@ -3,7 +3,7 @@
 //! <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notificationMessage>
 use crate::{
     buffer::Buffers,
-    editor::{Action, Actions, MbSelect, MiniBufferSelection, ViewPort},
+    editor::{Actions, BAction, EAction, MbSelect, MiniBufferSelection, UAction, ViewPort},
     input::Event,
     lsp::{
         LspManager,
@@ -81,7 +81,7 @@ impl LspServerNotification for Progress {
                 format!("{title}: {message}")
             };
 
-            Some(Actions::Single(Action::SetStatusMessage { message }))
+            Some(Actions::single(EAction::SetStatusMessage { message }))
         };
 
         match params.value {
@@ -113,7 +113,7 @@ impl LspServerNotification for Progress {
                 man.progress_tokens(lsp_id).remove(&params.token);
 
                 // Clear the status message when progress is done
-                Some(Actions::Single(Action::SetStatusMessage {
+                Some(Actions::single(EAction::SetStatusMessage {
                     message: "".to_owned(),
                 }))
             }
@@ -191,14 +191,16 @@ impl Diagnostic {
 
     pub fn as_actions(&self) -> Actions {
         Actions::Multi(vec![
-            Action::OpenFile {
+            EAction::OpenFile {
                 path: self.path.clone(),
                 new_window: false,
-            },
-            Action::DotSetFromCoords {
+            }
+            .into(),
+            BAction::DotSetFromCoords {
                 coords: self.coords,
-            },
-            Action::SetViewPort(ViewPort::Center),
+            }
+            .for_active(),
+            UAction::SetViewPort(ViewPort::Center).into(),
         ])
     }
 }

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     buffer::{Buffer, Buffers},
     config::{FtypeConfig, LspConfig, ftype_config_for_path_and_first_line},
     die,
-    editor::{Action, MbSelect},
+    editor::{Action, EAction, MbSelect},
     input::Event,
     lsp::{
         capabilities::{Capabilities, PositionEncoding},
@@ -206,7 +206,7 @@ impl LspManagerHandle {
         let mut diags: Vec<Diagnostic> = guard.values().flatten().cloned().collect();
         diags.sort_unstable();
 
-        Action::MbSelect(Diagnostics(diags).into_selector())
+        EAction::MbSelect(Diagnostics(diags).into_selector()).into()
     }
 
     /// Notify an attached LSP server that a document has been opened.
@@ -511,9 +511,12 @@ impl LspManager {
     }
 
     fn send_status(&self, message: impl Into<String>) {
-        _ = self.tx_events.send(Event::Action(Action::SetStatusMessage {
-            message: message.into(),
-        }));
+        _ = self.tx_events.send(Event::Action(
+            EAction::SetStatusMessage {
+                message: message.into(),
+            }
+            .into(),
+        ));
     }
 
     #[inline]

--- a/src/mode/insert.rs
+++ b/src/mode/insert.rs
@@ -1,7 +1,7 @@
 //! vim style insert mode where most keys are directly modifying the buffer
 use crate::{
     dot::TextObject::*,
-    editor::{Action::*, Actions},
+    editor::{Actions, BAction::*, EAction::*},
     key::{Arrow::*, Input::*},
     keymap,
     mode::Mode,
@@ -11,37 +11,41 @@ use crate::{
 pub(crate) fn insert_mode() -> (Mode, Vec<(String, &'static str)>) {
     let (keymap, docs) = keymap! {
         "return to NORMAL mode";
-        [ Esc ] => [ SetMode { m: "NORMAL" }, NewEditLogTransaction ],
+        [ Esc ] => [ SetMode { m: "NORMAL" }.into(), NewEditLogTransaction.for_active() ],
         "toggle the visibility of the scratch buffer";
         [ Alt(';') ] => [ ToggleScratch ],
 
         "backspace";
-        [ Backspace ] => [ DotSet(Arr(Left), 1), Delete ],
+        [ Backspace ] => [ DotSet(Arr(Left), 1).for_active(), Delete.for_active() ],
         "delete";
-        [ Del ] => [ Delete ],
+        [ Del ] => [ Delete.for_active() ],
         "move to start of line";
-        [ Home ] => [ DotSet(LineStart, 1) ],
+        [ Home ] => [ DotSet(LineStart, 1).for_active() ],
         "move to end of line";
-        [ End ] => [ DotSet(LineEnd, 1) ],
+        [ End ] => [ DotSet(LineEnd, 1).for_active() ],
 
         // following vim here: alt-hjkl will move the cursor the same as normal mode hjkl
         // with the added effect of moving you to normal mode.
         "return to NORMAL mode and move one character left";
-        [ Alt('h') ] => [ SetMode { m: "NORMAL" }, DotSet(Arr(Left), 1) ],
+        [ Alt('h') ] => [ SetMode { m: "NORMAL" }.into(), DotSet(Arr(Left), 1).for_active() ],
         "return to NORMAL mode and move one line down";
-        [ Alt('j') ] => [ SetMode { m: "NORMAL" }, DotSet(Arr(Down), 1) ],
+        [ Alt('j') ] => [ SetMode { m: "NORMAL" }.into(), DotSet(Arr(Down), 1).for_active() ],
         "return to NORMAL mode and move one line up";
-        [ Alt('k') ] => [ SetMode { m: "NORMAL" }, DotSet(Arr(Up), 1) ],
+        [ Alt('k') ] => [ SetMode { m: "NORMAL" }.into(), DotSet(Arr(Up), 1).for_active() ],
         "return to NORMAL mode and move one character right";
-        [ Alt('l') ] => [ SetMode { m: "NORMAL" }, DotSet(Arr(Right), 1) ],
+        [ Alt('l') ] => [ SetMode { m: "NORMAL" }.into(), DotSet(Arr(Right), 1).for_active() ],
 
         // readline style bindings
         "move to start of line";
-        [ Ctrl('a') ] => [ DotSet(LineStart, 1) ],
+        [ Ctrl('a') ] => [ DotSet(LineStart, 1).for_active() ],
         "move to end of line";
-        [ Ctrl('e') ] => [ DotSet(LineEnd, 1) ],
+        [ Ctrl('e') ] => [ DotSet(LineEnd, 1).for_active() ],
         "delete previous word";
-        [ Ctrl('w') ] => [ DotSet(Arr(Left), 1), DotExtendBackward(Word, 1), Delete ],
+        [ Ctrl('w') ] => [
+            DotSet(Arr(Left), 1).for_active(),
+            DotExtendBackward(Word, 1).for_active(),
+            Delete.for_active()
+        ],
 
         // LSP
         "LSP: request completions";
@@ -54,9 +58,9 @@ pub(crate) fn insert_mode() -> (Mode, Vec<(String, &'static str)>) {
         keymap,
         handle_expired_pending: |keys| {
             Some(if keys.len() == 1 {
-                Actions::Single(RawInput { i: keys[0] })
+                Actions::single(RawInput { i: keys[0] })
             } else {
-                Actions::Multi(keys.iter().map(|&i| RawInput { i }).collect())
+                Actions::multi(keys.iter().map(|&i| RawInput { i }).collect())
             })
         },
     };
@@ -69,12 +73,11 @@ mod tests {
     use super::*;
     use crate::{
         config::{Inputs, KeyBindings},
-        editor::Action,
         key::Input,
     };
     use simple_test_case::test_case;
 
-    #[test_case("C-a", Some(Actions::Single(Action::DotSet(LineStart, 1))); "direct override single")]
+    #[test_case("C-a", Some(Actions::single(DotSet(LineStart, 1).for_active())); "direct override single")]
     #[test]
     fn overrides_work(binding: &str, expected_default_actions: Option<Actions>) {
         let action = r#"{ send_keys = "A" }"#;
@@ -98,7 +101,7 @@ mod tests {
         let override_actions = mode.handle_keys(&mut keys);
         assert_eq!(
             override_actions,
-            Some(Actions::Single(Action::SendKeys {
+            Some(Actions::single(SendKeys {
                 ks: vec![Input::Char('A')]
             })),
             "override"

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -106,8 +106,8 @@ macro_rules! keymap {
         }
     };
 
-    (@action $v:expr) => { $crate::editor::Actions::Single($v) };
-    (@action $($v:expr),+) => { $crate::editor::Actions::Multi(vec![$($v),+]) };
+    (@action $v:expr) => { $crate::editor::Actions::single($v) };
+    (@action $($v:expr),+) => { $crate::editor::Actions::multi(vec![$($v),+]) };
 }
 
 #[cfg(test)]

--- a/src/mode/normal.rs
+++ b/src/mode/normal.rs
@@ -1,7 +1,7 @@
 //! vim style normal mode
 use crate::{
     dot::TextObject::*,
-    editor::{Action::*, Actions, ViewPort},
+    editor::{Actions, BAction::*, EAction::*, UAction::*, ViewPort},
     key::{Arrow::*, Input::*},
     keymap,
     mode::Mode,
@@ -50,122 +50,148 @@ pub(crate) fn normal_mode() -> (Mode, Vec<(String, &'static str)>) {
 
         // Entering INSERT mode
         "enter INSERT mode at current position";
-        [ Char('i') ] => [ SetMode { m: "INSERT" }, NewEditLogTransaction ],
+        [ Char('i') ] => [
+            SetMode { m: "INSERT" }.into(),
+            NewEditLogTransaction.for_active()
+        ],
         "enter INSERT mode at start of line";
-        [ Char('I') ] => [ DotSet(LineStart, 1), SetMode { m: "INSERT" }, NewEditLogTransaction ],
+        [ Char('I') ] => [
+            DotSet(LineStart, 1).for_active(),
+            SetMode { m: "INSERT" }.into(),
+            NewEditLogTransaction.for_active()
+        ],
         "enter INSERT mode after current position";
-        [ Char('a') ] => [ DotSet(Arr(Right), 1), SetMode { m: "INSERT" }, NewEditLogTransaction ],
+        [ Char('a') ] => [
+            DotSet(Arr(Right), 1).for_active(),
+            SetMode { m: "INSERT" }.into(),
+            NewEditLogTransaction.for_active()
+        ],
         "enter INSERT mode at end of line";
-        [ Char('A') ] => [ DotSet(LineEnd, 1), SetMode { m: "INSERT" }, NewEditLogTransaction ],
+        [ Char('A') ] => [
+            DotSet(LineEnd, 1).for_active(),
+            SetMode { m: "INSERT" }.into(),
+            NewEditLogTransaction.for_active()
+        ],
         "enter INSERT mode on new line below";
-        [ Char('o') ] => [ DotSet(LineEnd, 1), SetMode { m: "INSERT" }, NewEditLogTransaction, InsertChar { c: '\n' } ],
+        [ Char('o') ] => [
+            DotSet(LineEnd, 1).for_active(),
+            SetMode { m: "INSERT" }.into(),
+            NewEditLogTransaction.for_active(),
+            InsertChar { c: '\n' }.for_active()
+        ],
         "enter INSERT mode on new line above";
-        [ Char('O') ] => [ DotSet(LineStart, 1), SetMode { m: "INSERT" }, NewEditLogTransaction, InsertChar { c: '\n' }, DotSet(Arr(Up), 1) ],
+        [ Char('O') ] => [
+            DotSet(LineStart, 1).for_active(),
+            SetMode { m: "INSERT" }.into(),
+            NewEditLogTransaction.for_active(),
+            InsertChar { c: '\n' }.for_active(),
+            DotSet(Arr(Up), 1).for_active()
+        ],
 
         // Setting dot
         // >> character positions
         "move one character left";
-        [ Char('h') ] => [ DotSet(Arr(Left), 1) ],
+        [ Char('h') ] => [ DotSet(Arr(Left), 1).for_active() ],
         "move one character down";
-        [ Char('j') ] => [ DotSet(Arr(Down), 1) ],
+        [ Char('j') ] => [ DotSet(Arr(Down), 1).for_active() ],
         "move one character up";
-        [ Char('k') ] => [ DotSet(Arr(Up), 1) ],
+        [ Char('k') ] => [ DotSet(Arr(Up), 1).for_active() ],
         "move one character right";
-        [ Char('l') ] => [ DotSet(Arr(Right), 1) ],
+        [ Char('l') ] => [ DotSet(Arr(Right), 1).for_active() ],
         // >> line anchors
         "move to start of line";
-        [ Ctrl('h') ] => [ DotSet(LineStart, 1) ],
+        [ Ctrl('h') ] => [ DotSet(LineStart, 1).for_active() ],
         "move to end of line";
-        [ Ctrl('l') ] => [ DotSet(LineEnd, 1) ],
+        [ Ctrl('l') ] => [ DotSet(LineEnd, 1).for_active() ],
         "move to start of line";
-        [ Home ] => [ DotSet(LineStart, 1) ],
+        [ Home ] => [ DotSet(LineStart, 1).for_active() ],
         "move to end of line";
-        [ End ] => [ DotSet(LineEnd, 1) ],
+        [ End ] => [ DotSet(LineEnd, 1).for_active() ],
         // >> objects
         "move forward word";
-        [ Char('w') ] => [ DotExtendForward(Word, 1), DotCollapseLast ],
+        [ Char('w') ] => [ DotExtendForward(Word, 1).for_active(), DotCollapseLast.for_active() ],
         "move backward word";
-        [ Char('b') ] => [ DotExtendBackward(Word, 1), DotCollapseFirst ],
+        [ Char('b') ] => [ DotExtendBackward(Word, 1).for_active(), DotCollapseFirst.for_active() ],
         "select current line";
-        [ Char('x') ] => [ DotSet(Line, 1) ],
+        [ Char('x') ] => [ DotSet(Line, 1).for_active() ],
         "select current paragraph";
-        [ Char('X') ] => [ DotSet(Paragraph, 1) ],
+        [ Char('X') ] => [ DotSet(Paragraph, 1).for_active() ],
         "select buffer";
-        [ Char('%') ] => [ DotSet(BufferStart, 1), DotExtendForward(BufferEnd, 1) ],
+        [ Char('%') ] => [ DotSet(BufferStart, 1).for_active(), DotExtendForward(BufferEnd, 1).for_active() ],
         "move to end of paragraph";
-        [ Char('{') ] => [ DotExtendBackward(Paragraph, 1), DotCollapseFirst ],
+        [ Char('{') ] => [ DotExtendBackward(Paragraph, 1).for_active(), DotCollapseFirst.for_active() ],
         "move to start of paragraph";
-        [ Char('}') ] => [ DotExtendForward(Paragraph, 1), DotCollapseLast ],
+        [ Char('}') ] => [ DotExtendForward(Paragraph, 1).for_active(), DotCollapseLast.for_active() ],
 
         "move to start of buffer";
-        [ Char('g'), Char('g') ] => [ DotSet(BufferStart, 1) ],
+        [ Char('g'), Char('g') ] => [ DotSet(BufferStart, 1).for_active() ],
         "move to end of buffer";
-        [ Char('g'), Char('e') ] => [ DotSet(BufferEnd, 1) ],
+        [ Char('g'), Char('e') ] => [ DotSet(BufferEnd, 1).for_active() ],
         "move to start of line";
-        [ Char('g'), Char('h') ] => [ DotSet(LineStart, 1) ],
+        [ Char('g'), Char('h') ] => [ DotSet(LineStart, 1).for_active() ],
         "move to end of line";
-        [ Char('g'), Char('l') ] => [ DotSet(LineEnd, 1) ],
+        [ Char('g'), Char('l') ] => [ DotSet(LineEnd, 1).for_active() ],
 
         // Delimited pairs
         "select inside of parens";
-        [ Alt('i'), Char('(') ] => [ DotSet(Delimited('(', ')'), 1) ],
+        [ Alt('i'), Char('(') ] => [ DotSet(Delimited('(', ')'), 1).for_active() ],
         "select inside of parens";
-        [ Alt('i'), Char(')') ] => [ DotSet(Delimited('(', ')'), 1) ],
+        [ Alt('i'), Char(')') ] => [ DotSet(Delimited('(', ')'), 1).for_active() ],
         "select inside of brackets";
-        [ Alt('i'), Char('[') ] => [ DotSet(Delimited('[', ']'), 1) ],
+        [ Alt('i'), Char('[') ] => [ DotSet(Delimited('[', ']'), 1).for_active() ],
         "select inside of brackets";
-        [ Alt('i'), Char(']') ] => [ DotSet(Delimited('[', ']'), 1) ],
+        [ Alt('i'), Char(']') ] => [ DotSet(Delimited('[', ']'), 1).for_active() ],
         "select inside of curlies";
-        [ Alt('i'), Char('{') ] => [ DotSet(Delimited('{', '}'), 1) ],
+        [ Alt('i'), Char('{') ] => [ DotSet(Delimited('{', '}'), 1).for_active() ],
         "select inside of curlies";
-        [ Alt('i'), Char('}') ] => [ DotSet(Delimited('{', '}'), 1) ],
+        [ Alt('i'), Char('}') ] => [ DotSet(Delimited('{', '}'), 1).for_active() ],
         "select inside of angle brackets";
-        [ Alt('i'), Char('<') ] => [ DotSet(Delimited('<', '>'), 1) ],
+        [ Alt('i'), Char('<') ] => [ DotSet(Delimited('<', '>'), 1).for_active() ],
         "select inside of angle brackets";
-        [ Alt('i'), Char('>') ] => [ DotSet(Delimited('<', '>'), 1) ],
+        [ Alt('i'), Char('>') ] => [ DotSet(Delimited('<', '>'), 1).for_active() ],
         "select inside of double quotes";
-        [ Alt('i'), Char('"') ] => [ DotSet(Delimited('"', '"'), 1) ],
+        [ Alt('i'), Char('"') ] => [ DotSet(Delimited('"', '"'), 1).for_active() ],
         "select inside of single quotes";
-        [ Alt('i'), Char('\'') ] => [ DotSet(Delimited('\'', '\''), 1) ],
+        [ Alt('i'), Char('\'') ] => [ DotSet(Delimited('\'', '\''), 1).for_active() ],
         "select inside of forward slashes";
-        [ Alt('i'), Char('/') ] => [ DotSet(Delimited('/', '/'), 1) ],
+        [ Alt('i'), Char('/') ] => [ DotSet(Delimited('/', '/'), 1).for_active() ],
 
         // Extending dot
         // >> character positions
         "extend selection one character left";
-        [ Char('H') ] => [ DotExtendBackward(Character, 1) ],
+        [ Char('H') ] => [ DotExtendBackward(Character, 1).for_active() ],
         "extend selection one line down";
-        [ Char('J') ] => [ DotExtendForward(Line, 1) ],
+        [ Char('J') ] => [ DotExtendForward(Line, 1).for_active() ],
         "extend selection one line up";
-        [ Char('K') ] => [ DotExtendBackward(Line, 1) ],
+        [ Char('K') ] => [ DotExtendBackward(Line, 1).for_active() ],
         "extend selection one character right";
-        [ Char('L') ] => [ DotExtendForward(Character, 1) ],
+        [ Char('L') ] => [ DotExtendForward(Character, 1).for_active() ],
         // >> lines
         "extend selection to start of line";
-        [ Alt('h') ] => [ DotExtendBackward(LineStart, 1) ],
+        [ Alt('h') ] => [ DotExtendBackward(LineStart, 1).for_active() ],
         "extend selection one line down";
-        [ Alt('j') ] => [ DotExtendForward(Line, 1) ],
+        [ Alt('j') ] => [ DotExtendForward(Line, 1).for_active() ],
         "extend selection one line up";
-        [ Alt('k') ] => [ DotExtendBackward(Line, 1) ],
+        [ Alt('k') ] => [ DotExtendBackward(Line, 1).for_active() ],
         "extend selection to end of line";
-        [ Alt('l') ] => [ DotExtendForward(LineEnd, 1) ],
+        [ Alt('l') ] => [ DotExtendForward(LineEnd, 1).for_active() ],
         // >> objects
         "extend selection forward one word";
-        [ Char('W') ] => [ DotExtendForward(Word, 1) ],
+        [ Char('W') ] => [ DotExtendForward(Word, 1).for_active() ],
         "extend selection backward one word";
-        [ Char('B') ] => [ DotExtendBackward(Word, 1) ],
+        [ Char('B') ] => [ DotExtendBackward(Word, 1).for_active() ],
         "extend selection to end of paragraph";
-        [ Alt('{') ] => [ DotExtendBackward(Paragraph, 1) ],
+        [ Alt('{') ] => [ DotExtendBackward(Paragraph, 1).for_active() ],
         "extend selection to start of paragraph";
-        [ Alt('}') ] => [ DotExtendForward(Paragraph, 1) ],
+        [ Alt('}') ] => [ DotExtendForward(Paragraph, 1).for_active() ],
 
         // Manipulate dot
         "flip active cursor";
-        [ Char(';') ] => [ DotFlip ],
+        [ Char(';') ] => [ DotFlip.for_active() ],
         "collapse dot to start";
-        [ Char(',') ] => [ DotCollapseFirst ],
+        [ Char(',') ] => [ DotCollapseFirst.for_active() ],
         "collapse dot to end";
-        [ Alt(',') ] => [ DotCollapseLast ],
+        [ Alt(',') ] => [ DotCollapseLast.for_active() ],
 
         // Manipulating viewport
         "set viewport to top";
@@ -195,17 +221,17 @@ pub(crate) fn normal_mode() -> (Mode, Vec<(String, &'static str)>) {
 
         // Editing actions
         "delete current selection and enter INSERT mode";
-        [ Char('c') ] => [ Delete, SetMode { m: "INSERT" } ],
+        [ Char('c') ] => [ Delete.for_active(), SetMode { m: "INSERT" }.into() ],
         "delete current selection";
-        [ Char('d') ] => [ Delete ],
+        [ Char('d') ] => [ Delete.for_active() ],
         "paste";
-        [ Char('p') ] => [ NewEditLogTransaction, Paste, NewEditLogTransaction ],
+        [ Char('p') ] => [ NewEditLogTransaction.for_active(), Paste.into(), NewEditLogTransaction.for_active() ],
         "yank (copy)";
         [ Char('y') ] => [ Yank ],
         "undo";
-        [ Char('u') ] => [ Undo ],
+        [ Char('u') ] => [ Undo.for_active() ],
         "redo";
-        [ Char('U') ] => [ Redo ],
+        [ Char('U') ] => [ Redo.for_active() ],
 
         "move backward in the jump list";
         [ Ctrl('o') ] => [ JumpListBack ],
@@ -217,13 +243,13 @@ pub(crate) fn normal_mode() -> (Mode, Vec<(String, &'static str)>) {
         [ Alt(']') ] => [ JumpListForward ],
 
         "load dot in current window";
-        [ Return ] => [ LoadDot { new_window: false } ],
+        [ Return ] => [ LoadDot { bufid: None, new_window: false } ],
         "load dot in new window";
-        [ AltReturn ] => [ LoadDot { new_window: true } ],
+        [ AltReturn ] => [ LoadDot { bufid: None, new_window: true } ],
         "execute dot";
-        [ Char('@') ] => [ ExecuteDot ],
+        [ Char('@') ] => [ ExecuteDot { bufid: None } ],
         "expand dot";
-        [ Char('*') ] => [ ExpandDot ],
+        [ Char('*') ] => [ ExpandDot.for_active() ],
 
         // LSP
         "LSP: show diagnostics";
@@ -252,7 +278,7 @@ pub(crate) fn normal_mode() -> (Mode, Vec<(String, &'static str)>) {
             }
             let i = keys[0];
             match i {
-                Mouse(_) | Arrow(_) | PageUp | PageDown => Some(Actions::Single(RawInput { i })),
+                Mouse(_) | Arrow(_) | PageUp | PageDown => Some(Actions::single(RawInput { i })),
                 _ => None,
             }
         },
@@ -266,13 +292,12 @@ mod tests {
     use super::*;
     use crate::{
         config::{Inputs, KeyBindings},
-        editor::Action,
         key::Input,
     };
     use simple_test_case::test_case;
 
-    #[test_case("C-k", Some(Actions::Single(Action::LspHover)); "direct override single")]
-    #[test_case("g d", Some(Actions::Single(Action::LspGotoDefinition)); "direct override sequence")]
+    #[test_case("C-k", Some(Actions::single(LspHover)); "direct override single")]
+    #[test_case("g d", Some(Actions::single(LspGotoDefinition)); "direct override sequence")]
     #[test_case("z x", None; "sharing prefix with defaults")]
     #[test]
     fn overrides_work(binding: &str, expected_default_actions: Option<Actions>) {
@@ -297,7 +322,7 @@ mod tests {
         let override_actions = mode.handle_keys(&mut keys);
         assert_eq!(
             override_actions,
-            Some(Actions::Single(Action::SendKeys {
+            Some(Actions::single(SendKeys {
                 ks: vec![Input::Char('A')]
             })),
             "override"

--- a/src/syntax/ts.rs
+++ b/src/syntax/ts.rs
@@ -534,7 +534,7 @@ mod tests {
     use crate::{
         buffer::Buffer,
         dot::{Cur, Dot},
-        editor::Action,
+        editor::BAction,
         syntax::{RangeToken, SyntaxState, SyntaxStateInner},
     };
     use ad_event::Source;
@@ -550,7 +550,7 @@ mod tests {
     #[test_case(
         |b| {
             b.dot = Dot::Cur { c: Cur { idx: 9 } };
-            b.handle_action(Action::Delete, Source::Fsys);
+            b.handle_action(BAction::Delete, Source::Fsys);
         };
         "cur delete"
     )]

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,6 +1,6 @@
 //! An abstraction around system interactions to support testing and
 //! platform specific behaviour
-use crate::{editor::Action, input::Event, util::normalize_line_endings};
+use crate::{editor::EAction, input::Event, util::normalize_line_endings};
 use std::{
     env, fmt,
     io::{self, BufRead, BufReader, Read, Write},
@@ -247,7 +247,7 @@ fn run_command(cmd: &str, cwd: &Path, bufid: usize, tx: Sender<Event>) -> io::Re
         let tx2 = tx.clone();
         spawn(move || send_lines(bufid, stderr.lines(), tx2));
         send_lines(bufid, stdout.lines(), tx.clone());
-        _ = tx.send(Event::Action(Action::CleanupChild { id }));
+        _ = tx.send(Event::action(EAction::CleanupChild { id }));
     });
 
     Ok(child)
@@ -258,7 +258,7 @@ fn send_lines(bufid: usize, it: impl Iterator<Item = io::Result<String>>, tx: Se
         match res {
             Ok(mut line) => {
                 line.push('\n');
-                _ = tx.send(Event::Action(Action::AppendToOutputBuffer {
+                _ = tx.send(Event::action(EAction::AppendToOutputBuffer {
                     bufid,
                     content: normalize_line_endings(line),
                 }));

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -8,8 +8,8 @@ use crate::{
     fsys::InputFilter,
     key::Arrow,
     lsp::LspManagerHandle,
-    ziplist,
     ziplist::{Position, ZipList},
+    zlist,
 };
 use parking_lot::RwLock;
 use std::{
@@ -124,7 +124,7 @@ impl Layout {
             scratch,
             screen_rows,
             screen_cols,
-            cols: ziplist![Column::new(screen_rows, screen_cols, &[id])],
+            cols: zlist![Column::new(screen_rows, screen_cols, &[id])],
             views: vec![],
             changed_since_last_render: false,
         };
@@ -412,7 +412,7 @@ impl Layout {
             .all(|bufid| bufid == id);
 
         if only_closing_buffer {
-            self.cols = ziplist![Column::new(
+            self.cols = zlist![Column::new(
                 self.screen_rows,
                 self.screen_cols,
                 &[focused_id]
@@ -1936,7 +1936,7 @@ mod tests {
             scratch,
             screen_rows: 80,
             screen_cols: 100,
-            cols: ziplist![Column::new(80, 100, &[id])],
+            cols: zlist![Column::new(80, 100, &[id])],
             views: vec![],
             changed_since_last_render: false,
         };

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -4,8 +4,9 @@ use crate::{
     config::Config,
     die,
     dot::{Cur, Dot},
-    editor::ViewPort,
+    editor::{ActionOutcome, UAction, ViewPort},
     fsys::InputFilter,
+    key::Arrow,
     lsp::LspManagerHandle,
     ziplist,
     ziplist::{Position, ZipList},
@@ -134,6 +135,68 @@ impl Layout {
         l
     }
 
+    pub fn handle_ui_action(&mut self, uaction: UAction) -> Option<ActionOutcome> {
+        use UAction::*;
+
+        match uaction {
+            BalanceActiveColumn => self.balance_active_column(),
+            BalanceAll => self.balance_all(),
+            BalanceColumns => self.balance_columns(),
+            BalanceWindows => self.balance_windows(),
+
+            DeleteColumn { force } => return self.close_active_column(force),
+            DeleteWindow { force } => return self.close_active_window(force),
+
+            DragWindow {
+                direction: Arrow::Up,
+            } => self.drag_up(),
+            DragWindow {
+                direction: Arrow::Down,
+            } => self.drag_down(),
+            DragWindow {
+                direction: Arrow::Left,
+            } => self.drag_left(),
+            DragWindow {
+                direction: Arrow::Right,
+            } => self.drag_right(),
+
+            NewColumn => self.new_column(),
+            NewWindow => self.new_window(),
+            NextBuffer => {
+                let id = self.focus_next_buffer();
+                return Some(ActionOutcome::NotifyFocusChange(id));
+            }
+            NextColumn => {
+                self.next_column();
+                return Some(ActionOutcome::NotifyFocusChange(self.active_buffer_id()));
+            }
+            NextWindowInColumn => {
+                self.next_window_in_column();
+                return Some(ActionOutcome::NotifyFocusChange(self.active_buffer_id()));
+            }
+
+            PreviousBuffer => {
+                let id = self.focus_previous_buffer();
+                return Some(ActionOutcome::NotifyFocusChange(id));
+            }
+            PreviousColumn => {
+                self.prev_column();
+                return Some(ActionOutcome::NotifyFocusChange(self.active_buffer_id()));
+            }
+            PreviousWindowInColumn => {
+                self.prev_window_in_column();
+                return Some(ActionOutcome::NotifyFocusChange(self.active_buffer_id()));
+            }
+
+            ResizeActiveColumn { delta } => self.resize_active_column(delta),
+            ResizeActiveWindow { delta } => self.resize_active_window(delta),
+
+            SetViewPort(vp) => self.set_viewport(vp),
+        }
+
+        None
+    }
+
     /// Check to see if any actions taken since the last time this method was called resulted
     /// in changes to the visible UI state.
     ///
@@ -182,6 +245,10 @@ impl Layout {
         self.cols
             .iter()
             .any(|(_, c)| c.wins.iter().any(|(_, w)| w.view.bufid == id))
+    }
+
+    fn active_buffer_id(&self) -> usize {
+        self.buffers.active().id
     }
 
     /// Returns the active buffer, ignoring whether or not the scratch buffer is focused
@@ -479,16 +546,16 @@ impl Layout {
 
     /// Close the active window, if this was the last remaining window then
     /// Editor::delete_active_window will exit.
-    pub(crate) fn close_active_window(&mut self) -> bool {
+    pub(crate) fn close_active_window(&mut self, force: bool) -> Option<ActionOutcome> {
         self.changed_since_last_render = true;
 
         if self.scratch.is_focused {
             self.scratch.toggle();
-            return false;
+            return None;
         }
 
         if self.cols.len() == 1 && self.cols.focus.wins.len() == 1 {
-            return true;
+            return Some(ActionOutcome::Exit(force));
         }
 
         if self.cols.focus.wins.len() == 1 {
@@ -505,21 +572,21 @@ impl Layout {
         #[cfg(test)]
         assert_invariants!(self);
 
-        false
+        None
     }
 
     /// Close the active column, if this was the last remaining column then
     /// Editor::delete_active_column will exit.
-    pub(crate) fn close_active_column(&mut self) -> bool {
+    pub(crate) fn close_active_column(&mut self, force: bool) -> Option<ActionOutcome> {
         self.changed_since_last_render = true;
 
         if self.scratch.is_focused {
             self.scratch.toggle();
-            return false;
+            return None;
         }
 
         if self.cols.len() == 1 {
-            return true;
+            return Some(ActionOutcome::Exit(force));
         }
 
         self.cols.remove_focused_unchecked();
@@ -531,7 +598,7 @@ impl Layout {
         #[cfg(test)]
         assert_invariants!(self);
 
-        false
+        None
     }
 
     pub(crate) fn record_jump_position(&mut self) {

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -190,7 +190,7 @@ impl Layout {
     }
 
     /// Returns the active buffer, ignoring whether or not the scratch buffer is focused
-    pub(crate) fn active_buffer_mut_ignoring_scratch(&mut self) -> &mut Buffer {
+    pub(crate) fn active_buffer_ignoring_scratch_mut(&mut self) -> &mut Buffer {
         self.buffers.active_mut()
     }
 

--- a/src/ziplist.rs
+++ b/src/ziplist.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 #[macro_export]
-macro_rules! ziplist {
+macro_rules! zlist {
     ([$($up:expr),*], $focus:expr, [$($down:expr),*]) => { $crate::ziplist::ZipList::new([$($up),*], $focus, [$($down),*]) };
     ([$($up:expr),*], $focus:expr) => { $crate::ziplist::ZipList::new([$($up),*], $focus, []) };
     ($focus:expr, [$($down:expr),*]) => { $crate::ziplist::ZipList::new([], $focus, [$($down),*]) };
@@ -754,22 +754,22 @@ mod tests {
 
     #[test]
     fn focused() {
-        let s = ziplist!([1, 2], 3, [4, 5]);
+        let s = zlist!([1, 2], 3, [4, 5]);
 
         assert_eq!(s.focused(), &3)
     }
 
     #[test]
     fn head() {
-        let s = ziplist!([1, 2], 3, [4, 5]);
+        let s = zlist!([1, 2], 3, [4, 5]);
 
         assert_eq!(s.head(), &1)
     }
 
-    #[test_case(ziplist!([1, 2], 3, [4, 5]), ziplist!(3, [2, 1, 4, 5]); "items up and down")]
-    #[test_case(ziplist!([1, 2], 3), ziplist!(3, [2, 1]); "items up")]
-    #[test_case(ziplist!(3, [4, 5]), ziplist!(3, [4, 5]); "items down")]
-    #[test_case(ziplist!(3), ziplist!(3); "focus only")]
+    #[test_case(zlist!([1, 2], 3, [4, 5]), zlist!(3, [2, 1, 4, 5]); "items up and down")]
+    #[test_case(zlist!([1, 2], 3), zlist!(3, [2, 1]); "items up")]
+    #[test_case(zlist!(3, [4, 5]), zlist!(3, [4, 5]); "items down")]
+    #[test_case(zlist!(3), zlist!(3); "focus only")]
     #[test]
     fn swap_focus_and_head(mut s: ZipList<u8>, expected: ZipList<u8>) {
         s.swap_focus_and_head();
@@ -777,10 +777,10 @@ mod tests {
         assert_eq!(s, expected);
     }
 
-    #[test_case(ziplist!([1, 2], 3, [4, 5]), ziplist!(3, [4, 5, 1, 2]); "items up and down")]
-    #[test_case(ziplist!([1, 2], 3), ziplist!(3, [1, 2]); "items up")]
-    #[test_case(ziplist!(3, [4, 5]), ziplist!(3, [4, 5]); "items down")]
-    #[test_case(ziplist!(3), ziplist!(3); "focus only")]
+    #[test_case(zlist!([1, 2], 3, [4, 5]), zlist!(3, [4, 5, 1, 2]); "items up and down")]
+    #[test_case(zlist!([1, 2], 3), zlist!(3, [1, 2]); "items up")]
+    #[test_case(zlist!(3, [4, 5]), zlist!(3, [4, 5]); "items down")]
+    #[test_case(zlist!(3), zlist!(3); "focus only")]
     #[test]
     fn rotate_focus_to_head(mut s: ZipList<u8>, expected: ZipList<u8>) {
         s.rotate_focus_to_head();
@@ -788,10 +788,10 @@ mod tests {
         assert_eq!(s, expected);
     }
 
-    #[test_case(ziplist!([1, 2, 3], 4, [5, 6, 7]), ziplist!(1, [2, 3, 4, 5, 6, 7]); "items up and down")]
-    #[test_case(ziplist!([1, 2, 3], 4), ziplist!(1, [2, 3, 4]); "items up")]
-    #[test_case(ziplist!(3, [4, 5, 6]), ziplist!(3, [4, 5, 6]); "items down")]
-    #[test_case(ziplist!(3), ziplist!(3); "focus only")]
+    #[test_case(zlist!([1, 2, 3], 4, [5, 6, 7]), zlist!(1, [2, 3, 4, 5, 6, 7]); "items up and down")]
+    #[test_case(zlist!([1, 2, 3], 4), zlist!(1, [2, 3, 4]); "items up")]
+    #[test_case(zlist!(3, [4, 5, 6]), zlist!(3, [4, 5, 6]); "items down")]
+    #[test_case(zlist!(3), zlist!(3); "focus only")]
     #[test]
     fn focus_head(mut s: ZipList<u8>, expected: ZipList<u8>) {
         s.focus_head();
@@ -799,10 +799,10 @@ mod tests {
         assert_eq!(s, expected);
     }
 
-    #[test_case(ziplist!([1, 2, 3], 4, [5, 6, 7]), ziplist!([1, 2, 3, 4, 5, 6], 7); "items up and down")]
-    #[test_case(ziplist!([1, 2, 3], 4), ziplist!([1, 2, 3], 4); "items up")]
-    #[test_case(ziplist!(3, [4, 5, 6]), ziplist!([3, 4, 5], 6); "items down")]
-    #[test_case(ziplist!(3), ziplist!(3); "focus only")]
+    #[test_case(zlist!([1, 2, 3], 4, [5, 6, 7]), zlist!([1, 2, 3, 4, 5, 6], 7); "items up and down")]
+    #[test_case(zlist!([1, 2, 3], 4), zlist!([1, 2, 3], 4); "items up")]
+    #[test_case(zlist!(3, [4, 5, 6]), zlist!([3, 4, 5], 6); "items down")]
+    #[test_case(zlist!(3), zlist!(3); "focus only")]
     #[test]
     fn focus_tail(mut s: ZipList<u8>, expected: ZipList<u8>) {
         s.focus_tail();
@@ -810,12 +810,12 @@ mod tests {
         assert_eq!(s, expected);
     }
 
-    #[test_case(ziplist!([1, 2], 3, [4, 5, 6]), |&e| e == 3, ziplist!([1, 2], 3, [4, 5, 6]); "current focus")]
-    #[test_case(ziplist!([1, 2], 3, [4, 5, 6]), |&e| e > 4, ziplist!([1, 2, 3, 4], 5, [6]); "in tail")]
-    #[test_case(ziplist!([1, 2], 3, [4, 5, 6]), |&e| e < 3 && e > 1, ziplist!([1], 2, [3, 4, 5, 6]); "in head")]
-    #[test_case(ziplist!([1, 2], 3, [4, 5, 6]), |&e| e < 3, ziplist!([], 1, [2, 3, 4, 5, 6]); "in head multiple matches")]
-    #[test_case(ziplist!([1, 2], 3, [4, 5, 6]), |&e| e == 42, ziplist!([1, 2], 3, [4, 5, 6]); "not found")]
-    #[test_case(ziplist!([1, 2], 3, [4, 5, 3, 6]), |&e| e == 42, ziplist!([1, 2], 3, [4, 5, 3, 6]); "not found with current focus duplicated")]
+    #[test_case(zlist!([1, 2], 3, [4, 5, 6]), |&e| e == 3, zlist!([1, 2], 3, [4, 5, 6]); "current focus")]
+    #[test_case(zlist!([1, 2], 3, [4, 5, 6]), |&e| e > 4, zlist!([1, 2, 3, 4], 5, [6]); "in tail")]
+    #[test_case(zlist!([1, 2], 3, [4, 5, 6]), |&e| e < 3 && e > 1, zlist!([1], 2, [3, 4, 5, 6]); "in head")]
+    #[test_case(zlist!([1, 2], 3, [4, 5, 6]), |&e| e < 3, zlist!([], 1, [2, 3, 4, 5, 6]); "in head multiple matches")]
+    #[test_case(zlist!([1, 2], 3, [4, 5, 6]), |&e| e == 42, zlist!([1, 2], 3, [4, 5, 6]); "not found")]
+    #[test_case(zlist!([1, 2], 3, [4, 5, 3, 6]), |&e| e == 42, zlist!([1, 2], 3, [4, 5, 3, 6]); "not found with current focus duplicated")]
     #[test]
     fn focus_element_by(mut s: ZipList<u8>, predicate: fn(&u8) -> bool, expected: ZipList<u8>) {
         s.focus_element_by(predicate);
@@ -825,7 +825,7 @@ mod tests {
 
     #[test]
     fn iter_yields_all_elements_in_order() {
-        let s = ziplist!([1, 2], 3, [4, 5]);
+        let s = zlist!([1, 2], 3, [4, 5]);
         let elems: Vec<(bool, u8)> = s.iter().map(|(b, t)| (b, *t)).collect();
 
         assert_eq!(
@@ -836,7 +836,7 @@ mod tests {
 
     #[test]
     fn iter_mut_yields_all_elements_in_order() {
-        let mut s = ziplist!([1, 2], 3, [4, 5]);
+        let mut s = zlist!([1, 2], 3, [4, 5]);
         let elems: Vec<(bool, u8)> = s.iter_mut().map(|(b, t)| (b, *t)).collect();
 
         assert_eq!(
@@ -847,7 +847,7 @@ mod tests {
 
     #[test]
     fn into_iter_yields_all_elements_in_order() {
-        let s = ziplist!([1, 2], 3, [4, 5]);
+        let s = zlist!([1, 2], 3, [4, 5]);
         let elems: Vec<(bool, u8)> = s.into_iter().collect();
 
         assert_eq!(
@@ -858,36 +858,36 @@ mod tests {
 
     #[test]
     fn map_preserves_structure() {
-        let s = ziplist!(["a", "bunch"], "of", ["string", "refs"]);
+        let s = zlist!(["a", "bunch"], "of", ["string", "refs"]);
 
         let mapped = s.map(|x| x.len());
-        let expected = ziplist!([1, 5], 2, [6, 4]);
+        let expected = zlist!([1, 5], 2, [6, 4]);
 
         assert_eq!(mapped, expected);
     }
 
     #[test_case(|&x| x > 5, None; "returns None if no elements satisfy the predicate")]
-    #[test_case(|x| x % 2 == 1, Some(ziplist!([3], 1, [5])); "holds focus with predicate")]
-    #[test_case(|x| x % 2 == 0, Some(ziplist!([2], 4)); "moves focus to top of down when possible")]
-    #[test_case(|&x| x == 2 || x == 3, Some(ziplist!([2], 3)); "moves focus to end of up if down is empty")]
+    #[test_case(|x| x % 2 == 1, Some(zlist!([3], 1, [5])); "holds focus with predicate")]
+    #[test_case(|x| x % 2 == 0, Some(zlist!([2], 4)); "moves focus to top of down when possible")]
+    #[test_case(|&x| x == 2 || x == 3, Some(zlist!([2], 3)); "moves focus to end of up if down is empty")]
     #[test]
     fn filter(predicate: fn(&usize) -> bool, expected: Option<ZipList<usize>>) {
-        let filtered = ziplist!([2, 3], 1, [4, 5]).filter(predicate);
+        let filtered = zlist!([2, 3], 1, [4, 5]).filter(predicate);
 
         assert_eq!(filtered, expected);
     }
 
     #[test_case(|&x| x > 5, None, vec![2,3,1,4,5]; "no elements satisfy the predicate")]
-    #[test_case(|x| x % 2 == 1, Some(ziplist!([3], 1, [5])), vec![2,4]; "holds focus with predicate")]
-    #[test_case(|x| x % 2 == 0, Some(ziplist!([2], 4)), vec![3,1,5]; "moves focus to top of down when possible")]
-    #[test_case(|&x| x == 2 || x == 3, Some(ziplist!([2], 3)), vec![1,4,5]; "moves focus to end of up if down is empty")]
+    #[test_case(|x| x % 2 == 1, Some(zlist!([3], 1, [5])), vec![2,4]; "holds focus with predicate")]
+    #[test_case(|x| x % 2 == 0, Some(zlist!([2], 4)), vec![3,1,5]; "moves focus to top of down when possible")]
+    #[test_case(|&x| x == 2 || x == 3, Some(zlist!([2], 3)), vec![1,4,5]; "moves focus to end of up if down is empty")]
     #[test]
     fn extract(
         predicate: fn(&usize) -> bool,
         expected: Option<ZipList<usize>>,
         expected_extracted: Vec<usize>,
     ) {
-        let (s, extracted) = ziplist!([2, 3], 1, [4, 5]).extract(predicate);
+        let (s, extracted) = zlist!([2, 3], 1, [4, 5]).extract(predicate);
 
         assert_eq!(s, expected);
         assert_eq!(extracted, expected_extracted);
@@ -895,7 +895,7 @@ mod tests {
 
     #[test]
     fn flatten_is_correctly_ordered() {
-        let res = ziplist!([1, 2], 3, [4, 5]).flatten();
+        let res = zlist!([1, 2], 3, [4, 5]).flatten();
 
         assert_eq!(res, vec![1, 2, 3, 4, 5]);
     }
@@ -904,7 +904,7 @@ mod tests {
     fn try_from_iter_is_correctly_ordered() {
         let res = ZipList::try_from_iter(vec![1, 2, 3, 4, 5]);
 
-        assert_eq!(res, Some(ziplist!(1, [2, 3, 4, 5])));
+        assert_eq!(res, Some(zlist!(1, [2, 3, 4, 5])));
     }
 
     #[test]
@@ -916,7 +916,7 @@ mod tests {
 
     #[test]
     fn try_from_iter_after_flatten_with_empty_up_is_inverse() {
-        let s = ziplist!(1, [2, 3, 4]);
+        let s = zlist!(1, [2, 3, 4]);
         let res = ZipList::try_from_iter(s.clone().flatten());
 
         assert_eq!(res, Some(s));
@@ -924,16 +924,16 @@ mod tests {
 
     #[test]
     fn reverse_holds_focus() {
-        let mut s = ziplist!([1, 2], 3, [4, 5]);
+        let mut s = zlist!([1, 2], 3, [4, 5]);
         s.reverse();
 
-        assert_eq!(s, ziplist!([5, 4], 3, [2, 1]));
+        assert_eq!(s, zlist!([5, 4], 3, [2, 1]));
     }
 
-    #[test_case(ziplist!([1, 2], 3, [4, 5]), ziplist!([1], 2, [3, 4, 5]); "items up and down")]
-    #[test_case(ziplist!([], 1, [2, 3]), ziplist!([1, 2], 3); "items down only")]
-    #[test_case(ziplist!([1, 2], 3, []), ziplist!([1], 2, [3]); "items up only")]
-    #[test_case(ziplist!([], 1, []), ziplist!(1); "only focused")]
+    #[test_case(zlist!([1, 2], 3, [4, 5]), zlist!([1], 2, [3, 4, 5]); "items up and down")]
+    #[test_case(zlist!([], 1, [2, 3]), zlist!([1, 2], 3); "items down only")]
+    #[test_case(zlist!([1, 2], 3, []), zlist!([1], 2, [3]); "items up only")]
+    #[test_case(zlist!([], 1, []), zlist!(1); "only focused")]
     #[test]
     fn focus_up(mut s: ZipList<usize>, expected: ZipList<usize>) {
         s.focus_up();
@@ -941,10 +941,10 @@ mod tests {
         assert_eq!(s, expected);
     }
 
-    #[test_case(ziplist!([1, 2], 3, [4, 5]), ziplist!([1, 2, 3], 4, [5]); "items up and down")]
-    #[test_case(ziplist!(1, [2, 3]), ziplist!([1], 2, [3]); "items down only")]
-    #[test_case(ziplist!([1, 2], 3), ziplist!(1, [2, 3]); "items up only")]
-    #[test_case(ziplist!(1), ziplist!(1); "only focused")]
+    #[test_case(zlist!([1, 2], 3, [4, 5]), zlist!([1, 2, 3], 4, [5]); "items up and down")]
+    #[test_case(zlist!(1, [2, 3]), zlist!([1], 2, [3]); "items down only")]
+    #[test_case(zlist!([1, 2], 3), zlist!(1, [2, 3]); "items up only")]
+    #[test_case(zlist!(1), zlist!(1); "only focused")]
     #[test]
     fn focus_down(mut s: ZipList<usize>, expected: ZipList<usize>) {
         s.focus_down();
@@ -952,10 +952,10 @@ mod tests {
         assert_eq!(s, expected);
     }
 
-    #[test_case(ziplist!([1, 2], 3, [4, 5]), ziplist!([1], 3, [2, 4, 5]); "items up and down")]
-    #[test_case(ziplist!(1, [2, 3]), ziplist!([2, 3], 1); "items down only")]
-    #[test_case(ziplist!([1, 2], 3), ziplist!([1], 3, [2]); "items up only")]
-    #[test_case(ziplist!(1), ziplist!(1); "only focused")]
+    #[test_case(zlist!([1, 2], 3, [4, 5]), zlist!([1], 3, [2, 4, 5]); "items up and down")]
+    #[test_case(zlist!(1, [2, 3]), zlist!([2, 3], 1); "items down only")]
+    #[test_case(zlist!([1, 2], 3), zlist!([1], 3, [2]); "items up only")]
+    #[test_case(zlist!(1), zlist!(1); "only focused")]
     #[test]
     fn swap_up(mut s: ZipList<usize>, expected: ZipList<usize>) {
         s.swap_up();
@@ -965,20 +965,20 @@ mod tests {
 
     #[test]
     fn swap_up_chained() {
-        let mut s = ziplist!([1, 2], 3, [4]);
+        let mut s = zlist!([1, 2], 3, [4]);
 
         s.swap_up();
-        assert_eq!(s, ziplist!([1], 3, [2, 4]));
+        assert_eq!(s, zlist!([1], 3, [2, 4]));
         s.swap_up();
-        assert_eq!(s, ziplist!(3, [1, 2, 4]));
+        assert_eq!(s, zlist!(3, [1, 2, 4]));
         s.swap_up();
-        assert_eq!(s, ziplist!([1, 2, 4], 3));
+        assert_eq!(s, zlist!([1, 2, 4], 3));
     }
 
-    #[test_case(ziplist!([1, 2], 3, [4, 5]), ziplist!([1, 2, 4], 3, [5]); "items up and down")]
-    #[test_case(ziplist!(1, [2, 3]), ziplist!([2], 1, [3]); "items down only")]
-    #[test_case(ziplist!([1, 2], 3), ziplist!(3, [1, 2]); "items up only")]
-    #[test_case(ziplist!(1), ziplist!(1); "only focused")]
+    #[test_case(zlist!([1, 2], 3, [4, 5]), zlist!([1, 2, 4], 3, [5]); "items up and down")]
+    #[test_case(zlist!(1, [2, 3]), zlist!([2], 1, [3]); "items down only")]
+    #[test_case(zlist!([1, 2], 3), zlist!(3, [1, 2]); "items up only")]
+    #[test_case(zlist!(1), zlist!(1); "only focused")]
     #[test]
     fn swap_down(mut s: ZipList<usize>, expected: ZipList<usize>) {
         s.swap_down();
@@ -986,10 +986,10 @@ mod tests {
         assert_eq!(s, expected);
     }
 
-    #[test_case(ziplist!([1, 2], 3, [4, 5]), ziplist!([2], 3, [4, 5, 1]); "items up and down")]
-    #[test_case(ziplist!(1, [2, 3]), ziplist!([2, 3], 1); "items down only")]
-    #[test_case(ziplist!([1, 2], 3), ziplist!([2], 3, [1]); "items up only")]
-    #[test_case(ziplist!(1), ziplist!(1); "only focused")]
+    #[test_case(zlist!([1, 2], 3, [4, 5]), zlist!([2], 3, [4, 5, 1]); "items up and down")]
+    #[test_case(zlist!(1, [2, 3]), zlist!([2, 3], 1); "items down only")]
+    #[test_case(zlist!([1, 2], 3), zlist!([2], 3, [1]); "items up only")]
+    #[test_case(zlist!(1), zlist!(1); "only focused")]
     #[test]
     fn rotate_up(mut s: ZipList<usize>, expected: ZipList<usize>) {
         s.rotate_up();
@@ -997,10 +997,10 @@ mod tests {
         assert_eq!(s, expected);
     }
 
-    #[test_case(ziplist!([1, 2], 3, [4, 5]), ziplist!([5, 1, 2], 3, [4]); "items up and down")]
-    #[test_case(ziplist!(1, [2, 3]), ziplist!([3], 1, [2]); "items down only")]
-    #[test_case(ziplist!([1, 2], 3), ziplist!(3, [1, 2]); "items up only")]
-    #[test_case(ziplist!(1), ziplist!(1); "only focused")]
+    #[test_case(zlist!([1, 2], 3, [4, 5]), zlist!([5, 1, 2], 3, [4]); "items up and down")]
+    #[test_case(zlist!(1, [2, 3]), zlist!([3], 1, [2]); "items down only")]
+    #[test_case(zlist!([1, 2], 3), zlist!(3, [1, 2]); "items up only")]
+    #[test_case(zlist!(1), zlist!(1); "only focused")]
     #[test]
     fn rotate_down(mut s: ZipList<usize>, expected: ZipList<usize>) {
         s.rotate_down();
@@ -1008,23 +1008,23 @@ mod tests {
         assert_eq!(s, expected);
     }
 
-    #[test_case(Position::Focus, ziplist!([1,2], 6, [3,4,5]); "focus")]
-    #[test_case(Position::Before, ziplist!([1,2,6], 3, [4,5]); "before")]
-    #[test_case(Position::After, ziplist!([1,2], 3, [6,4,5]); "after")]
-    #[test_case(Position::Head, ziplist!([6,1,2], 3, [4,5]); "head")]
-    #[test_case(Position::Tail, ziplist!([1,2], 3, [4,5,6]); "tail")]
+    #[test_case(Position::Focus, zlist!([1,2], 6, [3,4,5]); "focus")]
+    #[test_case(Position::Before, zlist!([1,2,6], 3, [4,5]); "before")]
+    #[test_case(Position::After, zlist!([1,2], 3, [6,4,5]); "after")]
+    #[test_case(Position::Head, zlist!([6,1,2], 3, [4,5]); "head")]
+    #[test_case(Position::Tail, zlist!([1,2], 3, [4,5,6]); "tail")]
     #[test]
     fn insert_at(pos: Position, expected: ZipList<usize>) {
-        let mut s = ziplist!([1, 2], 3, [4, 5]);
+        let mut s = zlist!([1, 2], 3, [4, 5]);
         s.insert_at(pos, 6);
 
         assert_eq!(s, expected);
     }
 
-    #[test_case(ziplist!([1,2,3,4], 5, []); "up and focus")]
-    #[test_case(ziplist!([], 1, [2,3,4,5]); "focus and down")]
-    #[test_case(ziplist!([1,2], 3, [4,5]); "all")]
-    #[test_case(ziplist!([], 1, []); "focus only")]
+    #[test_case(zlist!([1,2,3,4], 5, []); "up and focus")]
+    #[test_case(zlist!([], 1, [2,3,4,5]); "focus and down")]
+    #[test_case(zlist!([1,2], 3, [4,5]); "all")]
+    #[test_case(zlist!([], 1, []); "focus only")]
     #[test]
     fn index(zl: ZipList<usize>) {
         for i in 0..zl.len() {
@@ -1032,10 +1032,10 @@ mod tests {
         }
     }
 
-    #[test_case(ziplist!([1,2,3,4], 5, []); "up and focus")]
-    #[test_case(ziplist!([], 1, [2,3,4,5]); "focus and down")]
-    #[test_case(ziplist!([1,2], 3, [4,5]); "all")]
-    #[test_case(ziplist!([], 1, []); "focus only")]
+    #[test_case(zlist!([1,2,3,4], 5, []); "up and focus")]
+    #[test_case(zlist!([], 1, [2,3,4,5]); "focus and down")]
+    #[test_case(zlist!([1,2], 3, [4,5]); "all")]
+    #[test_case(zlist!([], 1, []); "focus only")]
     #[test]
     fn index_mut(mut zl: ZipList<usize>) {
         let expected = zl.clone().map(|_| 6);

--- a/tests/scenario_tests.rs
+++ b/tests/scenario_tests.rs
@@ -5,7 +5,7 @@
 use ad_editor::{
     Config, Editor, EditorMode, LogBuffer, PlumbingRules,
     buffer::BufferId,
-    editor::{Action, Click, MiniBufferState},
+    editor::{Click, EAction, MiniBufferState},
     input::Event,
     key::Input,
     system::DefaultSystem,
@@ -102,7 +102,7 @@ fn editor_scenarios(path: &str, content: &str) {
         &file_paths,
     );
 
-    e.handle_event(Event::Action(Action::ChangeDirectory {
+    e.handle_event(Event::action(EAction::ChangeDirectory {
         path: Some(test_file_dir.to_string_lossy().to_string()),
     }));
 
@@ -444,22 +444,22 @@ impl UserInterface for ScriptedUi {
             // which triggers additional refreshes for when our message actually comes through to
             // the event loop
             sleep(Duration::from_millis(FSYS_SLEEP_MS));
-            Event::Action(Action::Noop)
+            Event::action(EAction::Noop)
         } else {
             match self.actions.pop() {
                 Some(TestAction::Fsys(f)) => {
                     self.spawn_fsys(f);
-                    Event::Action(Action::Noop)
+                    Event::action(EAction::Noop)
                 }
 
                 Some(TestAction::SleepMs(n)) => {
                     sleep(Duration::from_millis(n));
-                    Event::Action(Action::Noop)
+                    Event::action(EAction::Noop)
                 }
 
                 Some(TestAction::Input(input)) => Event::Input(input),
 
-                None => Event::Action(Action::Exit { force: true }),
+                None => Event::action(EAction::Exit { force: true }),
             }
         };
 


### PR DESCRIPTION
The internal event loop and `Action` enum has evolved over time pretty much since the start of the project. As such, it has ended up being pretty unorganised and somewhat of a dumping ground rather than enforcing too much structure to how actions are processed and _what_ handled each action. I want to move towards a better split between the UI and core editor event loop, and to support targeting specific buffers via `fsys`. Both of which are going to be a lot easier to do if actions have a clear target, which is what this PR sets up.

The current `Action` enum is therefore being split into three:
1. `BAction` - actions handled by a specific `Buffer`
    - (paired with an optional buffer ID: `None` mapping to the active buffer)
2. `EAction` - actions handled by the `Editor`
3. `UAction` - actions handled by the UI

`EAction` is still a little bit odd, as there a multiple places where even though the conceptual effect of an action is targeting a single buffer, we have book keeping and side effects to handle in the main editor state. As such, there are some actions inside of `EAction` that also take a buffer ID.